### PR TITLE
Re-add remove WPML header

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Profile.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Profile.php
@@ -54,7 +54,7 @@ class Profile
          *--------------------------------------------*/
         // WPML settings under personal options
         $crawler->filter('#name')->addClass('hidden');
-        //$crawler->filter('.user-language-wrap')->remove();
+        $crawler->filter('.user-language-wrap')->remove();
 
         $crawler->filter('.user-user-login-wrap')->remove();
         // note nickname is a require field so it's hidden using CSS


### PR DESCRIPTION
Closes https://github.com/cds-snc/gc-articles-issues/issues/9

Not sure why this was commented out but re-adding code to remove the heading.

<img width="780" alt="Screen Shot 2021-11-02 at 1 32 26 PM" src="https://user-images.githubusercontent.com/62242/139916502-b3acc5c7-883e-4a1e-8353-f97fa29615ba.png">
