### PR TITLE
Remove mailhog from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,14 +43,6 @@ services:
     networks:
       - app-network
 
-  mailhog:
-    image: mailhog/mailhog
-    ports: 
-      - 1025:1025 # smtp server
-      - 8025:8025 # web ui
-    networks:
-      - app-network
-
   phpmyadmin:
     depends_on:
       - db


### PR DESCRIPTION
# Summary | Résumé

Mailhog was useful at the very beginning when using raw smtp email sending from WP .. but now that we have Notify and options for switching out keys locally, this just takes extra time when bringing up our dev environment.