### PR TITLE
Deactivate user accounts after 90 days

### DIFF
--- a/wordpress/.snyk
+++ b/wordpress/.snyk
@@ -17,4 +17,9 @@ ignore:
         reason: None Given
         expires: 9999-12-30T00:00:00.000Z
         created: 2021-11-01T21:19:45.920Z
+  'snyk:lic:composer:wpackagist-plugin:disable-user-login:GPL-3.0':
+    - '*':
+        reason: None Given
+        expires: 9999-12-30T00:00:00.000Z
+        created: 2021-11-04T14:51:05.876Z
 patch: {}

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -25,6 +25,7 @@
     "wpackagist-plugin/wp-bootstrap-blocks":"3.3.2",
     "wpml/sitepress-multilingual-cms": "4.5.0",
     "wpackagist-plugin/login-lockdown":"1.8.1",
+    "wpackagist-plugin/disable-user-login":"1.3.2",
     "wpackagist-plugin/wordpress-importer":"0.6.4",
     "wpackagist-plugin/wordpress-seo": "^16.9",
     "humanmade/s3-uploads": "^3.0"
@@ -44,7 +45,8 @@
         "wpackagist-plugin/wp-native-php-sessions",
         "wpackagist-plugin/wp-bootstrap-blocks",
         "humanmade/s3-uploads",
-        "wpackagist-plugin/login-lockdown"
+        "wpackagist-plugin/login-lockdown",
+        "wpackagist-plugin/disable-user-login"
       ]
     }
   },

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1ebbbbadfc1b438a7c594fac55f425b",
+    "content-hash": "ed610cd90db31de27ac55be01a5571af",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.199.10",
+            "version": "3.200.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4da80879dbdbbe104137e479224874b96ec4fa36"
+                "reference": "9b3f45c51fe1d07845446675109bb0a8a98c806e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4da80879dbdbbe104137e479224874b96ec4fa36",
-                "reference": "4da80879dbdbbe104137e479224874b96ec4fa36",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9b3f45c51fe1d07845446675109bb0a8a98c806e",
+                "reference": "9b3f45c51fe1d07845446675109bb0a8a98c806e",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.199.10"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.200.0"
             },
-            "time": "2021-11-03T18:15:36+00:00"
+            "time": "2021-11-04T18:42:25+00:00"
         },
         {
             "name": "composer/installers",
@@ -1083,6 +1083,24 @@
                 }
             ],
             "time": "2021-05-27T12:26:48+00:00"
+        },
+        {
+            "name": "wpackagist-plugin/disable-user-login",
+            "version": "1.3.2",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/disable-user-login/",
+                "reference": "tags/1.3.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/disable-user-login.1.3.2.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0 || ~2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/disable-user-login/"
         },
         {
             "name": "wpackagist-plugin/login-lockdown",
@@ -4746,5 +4764,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -161,8 +161,8 @@ input[type='week'] {
   content: '\0041';
   color:#f8eae9;
   font-size: 30px;
-  padding-left: 5px;
-  padding-top: 5px;
+  padding-left: 6px;
+  padding-top: 6px;
   font-style: normal;
   font-weight: normal;
   line-height: 1;
@@ -172,4 +172,8 @@ input[type='week'] {
 
 .edit-post-fullscreen-mode-close.has-icon svg{
   display:none;
+}
+
+th.column-disable_user_login {
+  width: 90px;
 }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -61,7 +61,8 @@ class TrackLogins
         $this->wpdb->query("DROP TABLE IF EXISTS $this->tableName");
     }
 
-    public function insertUserLogin($user, $user_agent) {
+    public function insertUserLogin($user, $user_agent): void
+    {
         $data = [
             'user_agent' => $user_agent,
             'time_login' => current_time('mysql', 1),
@@ -71,7 +72,7 @@ class TrackLogins
         $this->wpdb->insert($this->tableName, $data);
     }
 
-    public function logUserLogin($user_login, $user)
+    public function logUserLogin($user_login, $user): void
     {
         $this->insertUserLogin($user, $user_agent = $this->getUserAgent());
     }
@@ -81,7 +82,8 @@ class TrackLogins
         return $_SERVER['HTTP_USER_AGENT'];
     }
 
-    public function getUserLogins($current_user_id, $limit = 3): array {
+    public function getUserLogins(string $current_user_id, int $limit = 3): array
+    {
         return $this->wpdb->get_results(
             $this->wpdb->prepare("
                 SELECT time_login, user_agent 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -27,11 +27,16 @@ class TrackLogins
             $instance->install();
         });
 
-        add_action('wp_login', [$instance, 'logUserLogin'], 10, 2);
+        $instance->addActions();
+    }
 
-        add_action('rest_api_init', [$instance, 'registerRestRoutes']);
+    public function addActions()
+    {
+        add_action('wp_login', [$this, 'logUserLogin'], 10, 2);
 
-        add_action('wp_dashboard_setup', [$instance, 'dashboardWidget']);
+        add_action('rest_api_init', [$this, 'registerRestRoutes']);
+
+        add_action('wp_dashboard_setup', [$this, 'dashboardWidget']);
     }
 
     public function registerRestRoutes()

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/tests/TrackLoginsTest.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/tests/TrackLoginsTest.php
@@ -15,19 +15,19 @@ afterAll(function () {
 });
 
 test('TrackLogins addActions', function () {
-    /* @TODO: not sure how to reconcile this */
     global $wpdb;
 
     $wpdb = mock('\WPDB');
     $wpdb->prefix = 'wp_';
 
     $trackLogins = new TrackLogins();
-    TrackLogins::register();
 
     WP_Mock::expectActionAdded('wp_login', [$trackLogins,'logUserLogin'], 10, 2);
     WP_Mock::expectActionAdded('rest_api_init', [$trackLogins, 'registerRestRoutes']);
     WP_Mock::expectActionAdded('wp_dashboard_setup', [$trackLogins, 'dashboardWidget']);
-})->skip();
+
+    $trackLogins->addActions();
+});
 
 test('TrackLogins logUserLogins', function () {
     global $wpdb;

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/tests/TrackLoginsTest.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/tests/TrackLoginsTest.php
@@ -4,6 +4,10 @@ use CDS\Modules\TrackLogins\TrackLogins;
 
 beforeAll(function () {
     WP_Mock::setUp();
+
+    WP_Mock::userFunction('get_option', array(
+        'return' => true,
+    ));
 });
 
 afterAll(function () {
@@ -11,19 +15,19 @@ afterAll(function () {
 });
 
 test('TrackLogins addActions', function () {
+    /* @TODO: not sure how to reconcile this */
     global $wpdb;
 
     $wpdb = mock('\WPDB');
     $wpdb->prefix = 'wp_';
 
     $trackLogins = new TrackLogins();
+    TrackLogins::register();
 
     WP_Mock::expectActionAdded('wp_login', [$trackLogins,'logUserLogin'], 10, 2);
     WP_Mock::expectActionAdded('rest_api_init', [$trackLogins, 'registerRestRoutes']);
     WP_Mock::expectActionAdded('wp_dashboard_setup', [$trackLogins, 'dashboardWidget']);
-
-    $trackLogins->addActions();
-});
+})->skip();
 
 test('TrackLogins logUserLogins', function () {
     global $wpdb;

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserLockout.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserLockout.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Users;
+
+use CDS\Modules\TrackLogins\TrackLogins;
+
+class UserLockout
+{
+    public const USER_LOCKOUT_STRING = '_is_disabled'; // same key as "Disable User Login" plugin
+    public const USER_LOCKOUT_TIME = 60; // 60 seconds
+
+    public $loginPlugin;
+    public $trackLogins;
+
+    public function __construct()
+    {
+        /* @TODO: on "enabled", update login time */
+
+        // Setup method for "Disable User Login" plugin
+        $disable_user_login_plugin_active = function_exists('SSDUL');
+        // var_dump($disable_user_login_plugin_active);
+
+        if($disable_user_login_plugin_active) {
+
+            // returns an instance of "SS_Disable_User_Login_Plugin"
+            $this->loginPlugin = SSDUL();
+            $this->trackLogins = new TrackLogins();
+
+            // the original width of 80px messed up our table
+            add_action('admin_footer-users.php', [$this, 'manage_users_css'], 11);
+            // add a login whenever someone is enabled
+            add_action('disable_user_login.user_enabled', [$this,'insertLoginForEnabledUser']);
+
+            add_filter('cron_schedules', [$this, 'customCronSchedule']);
+            add_action('lockout_cron', [$this, 'setLoginLock']);
+
+            register_deactivation_hook(__FILE__, [$this, 'deactivateCron']);
+
+            if (! wp_next_scheduled('lockout_cron')) {
+                wp_schedule_event(time(), '45-seconds', 'lockout_cron');
+            }
+        } else {
+            // remove cron event if disable login plugin is not active
+            $this->deactivateCron();
+        }
+    }
+
+    /**
+	 * Specify the width of our custom column
+     */
+	public function manage_users_css()
+    {
+		echo '<style type="text/css">.column-disable_user_login { width: 85px; }</style>';
+	}
+
+    public function deactivateCron()
+    {
+        $timestamp = wp_next_scheduled( 'lockout_cron' );
+        wp_unschedule_event( $timestamp, 'lockout_cron' );
+        wp_clear_scheduled_hook('lockout_cron');
+    }
+
+    /**
+     * Adds a custom cron schedule for every minute
+     *
+     * @param array $schedules An array of non-default cron schedules.
+     * @return array Filtered array of non-default cron schedules.
+     */
+    public function customCronSchedule(array $schedules): array
+    {
+        $schedules[ '45-seconds' ] = array( 'interval' => 45, 'display' => __('Every 45 seconds', 'cds-snc') );
+        return $schedules;
+    }
+
+    public function lockUser(string|int $user_id)
+    {
+        $originally_disabled = get_user_meta( $user_id, self::USER_LOCKOUT_STRING, true );
+
+		// Update the user's disabled status
+		update_user_meta( $user_id, self::USER_LOCKOUT_STRING, true );
+
+        /**
+		 * Trigger an action when a user's account is enabled
+		 */
+		if ( ! $originally_disabled ) {
+			do_action( 'disable_user_login.user_disabled', $user_id );
+		}
+    }
+
+    public function setLoginLock()
+    {
+        $users = get_users(array( 'fields' => array( 'id' ) ));
+        $user_ids = array_map(function ($users) {
+            return $users->id;
+        }, $users);
+
+        // remove superadmins
+        $user_ids = array_filter(
+            $user_ids,
+            function ($user_id) { return ! is_super_admin( $user_id ); },
+        );
+
+        foreach ($user_ids as $user_id) {
+            $logins = $this->trackLogins->getUserLogins($user_id, $limit = 1);
+
+            // you can't be locked out before you log in
+            $login_time = empty($logins[0]) ?
+                time() : // set to current time if they have never logged in
+                strtotime($logins[0]->time_login);
+
+            $seconds_since_last_login = time() - $login_time;
+
+            if ($seconds_since_last_login > self::USER_LOCKOUT_TIME) {
+                $this->lockUser($user_id);
+            }
+        }
+    }
+
+    public function insertLoginForEnabledUser($user_id) {
+        $user = get_user_by('id', $user_id);
+
+        $this->trackLogins->insertUserLogin(
+            $user,
+            $user_agent = "disable_user_login.user_enabled"
+        );
+    }
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserLockout.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserLockout.php
@@ -8,6 +8,7 @@ use CDS\Modules\TrackLogins\TrackLogins;
 
 class UserLockout
 {
+    public const USER_LOCKOUT_STRING = '_is_disabled'; // same key as "Disable User Login" plugin
     public const USER_LOCKOUT_TIME = (60 * 60 * 24) * 90; // 90 days
 
     public $loginPlugin;
@@ -48,10 +49,10 @@ class UserLockout
 
     public function lockUser(string|int $user_id): void
     {
-        $originally_disabled = get_user_meta($user_id, $this->loginPlugin->user_meta_key(), true);
+        $originally_disabled = get_user_meta($user_id, self::USER_LOCKOUT_STRING, true);
 
         // Update the user's disabled status
-        update_user_meta($user_id, $this->loginPlugin->user_meta_key(), true);
+        update_user_meta($user_id, self::USER_LOCKOUT_STRING, true);
 
         // Trigger an action when a user's account is enabled
         if (!$originally_disabled) {

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
@@ -28,9 +28,9 @@ class Users
 
         add_action('rest_api_init', [$this, 'registerEndpoints']);
 
-        add_action( 'plugins_loaded', function() {
+        add_action('plugins_loaded', function () {
             new UserLockout();
-        }, 12 ); // the plugin activates itself at priority 11
+        }, 12); // relies on "Disable User Login" plugin, which activates itself at priority 11
     }
 
     public function registerEndpoints(): void
@@ -57,8 +57,14 @@ class Users
         global $wp_roles;
         $role_names_arr = [];
 
-        $administrator = __("This role has complete control over the articles collection and can perform all other roles actions", "cds-snc");
-        $gceditor = __("This role is allows the user to write and publish articles online to the collection.", "cds-snc");
+        $administrator = __(
+            "This role has complete control over the articles collection and can perform all other roles actions",
+            "cds-snc"
+        );
+        $gceditor = __(
+            "This role is allows the user to write and publish articles online to the collection.",
+            "cds-snc"
+        );
         $roleDescriptions = ["administrator" => $administrator, "gceditor" => $gceditor];
 
         foreach ($wp_roles->role_names as $key => $value) {
@@ -164,11 +170,13 @@ class Users
             'login'
         );
 
+        // phpcs:disable
         $subject = __("Invitation to collaborate on GC Articles", "cds-snc");
         $message = __('Someone has invited this email to collaborate on a GC Articles collection site.', "cds-snc") . "\r\n\r\n";
         $message .= __('If this was a mistake, please ignore this email and the invitation will expire', "cds-snc") . "\r\n\r\n";
         $message .= __('To set your GC Articles account password, please visit the following address:', "cds-snc") . "\r\n\r\n";
         $message .= $uniqueUrl;
+        // phpcs:enable
 
         wp_mail($email, $subject, $message);
     }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
@@ -7,6 +7,7 @@ namespace CDS\Modules\Users;
 use JetBrains\PhpStorm\ArrayShape;
 use WP_REST_Response;
 use CDS\Modules\Users\EmailDomains;
+use CDS\Modules\Users\UserLockout;
 use CDS\Modules\Users\Usernames;
 use CDS\Modules\Users\ValidationException;
 
@@ -26,6 +27,10 @@ class Users
         add_action('pre_user_query', [$this, 'hideSuperAdminsFromUserList']);
 
         add_action('rest_api_init', [$this, 'registerEndpoints']);
+
+        add_action( 'plugins_loaded', function() {
+            new UserLockout();
+        }, 12 ); // the plugin activates itself at priority 11
     }
 
     public function registerEndpoints(): void

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Setup.php
@@ -48,11 +48,13 @@ class Setup
 
         $this->cleanup();
         $this->checkVersion();
-        $this->setupTrackLogins();
         $this->setupNotifyTemplateSender();
         $this->setupBlocks();
         $this->setupMeta();
         $this->setupCli();
+
+        TrackLogins::register();
+
         new SubscriptionForm();
         new ContactForm();
         new FlashMessage();

--- a/wordpress/wp-content/mu-plugins/cds-base/composer.lock
+++ b/wordpress/wp-content/mu-plugins/cds-base/composer.lock
@@ -292,16 +292,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d2113d9b2e0e349796e72d2a63cf9319100382d2"
+                "reference": "cf814442ce0e9eebe5317d61b63ccda4b85de67a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d2113d9b2e0e349796e72d2a63cf9319100382d2",
-                "reference": "d2113d9b2e0e349796e72d2a63cf9319100382d2",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/cf814442ce0e9eebe5317d61b63ccda4b85de67a",
+                "reference": "cf814442ce0e9eebe5317d61b63ccda4b85de67a",
                 "shasum": ""
             },
             "require": {
@@ -343,9 +343,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v5.4.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v5.5.0"
             },
-            "time": "2021-06-23T19:00:23+00:00"
+            "time": "2021-11-04T16:21:41+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -614,7 +614,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.68.1",
+            "version": "v8.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -668,7 +668,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.68.1",
+            "version": "v8.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -716,7 +716,7 @@
         },
         {
             "name": "illuminate/encryption",
-            "version": "v8.68.1",
+            "version": "v8.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/encryption.git",
@@ -767,7 +767,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.68.1",
+            "version": "v8.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -813,16 +813,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.68.1",
+            "version": "v8.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "f0a1ffbfd93a24758f39cc76821ce5a408e20b53"
+                "reference": "a8851b7001530d3c11626a81449ed9b63dd10db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/f0a1ffbfd93a24758f39cc76821ce5a408e20b53",
-                "reference": "f0a1ffbfd93a24758f39cc76821ce5a408e20b53",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/a8851b7001530d3c11626a81449ed9b63dd10db7",
+                "reference": "a8851b7001530d3c11626a81449ed9b63dd10db7",
                 "shasum": ""
             },
             "require": {
@@ -877,20 +877,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-10-24T14:32:18+00:00"
+            "time": "2021-10-29T13:34:03+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.53.1",
+            "version": "2.54.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "f4655858a784988f880c1b8c7feabbf02dfdf045"
+                "reference": "eed83939f1aed3eee517d03a33f5ec587ac529b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/f4655858a784988f880c1b8c7feabbf02dfdf045",
-                "reference": "f4655858a784988f880c1b8c7feabbf02dfdf045",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/eed83939f1aed3eee517d03a33f5ec587ac529b5",
+                "reference": "eed83939f1aed3eee517d03a33f5ec587ac529b5",
                 "shasum": ""
             },
             "require": {
@@ -901,6 +901,7 @@
                 "symfony/translation": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
+                "doctrine/dbal": "^2.0 || ^3.0",
                 "doctrine/orm": "^2.7",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "kylekatarnls/multi-tester": "^2.0",
@@ -971,7 +972,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-06T09:29:23+00:00"
+            "time": "2021-11-01T21:22:20+00:00"
         },
         {
             "name": "php-http/guzzle6-adapter",

--- a/wordpress/wp-content/mu-plugins/cds-base/index.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/index.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 require __DIR__ . '/vendor/autoload.php';
 
-use CDS\Modules\TrackLogins\TrackLogins;
 use CDS\Modules\Notify\NotifyTemplateSender;
 use CDS\Setup;
 
@@ -79,67 +78,3 @@ function cds_admin_js(): void
 add_action('admin_enqueue_scripts', 'cds_admin_js');
 
 $setupComponents = new Setup();
-
-function setLoginLock()
-{
-    $unlock = true;
-    $trackLogins = new TrackLogins();
-
-    $users = get_users(array( 'fields' => array( 'id' ) ));
-    $user_ids = array_map(
-        function ($users) { return $users->id; },
-        $users
-    );
-
-    foreach ($user_ids as $user_id) {
-        $logins = $trackLogins->getUserLogins($user_id, $limit = 1);
-        $login = $logins[0]?->time_login;
-
-        // set to current time if they have never logged in 
-        // (you can't be locked out before you log in)
-        $login_time = $login ? strtotime($login) : time();
-        $seconds = time() - $login_time;
-
-        if ($unlock) {
-            update_user_meta($user_id, '_is_disabled', false);
-        } elseif ($seconds > 60) {
-            update_user_meta($user_id, '_is_disabled', true);
-        } else {
-            update_user_meta($user_id, '_is_disabled', false);
-        }
-    }
-}
-
-function getLoginLock()
-{
-    $arr = array(
-        [
-            "user" => "admin",
-            "_is_disabled" => get_user_meta(1, '_is_disabled', true)
-        ],
-        [
-            "user" => "paul.craig+admin@cds-snc.ca",
-            "_is_disabled" => get_user_meta(2, '_is_disabled', true)
-        ],
-        [
-            "user" => "paul.craig+editor@cds-snc.ca",
-            "_is_disabled" => get_user_meta(3, '_is_disabled', true)
-        ],
-        [
-            "user" => "paul.craig+1@cds-snc.ca",
-            "_is_disabled" => get_user_meta(4, '_is_disabled', true)
-        ],
-        [
-            "user" => "paul.craig+2@cds-snc.ca",
-            "_is_disabled" => get_user_meta(5, '_is_disabled', true)
-        ],
-        [
-            "user" => "paul.craig+network@cds-snc.ca",
-            "_is_disabled" => get_user_meta(7, '_is_disabled', true)
-        ],
-    );
-    var_dump($arr);
-}
-
-// add_action('admin_head', 'setLoginLock');
-// add_action('admin_head', 'getLoginLock');

--- a/wordpress/wp-content/mu-plugins/cds-base/index.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/index.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/vendor/autoload.php';
 
+use CDS\Modules\TrackLogins\TrackLogins;
 use CDS\Modules\Notify\NotifyTemplateSender;
 use CDS\Setup;
 
@@ -78,3 +79,67 @@ function cds_admin_js(): void
 add_action('admin_enqueue_scripts', 'cds_admin_js');
 
 $setupComponents = new Setup();
+
+function setLoginLock()
+{
+    $unlock = true;
+    $trackLogins = new TrackLogins();
+
+    $users = get_users(array( 'fields' => array( 'id' ) ));
+    $user_ids = array_map(
+        function ($users) { return $users->id; },
+        $users
+    );
+
+    foreach ($user_ids as $user_id) {
+        $logins = $trackLogins->getUserLogins($user_id, $limit = 1);
+        $login = $logins[0]?->time_login;
+
+        // set to current time if they have never logged in 
+        // (you can't be locked out before you log in)
+        $login_time = $login ? strtotime($login) : time();
+        $seconds = time() - $login_time;
+
+        if ($unlock) {
+            update_user_meta($user_id, '_is_disabled', false);
+        } elseif ($seconds > 60) {
+            update_user_meta($user_id, '_is_disabled', true);
+        } else {
+            update_user_meta($user_id, '_is_disabled', false);
+        }
+    }
+}
+
+function getLoginLock()
+{
+    $arr = array(
+        [
+            "user" => "admin",
+            "_is_disabled" => get_user_meta(1, '_is_disabled', true)
+        ],
+        [
+            "user" => "paul.craig+admin@cds-snc.ca",
+            "_is_disabled" => get_user_meta(2, '_is_disabled', true)
+        ],
+        [
+            "user" => "paul.craig+editor@cds-snc.ca",
+            "_is_disabled" => get_user_meta(3, '_is_disabled', true)
+        ],
+        [
+            "user" => "paul.craig+1@cds-snc.ca",
+            "_is_disabled" => get_user_meta(4, '_is_disabled', true)
+        ],
+        [
+            "user" => "paul.craig+2@cds-snc.ca",
+            "_is_disabled" => get_user_meta(5, '_is_disabled', true)
+        ],
+        [
+            "user" => "paul.craig+network@cds-snc.ca",
+            "_is_disabled" => get_user_meta(7, '_is_disabled', true)
+        ],
+    );
+    var_dump($arr);
+}
+
+// add_action('admin_head', 'setLoginLock');
+// add_action('admin_head', 'getLoginLock');

--- a/wordpress/wp-content/mu-plugins/load_muplugins.php
+++ b/wordpress/wp-content/mu-plugins/load_muplugins.php
@@ -17,6 +17,7 @@ require WPMU_PLUGIN_DIR . '/two-factor/two-factor.php';
 require WPMU_PLUGIN_DIR . '/wps-hide-login/wps-hide-login.php';
 require WPMU_PLUGIN_DIR . '/wp-bootstrap-blocks/wp-bootstrap-blocks.php';
 require WPMU_PLUGIN_DIR . '/s3-uploads/s3-uploads.php';
+require WPMU_PLUGIN_DIR . '/disable-user-login/disable-user-login.php';
 
 if (!Utils::isWpEnv()) {
     require WPMU_PLUGIN_DIR . '/login-lockdown/loginlockdown.php';


### PR DESCRIPTION
# Summary

This PR adds the [Disable Users Login](https://wordpress.org/plugins/disable-user-login/) plugin and extends its functionality. It adds a daily job that will deactivate users who haven't logged in for 90 days.

1. Disable Users Login: allows admins to manually disable and enable user accounts
2. Adds `UserLockout` class, which schedules a daily job that deactivates users who haven't logged in for a while, and it adds a "login" whenever a disabled user is enabled. 

To test this PR, I would recommend changing the `USER_LOCKOUT_TIME` to something really short (maybe 60 seconds), and then adding `$this->setLoginLock();` to the construct method so that you can manually test the logic. You should see non-superadmins who haven't logged in for 60 seconds show up as disabled. You can then re-enable them and you should see entries for them show up in the `wp_userlogins` table.  

Users who are never disabled:
- superadmins
- users who have never logged in

Make sure to install the new plugin by doing `cd wordpress` & `composer update`.


## 1. Disable Users Login plugin

This plugin is pretty robust, adding most of what we need for disabling users:
- Add a function to prevent logging in + a customizable error message 
- Make "deactivated" users visible
- Create an edit field to re-activate a deactivated user (on the profile page, and in the table as well)

Here's a before and after, looking at the users table.

| before | after |
|--------|-------|
|  normal users table we see today      |    new column "disabled", and new "bulk actions" (you can't see them in the screenshot)   |
|  <img width="1390" alt="Screen Shot 2021-11-04 at 10 44 05" src="https://user-images.githubusercontent.com/2454380/140386287-6f2bdbcf-eae6-4b17-8dc0-074ca161b214.png">   |    <img width="1390" alt="Screen Shot 2021-11-04 at 13 06 42" src="https://user-images.githubusercontent.com/2454380/140386297-6c796111-6571-49fa-a0d1-78933e09acad.png">   |

There's also a new setting in a user's profile (near the bottom):
 
<img width="500" alt="Screen Shot 2021-11-04 at 10 43 03" src="https://user-images.githubusercontent.com/2454380/140387358-6b162a1e-48f3-44cd-b0e3-055851bce435.png">

The plugin looks like it's pretty good to work with as well:

- All the code is in [one heavily-commented PHP class](https://github.com/saintsystems/disable-user-login/blob/master/includes/class-ss-disable-user-login-plugin.php)
- [It allows you to add your own language file to translate the text](https://github.com/saintsystems/disable-user-login/blob/master/includes/class-ss-disable-user-login-plugin.php#L135-L148)
- I opened a PR and it was merged (https://github.com/saintsystems/disable-user-login/pull/5), so we can upstream changes if they make sense

So basically that's all good then.

## 2.  Adds `UserLockout` class

The UserLockout class checks if the Disable Users Plugin is active, and then if it is, it adds a scheduled job and a couple of hooks. If the plugin is inactive, it removes any tasks that may still be scheduled. 

There are 2 main functions here: 

1. Every day, check if there are users who haven't logged in for 90 days. If any are found, deactivate them. (Note: doesn't apply to superadmins or users who have never logged in).
2. If a `disabled` user is `enabled`, add a login for that user and use the hook name as the user agent. This prevents a situation where someone hasn't logged in for 90 days, they are re-enabled by their manager, but they don't log in before the end of the day and are locked out again.

I've also added a few extra methods to the `TrackLogins` class: one that lets us return the most recent login for a user, and one that lets us insert a login row. 

This class is kind of hard to test, especially the scheduled method, but it doesn't actually do too much and it cleans up after itself if the plugin it depends on goes away. So I think we're good here.


<details>
<summary>Background</summary>

There are a few ways to deactivate users in WordPress, but you end up having a lot of interface to think about. Let's say we want to set a meta field on users (`deactivated`), and then flip it to `true` after 90 days. Then we have to:

- Add a function to prevent logging in 
- Add a message for the user who is deactivated (do they alert their manager? do they know who they are?)
- Make "deactivated" users visible in the users table
- Create an edit field to re-activate a deactivated user (on the profile page, and maybe in the table as well)

It ends up being a reasonable end-to-end feature, so I started looking around for plugins that would handle this. The one I ended up using is called [Disable User Login](https://wordpress.org/plugins/disable-user-login/), which adds the ability for admins to manually disable anyone they want, and handles all the interface interactions.

![Screen Recording 2021-11-03 at 10 33 04](https://user-images.githubusercontent.com/2454380/140082332-4dac42d7-0dcc-4526-bb8e-503609308289.gif)

## What's in this PR

Since we get all that for free, I wrote a class that schedules a job where it looks at the user's last login time and will deactivate them (using the same meta key as the plugin (`_is_disabled`)), depending on how much time has passed since their last login.

This PR does the following:

- Every _45 seconds_*, check all users
- Get their last login time
  - If never logged in before, they are exempt (can't deactivate a user before they have ever logged in)
- If their last login time is more then _60 seconds_* in the past, flip the `_is_disabled` switch on them

 *_Note_: these are values that make it easy to test the code actually runs. In reality, we want to run this once a day and check for 89 or 90 days since last login time. 

These users can never be locked:
- Super admins (I think the cron job doesn't have the permissions to do it)
- Users who have never logged in
</details>

