### PR TITLE
Remove QuickEdit from Posts and Pages

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Misc.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Misc.php
@@ -11,9 +11,9 @@ class Misc
         add_filter('admin_footer_text', '__return_false');
         add_filter('screen_options_show_screen', [$this, 'removeScreenOptions']);
         add_action('admin_head', [$this, 'removeHelpTab']);
-        
-        add_filter('post_row_actions',[$this, 'removeQuickEdit'],10,1);
-        add_filter('page_row_actions',[$this, 'removeQuickEdit'],10,1);
+
+        add_filter('post_row_actions', [$this, 'removeQuickEdit'], 10, 1);
+        add_filter('page_row_actions', [$this, 'removeQuickEdit'], 10, 1);
     }
 
     public function removeScreenOptions()
@@ -27,7 +27,8 @@ class Misc
         $screen->remove_help_tabs();
     }
 
-    public function removeQuickEdit( $actions ) {
+    public function removeQuickEdit($actions)
+    {
         unset($actions['inline hide-if-no-js']);
         return $actions;
     }


### PR DESCRIPTION
# Summary | Résumé

Re: #87 

Removes the Quick Edit link from Posts (Articles) and Pages list views, ie:

| QuickEdit  | *poof* it's gone! |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1187115/136432448-c288b24f-d073-4188-976c-3d92a8f8e5c7.png) | ![image](https://user-images.githubusercontent.com/1187115/136432517-6ed1c703-807e-4882-9ce2-dd12090f5a5b.png)  | 


