### PR TITLE
Bugfix: copy vendor folder from composer build stage

### DIFF
--- a/wordpress/docker/production.Dockerfile
+++ b/wordpress/docker/production.Dockerfile
@@ -36,8 +36,8 @@ RUN a2enmod ssl \
     && echo "$APACHE_KEY" > /etc/ssl/private/self-signed.key
 
 COPY --from=buildjs /app/wordpress/wp-content ./wp-content
+COPY --from=composer /app/wordpress/vendor ../vendor
 COPY ./wordpress/wp-config.php ./
 COPY ./wordpress/.htaccess-multisite ./.htaccess
-COPY ./wordpress/vendor ../vendor
 
 EXPOSE 80 443


### PR DESCRIPTION
# Summary | Résumé

Fixes a bug in #173 - the vendor folder should be copied from the previous composer build stage, not local.
