### PR TITLE
Add GC admin user test 

### DIFF
--- a/cypress/integration/gc.user.can.create.spec.js
+++ b/cypress/integration/gc.user.can.create.spec.js
@@ -1,0 +1,21 @@
+/// <reference types="Cypress" />
+
+const NEW_TAB_REL_DEFAULT_VALUE = 'noreferrer noopener';
+
+describe('User - GC Editor', () => {
+    before(() => {
+
+    });
+
+    after(() => {
+        cy.exec('npm run wp-env:clean');
+    });
+
+    it('GC Admin can add GC Editors', () => {
+        cy.addUser('gcadmin', 'secret', 'GC Admin');
+        cy.loginUser('gcadmin', 'secret');
+        // try adding a GC Editor using GC Admin account
+        cy.addUser('gceditor', 'secret', 'GC Editor', false);
+    });
+
+});

--- a/cypress/support/commands/add-user.js
+++ b/cypress/support/commands/add-user.js
@@ -1,7 +1,9 @@
 
 
-Cypress.Commands.add('addUser', (userName, password, roleText) => {
-  cy.loginUser();
+Cypress.Commands.add('addUser', (userName, password, roleText, autoLogin = true) => {
+  if (autoLogin) {
+    cy.loginUser();
+  }
   cy.visit("/wp-admin/user-new.php");
   cy.get('#user_login').type(userName);
   cy.get('#email').type(`${userName}@example.com`);
@@ -11,6 +13,6 @@ Cypress.Commands.add('addUser', (userName, password, roleText) => {
   cy.get('.pw-checkbox').check();
   cy.get('#role').select(roleText);
   cy.get('form#createuser').submit();
-  cy.get('#wp-admin-bar-logout a').click({force: true});
+  cy.get('#wp-admin-bar-logout a').click({ force: true });
 });
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -20,7 +20,7 @@ class Roles
             }
         }
 
-        Utils::checkOptionCallback('cds_base_activated', '1.0.6', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.0.7', function () {
             if (is_blog_installed()) {
                 remove_role('administrator');
                 remove_role('editor');
@@ -196,6 +196,7 @@ class Roles
                 'create_users' => 1,
                 'remove_users' => 1,
                 'add_users' => 1,
+                'promote_users' => 1,
                 'read' => 1,
                 'level_1' => 1,
                 'level_0' => 1,


### PR DESCRIPTION
Adds a GC admin user test to ensure they can create other GC roles.

This PR also fixes a permissions level issue found here:

https://github.com/cds-snc/gc-articles/pull/72#pullrequestreview-766988649