### PR TITLE
Allow users who already exist to be re-added to blog

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
@@ -157,33 +157,33 @@ class Users
     {
         try {
             $uId = false;
+            $statusCode = 200;
 
             $list = list('email' => $email, 'role' => $role) = $this->sanitizeEmailAndRole($data);
 
             // if we just use a logical OR, we get $uId === true rather than the integer
             $uId = email_exists($email) ? email_exists($email) : username_exists($email);
 
-            // @TODO: handle case where uId exists but NOT member of blog
-
+            // if we have a user AND they are a member of the blog, end early
             if ($uId && is_user_member_of_blog($uId, get_current_blog_id())) {
                 throw new \Exception($email . " is already a member of this Collection");
                 return false;
             }
 
-            if (!$uId && $email) {
+            // create the user if not exists
+            if (!$uId) {
                 $uId = $this->createUser($email);
-                if (is_multisite()) {
-                    $this->addToBlog($uId, $role);
-                }
-
                 $this->sendReset($uId, $email);
-
-                return new WP_REST_Response([
-                    ["status" => 201, "message" => $email . " was added to the Collection.", "uID" => $uId]
-                ]);
+                $statusCode = 201;
             }
 
-            throw new \Exception("Unknown issue occurred");
+            if (is_multisite()) {
+                $this->addToBlog($uId, $role);
+            }
+
+            return new WP_REST_Response([
+                ["status" => $statusCode, "message" => $email . " was added to the Collection.", "uID" => $uId]
+            ]);
         } catch (ValidationException $exception) {
             return new WP_REST_Response([
                 [

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
@@ -106,7 +106,7 @@ export const UserForm = (props) => {
                 const [{ errors: serverErrors = [] } = {}] = response;
                 setErrors(serverErrors);
                 setSuccessMsg(''); // clear success message
-            } else if (parseInt(status) == 201) {
+            } else if ([200, 201].includes(parseInt(status)) ) {
                 const [{ message = '' } = {}] = response;
                 resetForm(); // clear inputs and remove errors
 


### PR DESCRIPTION
Previously, we would throw an error if a user who existed but was
removed from the collection was re-added to the collection.

Now we allow it and return a 200 reponse, vs a 201 if we need to create the user.

The success message is the same as when a new user is added, because it works in both cases (`Success! {email} was added to the Collection.`).
