### PR TITLE
Add ref to Notice container and focus it on submit

### DIFF
--- a/cypress/integration/user.add.spec.js
+++ b/cypress/integration/user.add.spec.js
@@ -48,6 +48,7 @@ describe('Add user', () => {
 
     // error summary
     cy.get('h2').contains("There is a problem");
+    cy.focused().should('contain', 'There is a problem');
     assertEmailErrors(cy)
     assertRoleErrors(cy)
   });
@@ -58,6 +59,7 @@ describe('Add user', () => {
 
     // error summary
     cy.get('h2').contains("There is a problem");
+    cy.focused().should('contain', 'There is a problem');
     assertRoleErrors(cy)
   });
 
@@ -68,6 +70,7 @@ describe('Add user', () => {
 
     // error summary
     cy.get('h2').contains("There is a problem");
+    cy.focused().should('contain', 'There is a problem');
     assertEmailErrors(cy, "You can’t use this email domain for registration.");
   });
 
@@ -78,6 +81,7 @@ describe('Add user', () => {
 
     // Success notice
     cy.get('h2').contains("Success!");
+    cy.focused().should('contain', 'Success!');
   });
 
   it('Shows an error when trying to add an existing user', () => {
@@ -87,7 +91,7 @@ describe('Add user', () => {
 
     // error summary
     cy.get('h2').contains("There is a problem");
+    cy.focused().should('contain', 'There is a problem');
     cy.get('.components-notice.is-error ul').contains("editor@cds-snc.ca is already a member of this Collection");
-
   });
 });

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from "@wordpress/components";
 
@@ -78,6 +78,7 @@ export const UserForm = (props) => {
         resetRole({ value: '' });
         setErrors([]);
     }
+    const errorSummary = useRef(null);
 
     useEffect(() => {
         const getRoles = async () => {
@@ -115,16 +116,19 @@ export const UserForm = (props) => {
             setErrors([{ "errors": [__("Internal server error", "cds-snc")] }]);
             setSuccessMsg(''); // clear success message
         }
+        errorSummary.current.focus();
     }
 
     return (
         <div className="cds-react-form">
-            {
-                successMsg.length > 0 && <Success message={successMsg} />
-            }
-            {
-                errors.length > 0 && <ErrorSummary errors={errors} />
-            }
+            <div className="notice-container" role="alert" aria-atomic="true" tabIndex={-1} ref={errorSummary}>
+                {
+                    successMsg.length > 0 && <Success message={successMsg} />
+                }
+                {
+                    errors.length > 0 && <ErrorSummary errors={errors} />
+                }
+            </div>
 
             <p>{__("Create a brand new user or add them to this Collection if they already exist.")}</p>
 


### PR DESCRIPTION
Whether we fail or succeed, we always want to move focus up to the `<Notice>` that shows up.

[According to the W3C](https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html):
> The error container must be present in the DOM on page load for the error message to be spoken by most screen readers.

And then we can use a ref on that element as long as it's a basic HTML
element, not another functional component (from the [React docs](https://reactjs.org/docs/refs-and-the-dom.html#refs-and-function-components)):
> You can, however, use the ref attribute inside a function component as long as you refer to a DOM element or a class component

So it all works, phew. Also added some Cypress tests as well that check the error/success heading is in focus.

## gif

You can see that submitting a user causes the `activeElement` to change to the notice. 

![Screen Recording 2021-10-26 at 13 48 07](https://user-images.githubusercontent.com/2454380/138936035-916950ee-6f33-46bb-b822-991ae8bc4262.gif)
