### PR TITLE
Don't modify ###SITENAME### for emails

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
@@ -24,10 +24,10 @@ class SitesToCollections
             return $translation;
         }
 
-        if($text === "###SITENAME###"){
+        if ($text === "###SITENAME###") {
             return $translation;
         }
-        
+
         return str_ireplace('Site', "Collection", $text);
     }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
@@ -24,6 +24,10 @@ class SitesToCollections
             return $translation;
         }
 
+        if($text === "###SITENAME###"){
+            return $translation;
+        }
+        
         return str_ireplace('Site', "Collection", $text);
     }
 


### PR DESCRIPTION
Digging into https://github.com/cds-snc/gc-articles-issues/issues/10 

User.php in WP core does a string replacement for "###SITENAME### 

<img width="1003" alt="Screen Shot 2021-11-03 at 8 44 14 AM" src="https://user-images.githubusercontent.com/62242/140062524-0e9f899e-2d10-438f-a6d3-660e800143d6.png">

We're seeing this type of string in password resets etc...

```
This notice confirms that your password was changed on ###CollectionNAME###.
```

Which make sense as that's not going to get string replaced

**Note:**
> I haven't been able to test this locally but if we do a staging release believe this is worth a try. Locally I'm hitting WPML errors (S3 WPML issue) and a Guzzle error with Notify neither of which would be caused by this update.




