### PR TITLE
feat: remove the SNS Lambda security group

### DIFF
--- a/infrastructure/terragrunt/aws/network/outputs.tf
+++ b/infrastructure/terragrunt/aws/network/outputs.tf
@@ -22,10 +22,6 @@ output "public_subnet_ids" {
   value = module.wordpress_vpc.public_subnet_ids
 }
 
-output "sns_lambda_security_group_id" {
-  value = aws_security_group.sns_lambda.id
-}
-
 output "vpc_id" {
   value = module.wordpress_vpc.vpc_id
 }

--- a/infrastructure/terragrunt/aws/network/security-groups.tf
+++ b/infrastructure/terragrunt/aws/network/security-groups.tf
@@ -134,16 +134,6 @@ resource "aws_security_group_rule" "vpc_endpoint_wordpress_ecs_egress" {
   source_security_group_id = aws_security_group.vpc_endpoint.id
 }
 
-resource "aws_security_group_rule" "vpc_endpoint_sns_lambda_egress" {
-  description              = "Security group rule for VPC endpoints egress to SNS Lambda"
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.vpc_endpoint.id
-  source_security_group_id = aws_security_group.sns_lambda.id
-}
-
 resource "aws_security_group_rule" "s3_gateway_wordpress_ecs_egress" {
   description       = "Security group rule for Wordpress ECS S3 egress through VPC endpoints"
   type              = "egress"
@@ -154,37 +144,6 @@ resource "aws_security_group_rule" "s3_gateway_wordpress_ecs_egress" {
   prefix_list_ids = [
     aws_vpc_endpoint.s3.prefix_list_id
   ]
-}
-
-resource "aws_security_group" "sns_lambda" {
-  # checkov:skip=CKV2_AWS_5: False positive, attached in the "alarms" module.
-  name        = "sns_lambda"
-  description = "SNS Lambda - egress to internet, ingress to VPC endpoints"
-  vpc_id      = module.wordpress_vpc.vpc_id
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-  }
-}
-
-resource "aws_security_group_rule" "sns_lambda_egress" {
-  description       = "Security group rule for SNS Lambda egress to internet"
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.sns_lambda.id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
-resource "aws_security_group_rule" "sns_lambda_vpc_endpoint_ingress" {
-  description              = "Security group rule for SNS Lambda ingress from VPC endpoints"
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.sns_lambda.id
-  source_security_group_id = aws_security_group.vpc_endpoint.id
 }
 
 resource "aws_security_group" "ecs_events_lambda" {


### PR DESCRIPTION
# Summary
This security group was only used by the previous Slack notification
Lambda.  Now that the project has switched to the common [Terraform module](https://github.com/cds-snc/terraform-modules/tree/main/notify_slack)
it is no longer required.

# Related
- #153 