### PR TITLE
Deploy script improvements

### DIFF
--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -16,6 +16,7 @@ import {
     gitCheckoutMain,
     gitPullLatestFromMain,
     gitCheckClean,
+    gitCheckMain,
 } from "./util/git.js";
 
 const argv = yargs(process.argv.slice(2)).argv;
@@ -47,6 +48,7 @@ const inputReleaseTag = async () => {
 (async () => {
     try {
         if (argv.version_num) {
+            await gitCheckMain();
             await gitCheckClean();
             const version = await inputVersionNumber();
             await gitCreateVersionBranch(version);
@@ -59,6 +61,7 @@ const inputReleaseTag = async () => {
         }
 
         if (argv.tag) {
+            await gitCheckMain();
             await gitCheckClean();
             await gitPullLatestFromMain();
             const { tag, notes } = await inputReleaseTag();

--- a/scripts/util/git.js
+++ b/scripts/util/git.js
@@ -118,3 +118,12 @@ export const gitCheckClean = async () => {
     await delay();
 }
 
+export const gitCheckMain = async () => {
+    if (shell.exec('[[ $(git rev-parse --abbrev-ref HEAD) = "main" ]]').code !== 0) {
+        shell.echo('Error: you should be on main branch when creating/tagging a release');
+        shell.exit(1);
+    }
+
+    await delay();
+}
+


### PR DESCRIPTION
# Summary | Résumé

Just a couple small improvements to the deploy scripts:
- Ensure you don't have local changes when preparing or tagging a release
- Pull latest from main before tagging a release