### PR TITLE
Add service id as a param for List Counts

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/FormHelpers.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/FormHelpers.php
@@ -79,7 +79,8 @@ class FormHelpers
         <div id="notify-panel"></div>
 
           <?php
-            $data = "CDS.Notify.renderPanel({ 'sendTemplateLink': false });";
+            $serviceId = get_option('LIST_MANAGER_SERVICE_ID');
+            $data = 'CDS.Notify.renderPanel({ "sendTemplateLink" :false , serviceId: "' . $serviceId . '"});';
             wp_add_inline_script('cds-snc-admin-js', $data, 'after');
             ?>
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -26,9 +26,10 @@ class NotifyTemplateSender
         add_action('rest_api_init', [$this, 'registerEndpoints']);
     }
 
-    public static function processListCounts(): WP_REST_Response
+    public static function processListCounts($data): WP_REST_Response
     {
         try {
+            $service_id = $data->get_param('service_id');
             $client = new Client([
                 'headers' => [
                     "Authorization" => get_option('LIST_MANAGER_API_KEY')
@@ -36,8 +37,6 @@ class NotifyTemplateSender
             ]);
 
             $endpoint = getenv('LIST_MANAGER_ENDPOINT');
-
-            $service_id = get_option('LIST_MANAGER_SERVICE_ID');
 
             $response = $client->request(
                 'GET',
@@ -60,9 +59,12 @@ class NotifyTemplateSender
             }
         ]);
 
-        register_rest_route('wp-notify/v1', '/list_counts', [
+        register_rest_route('wp-notify/v1', '/list_counts/(?P<service_id>[a-zA-Z0-9_-]+)', [
             'methods' => 'GET',
             'callback' => [$this, 'processListCounts'],
+            'args' => [
+                'service_id' => [],
+            ],
             'permission_callback' => function () {
                 return current_user_can('delete_posts');
             }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
@@ -22,8 +22,9 @@ class SendTemplateDashboardPanel
 
     public function notifyPanelHandler(): void
     {
+        $serviceId = get_option('LIST_MANAGER_SERVICE_ID');
         echo '<div id="notify-panel"></div>';
-        $data = 'CDS.Notify.renderPanel({ "sendTemplateLink" :true});';
+        $data = 'CDS.Notify.renderPanel({ "sendTemplateLink" :true , serviceId: "' . $serviceId . '"});';
         wp_add_inline_script('cds-snc-admin-js', $data, 'after');
     }
 }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/src/NotifyPanel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/src/NotifyPanel.tsx
@@ -124,13 +124,15 @@ const NotifyLists = ({
   );
 };
 
-export const NotifyPanel = ({ sendTemplateLink = false }) => {
+export const NotifyPanel = ({ sendTemplateLink = false, serviceId = "" }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [listCounts, setListCounts] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await getData('wp-notify/v1/list_counts');
+
+      console.log("serviceId:", serviceId);
+      const response = await getData(`wp-notify/v1/list_counts/${serviceId}`);
       setIsLoading(false);
       if (response.length >= 1) {
         setListCounts(await matchCountToList(response));

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/src/NotifyPanel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/src/NotifyPanel.tsx
@@ -131,11 +131,14 @@ export const NotifyPanel = ({ sendTemplateLink = false, serviceId = "" }) => {
   useEffect(() => {
     const fetchData = async () => {
 
-      console.log("serviceId:", serviceId);
-      const response = await getData(`wp-notify/v1/list_counts/${serviceId}`);
-      setIsLoading(false);
-      if (response.length >= 1) {
-        setListCounts(await matchCountToList(response));
+      try {
+        const response = await getData(`wp-notify/v1/list_counts/${serviceId}`);
+        setIsLoading(false);
+        if (response.length >= 1) {
+          setListCounts(await matchCountToList(response));
+        }
+      } catch (e) {
+        console.log(e.message)
       }
     };
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/src/LoginsPanel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/TrackLogins/src/LoginsPanel.tsx
@@ -21,11 +21,11 @@ const Logins = ({
     return null;
   }
 
-  const rows = logins.map((login) => {
+  const rows = logins.map((login, index) => {
     const date = new Date(login.time_login);
 
     return (
-      <tr>
+      <tr key={index}>
         <td>{date.toLocaleString()}</td>
         <td>{login.user_agent}</td>
       </tr>

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/UserCollections/src/CollectionsPanel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/UserCollections/src/CollectionsPanel.tsx
@@ -33,7 +33,7 @@ const Collections = ({
     const dashboardText = __('Dashboard', 'cds-snc');
     const websiteText = __('Visit', 'cds-snc');
     return (
-      <tr className={`row-${index}`}>
+      <tr key={`row-${index}`} className={`row-${index}`}>
         <td className="name">{collection.blogname}</td>
         <td className="website">
           <a

--- a/wordpress/wp-content/mu-plugins/cds-base/src/index.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/index.tsx
@@ -35,7 +35,7 @@ declare global {
       rest_nonce?: string;
       notify_list_ids?: List[];
     }
-    wp:any;
+    wp: any;
   }
 }
 
@@ -49,11 +49,13 @@ export const renderCollectionsPanel = () => {
 
 export const renderNotifyPanel = ({
   sendTemplateLink,
+  serviceId
 }: {
-  sendTemplateLink: boolean;
+  sendTemplateLink: boolean
+  serviceId: string
 }) => {
   render(
-    <NotifyPanel sendTemplateLink={sendTemplateLink} />,
+    <NotifyPanel sendTemplateLink={sendTemplateLink} serviceId={serviceId} />,
     document.getElementById("notify-panel")
   );
 };
@@ -87,9 +89,9 @@ window.CDS.renderListValuesRepeaterForm = renderListValuesRepeaterForm;
 window.CDS.renderNotifyServicesRepeaterForm = renderNotifyServicesRepeaterForm;
 
 window.wp.hooks.addFilter(
-	'editor.PostPreview.interstitialMarkup',
-	'my-plugin/custom-preview-message',
-	() => window.CDS.writeInterstitialMessage()
+  'editor.PostPreview.interstitialMarkup',
+  'my-plugin/custom-preview-message',
+  () => window.CDS.writeInterstitialMessage()
 );
 
 


### PR DESCRIPTION
Prep work in support of # 2 here:
https://github.com/cds-snc/gc-articles-issues/issues/69#issuecomment-962096516

This updates the endpoint to add a [param](https://github.com/cds-snc/gc-articles/pull/228/files#diff-e7c64114582df610f82aabaf46915d4aa66c2b15eea534f829168e87253644b3R62) -> Service ID
The Notify panel has also been updated to take in a [Service ID](https://github.com/cds-snc/gc-articles/pull/228/files#diff-348f0b081a0772b299475c1fb6b63cb58efb7e9e8594a7539248e1fad512eb48R127) prop.

Currently the prop being [passed in](https://github.com/cds-snc/gc-articles/pull/228/files#diff-0142875ced5485fad85e43a2c0953295cfba0ebda8b76b7570a9229902c3a67fR82) is the same one that was used in the original endpoint --- so nothing should be different visually at this point. This sets things up to make the next step possible i.e. dynamically passing a Service ID