### PR TITLE
fix: remove 5xx alarms that are redundant

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_alb.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_alb.tf
@@ -1,26 +1,6 @@
 #
 # ALB: target group health and response times
 # 
-resource "aws_cloudwatch_metric_alarm" "alb_5xx_response" {
-  alarm_name          = "ALB5xxResponse"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "HTTPCode_Target_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "300"
-  statistic           = "Sum"
-  threshold           = var.alb_5xx_maximum
-  treat_missing_data  = "notBreaching"
-
-  alarm_description = "Sum of 5xx response from the ALB in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.alert_warning.arn]
-  ok_actions        = [aws_sns_topic.alert_warning.arn]
-
-  dimensions = {
-    "LoadBalancer" = var.alb_arn_suffix
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "alb_target_4xx_response" {
   alarm_name          = "ALBTargetGroup4xxResponse"
   comparison_operator = "GreaterThanThreshold"

--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_cloudfront.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_cloudfront.tf
@@ -1,28 +1,6 @@
 #
-# CloudFront: 4xx and 5xx responses
+# CloudFront: 4xx response
 #
-resource "aws_cloudwatch_metric_alarm" "cloudfront_5xx_response" {
-  provider = aws.us-east-1
-
-  alarm_name          = "CloudFront5xxResponse"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "5xxErrorRate"
-  namespace           = "AWS/CloudFront"
-  period              = "300"
-  statistic           = "Average"
-  threshold           = var.cloudfront_5xx_maximum
-
-  alarm_description = "Monitors for high CloudFront 5xx responses in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.alert_warning_us_east.arn]
-  ok_actions        = [aws_sns_topic.alert_warning_us_east.arn]
-
-  dimensions = {
-    DistributionId = var.cloudfront_distribution_id
-    Region         = "Global"
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "cloudfront_4xx_response" {
   provider = aws.us-east-1
 

--- a/infrastructure/terragrunt/aws/alarms/inputs.tf
+++ b/infrastructure/terragrunt/aws/alarms/inputs.tf
@@ -28,11 +28,6 @@ variable "alb_target_4xx_maximum" {
   type        = number
 }
 
-variable "alb_5xx_maximum" {
-  description = "Maximum number of 5xx responses from the ALB in a 5 minute period"
-  type        = number
-}
-
 variable "canary_healthcheck_url_eng" {
   description = "URL for the English synthetic canary healthcheck."
   type        = string
@@ -55,11 +50,6 @@ variable "cloudfront_distribution_id" {
 
 variable "cloudfront_4xx_maximum" {
   description = "Allowed threshold of 4xx responses from CloudFront"
-  type        = number
-}
-
-variable "cloudfront_5xx_maximum" {
-  description = "Allowed threshold of 5xx responses from CloudFront"
   type        = number
 }
 

--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -64,7 +64,6 @@ dependency "ecs" {
 inputs = {
   alb_arn         = dependency.load-balancer.outputs.alb_arn
   alb_arn_suffix  = dependency.load-balancer.outputs.alb_arn_suffix
-  alb_5xx_maximum = 0
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
@@ -77,7 +76,6 @@ inputs = {
   cloudfront_arn              = dependency.load-balancer.outputs.cloudfront_arn
   cloudfront_distribution_id  = dependency.load-balancer.outputs.cloudfront_distribution_id
   cloudfront_waf_web_acl_name = dependency.load-balancer.outputs.cloudfront_waf_web_acl_name
-  cloudfront_5xx_maximum      = 0
   cloudfront_4xx_maximum      = 100
 
   ecs_cluster_name         = dependency.ecs.outputs.ecs_cluster_name

--- a/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -64,7 +64,6 @@ dependency "ecs" {
 inputs = {
   alb_arn         = dependency.load-balancer.outputs.alb_arn
   alb_arn_suffix  = dependency.load-balancer.outputs.alb_arn_suffix
-  alb_5xx_maximum = 0
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
@@ -77,7 +76,6 @@ inputs = {
   cloudfront_arn              = dependency.load-balancer.outputs.cloudfront_arn
   cloudfront_distribution_id  = dependency.load-balancer.outputs.cloudfront_distribution_id
   cloudfront_waf_web_acl_name = dependency.load-balancer.outputs.cloudfront_waf_web_acl_name
-  cloudfront_5xx_maximum      = 0
   cloudfront_4xx_maximum      = 100
 
   ecs_cluster_name         = dependency.ecs.outputs.ecs_cluster_name


### PR DESCRIPTION
# Summary
The CloudWatch 5xx and ALB 5xx alarms are reporting on the
same underlying 5xx errors caught by the ALB target group 5xx alarm.

Removing these alarms reduces alarm noise without removing
the ability to catch 5xx errors from WordPress.