### PR TITLE
Improve error message structure

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -122,7 +122,12 @@ input[type=date], input[type=datetime-local], input[type=datetime], input[type=e
 }
 
 .cds-react-form .components-notice h2 {
-    margin: .5em 0;
+    margin: 8px 0 16px 0;
+}
+
+
+.cds-react-form .components-notice p {
+    margin: 8px 0;
 }
 
 .error-summary {

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
@@ -85,14 +85,14 @@ class Users
 
     private function getEmailErrors($email)
     {
-        $error = ["location" => "email", "errors" => ["Email is required."], "value" => $email];
+        $error = ["location" => "email", "message" => __("Email is required."), "value" => $email];
 
         if ($email === "") {
             return $error;
         }
 
         if (!EmailDomains::isAllowedDomain(sanitize_email($email))) {
-            $error['errors'] = ["You can’t use this email domain for registration."];
+            $error['message'] = __("You can’t use this email domain for registration.");
             return $error;
         }
 
@@ -101,14 +101,14 @@ class Users
 
     private function getRoleErrors($role)
     {
-        $error = ["location" => "role", "errors" => ["Role is required."], "value" => $role];
+        $error = ["location" => "role", "message" => __("Role is required."), "value" => $role];
 
         if ($role === "") {
             return $error;
         }
 
         if (!in_array(sanitize_text_field($role), [ "gceditor", "gcadmin" ])) {
-            $error['errors'] = ["You entered an invalid role."];
+            $error['message'] = __("You entered an invalid role.");
             return $error;
         }
 
@@ -166,7 +166,7 @@ class Users
 
             // if we have a user AND they are a member of the blog, end early
             if ($uId && is_user_member_of_blog($uId, get_current_blog_id())) {
-                throw new \Exception($email . " is already a member of this Collection");
+                throw new \Exception($email . __(" is already a member of this Collection"));
                 return false;
             }
 
@@ -182,7 +182,12 @@ class Users
             }
 
             return new WP_REST_Response([
-                ["status" => $statusCode, "message" => $email . " was added to the Collection.", "uID" => $uId]
+                [
+                    "status" => $statusCode,
+                    "message" => $email . __(" was added to the Collection."),
+                    "uID" => $uId,
+                    "email" => $email
+                ]
             ]);
         } catch (ValidationException $exception) {
             return new WP_REST_Response([
@@ -198,8 +203,7 @@ class Users
             return new WP_REST_Response([
                 [
                     "status" => 400,
-                    "location" => 'unknown',
-                    'errors' => [$exception->getMessage()],
+                    'errors' => [ [ "message" => $exception->getMessage() ] ],
                     'uID' => $uId,
                     'email' => $email
                 ]

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
@@ -24,7 +24,7 @@ const Success = ({ message }) => {
         status="success"
         isDismissible={false}
     >
-        <h2>{__("Success!")}</h2>
+        <h2>{__("Success!", "cds-snc")}</h2>
         <p>{message}</p>
     </Notice>
 }
@@ -35,12 +35,12 @@ const ErrorSummary = ({ errors = [] }) => {
         status="error"
         isDismissible={false}
     >
-        <h2>{__("There is a problem")}</h2>
+        <h2>{__("There is a problem", "cds-snc")}</h2>
         <ul>
             {errors.map((err, i) => {
                 return err.location ?
-                    <li key={err.location}><a href={`#${err.location}`}>{err.errors[0]}</a></li> :
-                    <li key={i}>{err}</li>
+                    <li key={err.location}><a href={`#${err.location}`}>{err.message}</a></li> :
+                    <li key={i}>{err.message}</li>
             })
             }
         </ul>
@@ -58,15 +58,14 @@ const FieldError = ({ errors = [], id = '', children }) => {
 
     return <div className="error-wrapper">
         <span className="validation-error" id={`validation-error--${error.location}`}>
-            {/* Get the first error */}
-            {error.errors[0]}
+            {error.message}
         </span>
         {children}
     </div>
 }
 
 export const UserForm = (props) => {
-    const emptyRole = { id: "", name: __("Select one"), disabled: true, selected: true };
+    const emptyRole = { id: "", name: __("Select one", "cds-snc"), disabled: true, selected: true };
     const { value: email, bind: bindEmail, reset: resetEmail } = useInput('');
     const { value: role, bind: bindRole, reset: resetRole } = useInput({ value: '' });
     const [isLoading, setIsLoading] = useState(true);
@@ -113,7 +112,7 @@ export const UserForm = (props) => {
                 setSuccessMsg(message);
             }
         } catch (e) {
-            setErrors([{ "errors": [__("Internal server error", "cds-snc")] }]);
+            setErrors([{ "errors": [{ "message": __("Internal server error", "cds-snc") }] }]);
             setSuccessMsg(''); // clear success message
         }
         errorSummary.current.focus();
@@ -130,7 +129,7 @@ export const UserForm = (props) => {
                 }
             </div>
 
-            <p>{__("Create a brand new user or add them to this Collection if they already exist.")}</p>
+            <p>{__("Create a brand new user or add them to this Collection if they already exist.", "cds-snc")}</p>
 
             <form onSubmit={handleSubmit} id="adduser">
                 <table className="form-table">


### PR DESCRIPTION
# Summary | Résumé

This PR is a bit freelance-y. It translates error messages and Refactors server error messages to make them less confusing.

For reference, here's what our response objects look like:

<details>
<summary>1. Error message with location:</summary>

```js
[
    {
        "status": 400,
        "data": {},
        "type": "object",
        "errors": [
           {
                "location": "email",
                "message": "You can’t use this email domain for registration.",
                "value": "bademail"
            },
            {
                "location": "role",
                "message": "Role is required.",
                "value": ""
            }
        ],
        "uID": false
    }
]
```
</details>


<details>
<summary>2. Error message, no location:</summary>

```js
{
    "status": 400,
    "errors": [
        {
            "message": "paul.craig+10@cds-snc.ca is already a member of this Collection"
        }
    ],
    "uID": 91,
    "email": "paul.craig+10@cds-snc.ca",
    "blogPath": "/"
}
```
</details>


<details>
<summary>3. Success message:</summary>

```js
{
    "status": 201,
    "message": "paul.craig+21@cds-snc.ca was added to the Collection.",
    "uID": 101,
    "email": "paul.craig+21@cds-snc.ca",
    "blogPath": "/"
}
```
</details>

## 1. Refactor server error messages

Essentially, we have 2 levels of information
1. Root level error info: response status code, user id, email address, etc
2. Individual error info: location, error message

Confusingly, the original data structure was had 2 "errors" keys, like this:

```js
[
    {
        "status": 400,
        "errors": [
           {
                "errors": ["that sucks"]
                ...
            },
            ...
        ],
        ...
    }
]
```

So if you wanted to get an actual error message, you would have to do `response[0].errors[0].errors[0]`, which is super annoying once you start deconstructing things and then you don't know what `errors[0]` means anymore.

The new thing I did was to rename the second "errors" key to "message", and also make it not an array, so we only have 1 message per error. Like this: 

```js
[
    {
        "status": 400,
        "errors": [
           {
                "message": "that sucks"
                ...
            },
            ...
        ],
        ...
    }
]
```

So now, you can ask for `response[0].errors[0].message`, which is enough of an improvement to ship.

<details>
<summary> These changes were removed</summary>

## 2. Add 'actions' to success + error messages

When you add a new collection, you get these cool links at the top, which are actions you might want to take now that you have a new collection.

<img width="426" alt="Screen Shot 2021-10-28 at 16 53 45" src="https://user-images.githubusercontent.com/2454380/139344146-8727a87d-6ed8-4cec-923b-ff0bac09d679.png">

Similarly, when you add a new user (or if they already exist), you might want to edit them or return to the users screen.

| adding a user | user already exists |
|--------|-------|
| ![Screen Shot 2021-10-28 at 18 14 00](https://user-images.githubusercontent.com/2454380/139345963-1255c89e-4cbb-4bb6-a6ee-3cc420cf70fb.png)   |   ![Screen Shot 2021-10-28 at 18 14 11](https://user-images.githubusercontent.com/2454380/139345970-970ae7e5-e880-436e-b27d-1beefb0dfc43.png)  |

In order to get that to work, I had to move from "dumb" messages that were just a string we would print to more structured objects with a `uID`, `email`, and `blogPath`. As a consequence, our form's error handling and success message handling gets more complicated. Is it worth it? I dunno, it was already kind of complicated, and nobody asked for this.

Options here are:

1. We like them, merge PR as-is.
2. We don't like them, revert the second PR and just merge the first one
3. 
</details>
