### PR TITLE
Update site id

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -47,10 +47,10 @@ class AdminBar
         $wp_admin_bar->add_node([
             'id'    => 'cds-home',
             'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
-                'Canadian Digital Service',
+                'GC Articles',
                 'cds-snc'
             ) . '</div>',
-            'href'  => "https://digital.canada.ca",
+            'href'  => admin_url(),
         ]);
 
         $wp_admin_bar->remove_menu('my-sites');


### PR DESCRIPTION
Updates the site ID to reflect the GC Articles "brand" - also links back to Dashboard.

<img width="655" alt="Screen Shot 2021-10-06 at 9 50 54 AM" src="https://user-images.githubusercontent.com/62242/136216034-29693073-3d06-4465-93a9-f17b972ddd58.png">
