### PR TITLE
Cypress workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,29 +5,6 @@ on:
     branches: [main]
 
 jobs:
-  cypress-tests:
-    runs-on: ubuntu-latest
-    name: Cypress
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.0
-
-      - name: Add Composer auth credentials
-        run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/wordpress/auth.json
-      - run: cd wordpress && composer install --prefer-dist --no-progress --no-suggest
-      - run: npm install
-      - run: npm run wp-env:init
-      - name: Cypress run
-        uses: cypress-io/github-action@v2
-        with:
-          record: false
-        env:
-          # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          # pass GitHub token to allow accurately detecting a build vs a re-run build
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   php-tests:
     runs-on: ubuntu-latest
     name: PHP Pest tests

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Composer install
         run: cd wordpress && composer install --prefer-dist --no-progress
 
-      - name: Start test environment
-        run: npm -g i @wordpress/env && wp-env start
-
       - name: Cache NPM
         uses: actions/cache@v2
         with:
@@ -48,8 +45,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Cypress install
+        uses: cypress-io/github-action@v2
+        with:
+          runTests: false
+
+      - name: Start test environment
+        run: wp-env start
+
       - name: Cypress run
         uses: cypress-io/github-action@v2
+        with:
+          install: false
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,11 +1,11 @@
-name: Cypress Tests with installation job
+name: Cypress Tests
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  install-and-run:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -45,13 +45,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Cypress install
+      - name: Cypress and NPM install and build
         uses: cypress-io/github-action@v2
         with:
           runTests: false
 
       - name: Start test environment
-        run: wp-env start
+        run: npm run wp-env:init
 
       - name: Cypress run
         uses: cypress-io/github-action@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,57 @@
+name: Cypress Tests with installation job
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  install-and-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: PHP Setup
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+
+      - name: Add Composer auth credentials
+        run: echo '${{ secrets.COMPOSER_AUTH_JSON }}' > $GITHUB_WORKSPACE/wordpress/auth.json
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Composer install
+        run: cd wordpress && composer install --prefer-dist --no-progress
+
+      - name: Start test environment
+        run: npm -g i @wordpress/env && wp-env start
+
+      - name: Cache NPM
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          # pass GitHub token to allow accurately detecting a build vs a re-run build
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress/integration/gc.user.can.create.spec.js
+++ b/cypress/integration/gc.user.can.create.spec.js
@@ -8,7 +8,7 @@ describe('User - GC Editor', () => {
     });
 
     after(() => {
-        cy.exec('npm run wp-env:clean');
+
     });
 
     it('GC Admin can add GC Editors', () => {

--- a/cypress/integration/notify.settings.spec.js
+++ b/cypress/integration/notify.settings.spec.js
@@ -1,6 +1,5 @@
 describe('Encrypted options', () => {
   before(() => {
-    cy.exec('npm run wp-env:clean')
     cy.exec('npm run wp-env:test:setup')
   });
 

--- a/cypress/integration/track.login.panel.spec.js
+++ b/cypress/integration/track.login.panel.spec.js
@@ -30,7 +30,7 @@ describe('Track Login Panel', () => {
 
 describe('Track Login Panel captures logins', () => {
     before(() => {
-        cy.exec('npm run wp-env:clean')
+        cy.exec('npm run wp-env:test:setup')
     });
 
     it('On first Login display only one login', () => {

--- a/cypress/integration/two-factor.panel.spec.js
+++ b/cypress/integration/two-factor.panel.spec.js
@@ -8,7 +8,7 @@ describe('Two Factor Panel', () => {
     });
 
     after(() => {
-        cy.exec('npm run wp-env:clean')
+
     });
 
     it('Can view Two Factor Panel on dashboard', () => {

--- a/cypress/integration/user.add.spec.js
+++ b/cypress/integration/user.add.spec.js
@@ -16,7 +16,6 @@ const assertRoleErrors = (cy) => {
 
 describe('Add user', () => {
   before(() => {
-    cy.exec('npm run wp-env:clean');
     cy.exec('npm run wp-env:test:setup');
   });
 

--- a/cypress/test-setup/setup-ci.sh
+++ b/cypress/test-setup/setup-ci.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DB_BACKUP=test_run_dump.sql
+
+echo "Looking for $DB_BACKUP"
+if wp-env run tests-cli wp db import "$DB_BACKUP"; then
+    echo "Found $DB_BACKUP and imported it"
+    exit 0
+fi
+echo "Didn't find $DB_BACKUP will save one for next time"
+
+wp-env clean
+wp-env run tests-cli wp option delete list_values
+wp-env run tests-cli wp option set list_values --format=json < ./cypress/fixtures/notify-list-data.json
+wp-env run tests-cli wp theme activate cds-default
+wp-env run tests-cli wp option update permalink_structure "/%postname%/";
+
+wp-env run tests-cli wp db export "$DB_BACKUP"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "import": "node ./import/import.js",
     "wp-env": "wp-env",
     "wp-env:init": "wp-env start",
-    "wp-env:test:setup": "sh cypress/test-setup/setup.sh",
+    "wp-env:test:setup": "sh cypress/test-setup/setup-ci.sh",
     "wp-env:stop": "wp-env stop",
     "wp-env:debug": "wp-env start --debug",
     "wp-env:clean" : "wp-env clean all",


### PR DESCRIPTION
# Summary | Résumé

An attempt to speed up our Cypress tests. Moderately successful - seems to be saving 1-5 minutes per run, but that depends on multiple factors (ci runner availability/capacity for one).

This PR includes:
- Caching NPM modules
- Caching Composer modules
- Faster environment reset by using a .sql dump instead of running the full wp setup
- Fewer wp-env:clean commands

Ultimately, this will save a small amount of time here and there, but the real improvements will come from parallelizing test runs. We will need to procure Cypress.io to enable that, so it's not included here.
