### PR TITLE
Allow list wp-resetpass cookie

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -41,7 +41,9 @@ resource "aws_cloudfront_distribution" "wordpress" {
           "wordpress_logged_in_*",
           "wordpress_test_cookie",
           "wp-settings-*",
-          "wp-resetpass-*"
+          "wp-resetpass-*",
+          "wp-saving-post",
+          "wp-postpass_*"
         ]
       }
     }

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -40,7 +40,8 @@ resource "aws_cloudfront_distribution" "wordpress" {
           "wordpress_*",
           "wordpress_logged_in_*",
           "wordpress_test_cookie",
-          "wp-settings-*"
+          "wp-settings-*",
+          "wp-resetpass-*"
         ]
       }
     }


### PR DESCRIPTION
# Summary | Résumé

Allow list the wp-resetpass cookie to fix reset password links
