### PR TITLE
Send xdebug logs out to a file instead of console

### DIFF
--- a/wordpress/docker/php/conf.d/xdebug.ini
+++ b/wordpress/docker/php/conf.d/xdebug.ini
@@ -6,3 +6,4 @@ xdebug.client_host=host.docker.internal
 xdebug.start_with_request=yes
 
 xdebug.client_port=9003
+xdebug.log=/tmp/xdebug.log


### PR DESCRIPTION
# Summary | Résumé

Console output from the local docker container can be pretty noisy with all the failed XDebug connections when not fully configured. This just directs all those connection warnings to a file instead of the console.

## To test
Assuming you're running the docker-compose environment, take a look a the console, it's probably pretty noisy with stuff like this:

```
[Thu Oct 28 16:23:46.458485 2021] [php:notice] [pid 21] [client 192.168.224.1:59074] Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003
```

Check out this branch and restart your environment, then check your console as you navigate around the site. All that xdebug noise should be gone.