### PR TITLE
Usernames are emails are usernames

### DIFF
--- a/cypress/integration/user.add.spec.js
+++ b/cypress/integration/user.add.spec.js
@@ -75,24 +75,29 @@ describe('Add user', () => {
   });
 
   it('Successfully adds a new user', () => {
-    cy.get('input#email').type("editor@cds-snc.ca"); // domain is not allowed
+    cy.get('input#email').type("new+editor@cds-snc.ca"); // domain is not allowed
     cy.get('select#role').select('gceditor');
     cy.contains('button', 'Add user').click();
 
     // Success notice
     cy.get('h2').contains("Success!");
     cy.focused().should('contain', 'Success!');
+
+    // make sure exists in username column
+    cy.contains('Users').click();
+    cy.get('h1').contains("Users");
+    cy.get('table.users td.column-username').contains("new+editor@cds-snc.ca");
   });
 
   it('Shows an error when trying to add an existing user', () => {
-    cy.get('input#email').type("editor@cds-snc.ca");
+    cy.get('input#email').type("new+editor@cds-snc.ca");
     cy.get('select#role').select('gceditor');
     cy.contains('button', 'Add user').click();
 
     // error summary
     cy.get('h2').contains("There is a problem");
     cy.focused().should('contain', 'There is a problem');
-    cy.get('.components-notice.is-error ul').contains("editor@cds-snc.ca is already a member of this Collection");
+    cy.get('.components-notice.is-error ul').contains("new+editor@cds-snc.ca is already a member of this Collection");
   });
 });
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/EmailDomains.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/EmailDomains.php
@@ -32,4 +32,19 @@ class EmailDomains
 
         return false;
     }
+
+    public static function validateEmailDomain($result)
+    {
+        $message =
+            __(
+                'You can’t use this email domain for registration.',
+                'cds-snc',
+            ) . $details;
+
+        if (!self::isAllowedDomain($result['user_email'])) {
+            $result['errors']->add('user_email', $message);
+        }
+
+        return $result;
+    }
 }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Usernames.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Usernames.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Users;
+
+class Usernames
+{
+    public static function sanitizeUsernameAsEmail(string $username, string $raw_username = null, bool $strict): string
+    {
+        if ($username === $raw_username) {
+            return $username;
+        }
+
+        return sanitize_email($raw_username);
+    }
+
+
+    public static function removeEmailColumn(array $columns): array
+    {
+        unset($columns['email']);
+        $columns['username'] = __("Email");
+
+        return $columns;
+    }
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
@@ -14,7 +14,8 @@ class Users
     public function __construct()
     {
         add_filter('wpmu_validate_user_signup', [$this, 'validateEmailDomain']);
-
+        add_filter('sanitize_user', [$this, 'sanitize_username_like_email'], 10, 3 );
+    
         add_action('admin_menu', [$this, 'addPageAddUsers']);
         add_action('admin_menu', [$this, 'removePageUsersAddNew']);
         add_action('admin_enqueue_scripts', [$this, 'replacePageAddUsers']);
@@ -277,5 +278,13 @@ class Users
         }
 
         return $result;
+    }
+
+    public function sanitize_username_like_email( $username, $raw_username, $strict ) {
+        if ( $username === $raw_username) {
+            return $username;
+        }
+
+        return sanitize_email($raw_username);
     }
 }


### PR DESCRIPTION
## Summary 

This PR overrides the default username validation to use `sanitize_email` instead of [whatever else it was doing](https://github.com/WordPress/WordPress/blob/a60032feecf2002187218bdbf9e09c408b6d9f3a/wp-includes/formatting.php#L2097). 

Additionally, since we would then have a "Username" column which would be the same as an "Email" column, I removed the "Email" column and renamed the first one to say "Email". (👈  This wasn't in the story description so I am happy to revert / change this if need be. Note that it doesn't affect the "network" users table, so that one is the same as before.)

There is also a bit of code refactoring, basically pulling related functions into new classes inside of the Users module so that not everything ends up in "Users.php". They are all static methods at this point because there is no point creating a new class when we don't create any instance variables. 

### Changing the column names

It seems like, for all blog admins in the future, this makes things simpler. We keep the context menu ("edit", "remove", "view", etc), and reduce duplication. We also don't expose the fact that emails and usernames are separate fields, which should be irrelevant. 

_However_, because we are locally developing, we will lose email addresses where they don't match. For example, for the "admin" user, I only see "admin" — I don't see what my email is anymore. I can go into the Network users table to see my email (or my user profile), but I won't see it anymore in tables of individual collections. I think it's a NBD problem, since I delete all my users every day or two. But it's worth pointing out before this goes in.

## Screenshots

| before | after |
|--------|-------|
|  "Username" and "Email" column present. Also, all plus signs are stripped in usernames.      |  No "Email column. Username column renamed to "Email"     |
|  <img width="960" alt="Screen Shot 2021-10-28 at 16 35 44" src="https://user-images.githubusercontent.com/2454380/139332627-e18aa1b8-04b4-475a-b2c3-0b20050572c6.png">    |  <img width="960" alt="Screen Shot 2021-10-28 at 16 37 39" src="https://user-images.githubusercontent.com/2454380/139332633-2a986691-4774-4efd-8aea-a6f7bf26893b.png">   |

