### PR TITLE
Move get data call and add import alias

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/src/LoginsPanel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/src/LoginsPanel.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '../../Spinner/src/Spinner';
-import { getData } from '../../Notify/src/NotifyPanel';
-
-const CDS_VARS = window.CDS_VARS || {};
-
-const requestHeaders = new Headers();
-requestHeaders.append('X-WP-Nonce', CDS_VARS.rest_nonce);
-
+import { getData } from 'util/getData';
 interface Login {
   user_agent: string;
   time_login: string;
@@ -60,10 +54,14 @@ export const LoginsPanel = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await getData('user/logins');
-      setIsLoading(false);
-      if (response.length >= 1) {
-        setLogins(response);
+      try {
+        const response = await getData('user/logins');
+        setIsLoading(false);
+        if (response.length >= 1) {
+          setLogins(response);
+        }
+      } catch (e) {
+        setIsLoading(false);
       }
     };
 

--- a/wordpress/wp-content/mu-plugins/cds-base/src/util/getData.ts
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/util/getData.ts
@@ -1,0 +1,25 @@
+const CDS_VARS = window.CDS_VARS || {};
+const requestHeaders = new Headers();
+requestHeaders.append('X-WP-Nonce', CDS_VARS.rest_nonce);
+
+interface ErrorWithStatus extends Error {
+  status: number;
+}
+
+export const getData = async (endpoint: string) => {
+  const response = await fetch(`${CDS_VARS.rest_url}${endpoint}`, {
+    method: 'GET',
+    headers: requestHeaders,
+    mode: 'cors',
+    cache: 'default',
+  });
+
+  if (!response.ok) {
+    console.log(response.body);
+    const err = new Error(`HTTP error`) as ErrorWithStatus;
+    err.status = response.status;
+    throw err;
+  }
+
+  return await response.json();
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/tsconfig.json
+++ b/wordpress/wp-content/mu-plugins/cds-base/tsconfig.json
@@ -7,6 +7,9 @@
     "noImplicitAny": false,
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-	"baseUrl": "src",
+    "baseUrl": "src",
+    "paths": {
+      "util": ["/src/util/*"]
+    }
   }
 }

--- a/wordpress/wp-content/mu-plugins/cds-base/webpack.config.js
+++ b/wordpress/wp-content/mu-plugins/cds-base/webpack.config.js
@@ -23,11 +23,14 @@ module.exports = {
 	resolve: {
 		...defaultConfig.resolve,
 		extensions: [".tsx", ".ts", "js", "jsx"],
+		alias: {
+			util: path.resolve(__dirname, "src/util/")
+		}
 	},
 
 	output: {
 		...defaultConfig.output,
 		filename: "index.js",
 		path: path.resolve(__dirname, "build"),
-	},
+	}
 };


### PR DESCRIPTION
1) Moves getData to a utils dir to make it more re-usable for any REST / fetch calls

2) Adds a WebPack / Typescript [alias](https://github.com/cds-snc/gc-articles/pull/177/files#diff-61def896705517311bf7acdbc87e8e6a8b6170d44f213aa387de67573efc4d90R26) to allow easier imports i.e. to avoid  `../../../../src/util/`

3) Extends the JS Error class and adds a `status` 

```ts
interface ErrorWithStatus extends Error {
  status: number;
}

const err = new Error(`HTTP error`) as ErrorWithStatus;
```
☝️  This will allow us to be more granular in our module fetch / error handling as need be  i.e. WP 500 critical errors etc...

<hr>

Note: When calling getData it should be wrapped in a try catch and perform error handling that makes sense at the module level.

