### PR TITLE
Remove the "View" action from the Users table

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Misc.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Misc.php
@@ -17,6 +17,8 @@ class Misc
         add_filter('post_row_actions', [$this, 'removeQuickEdit'], 10, 1);
         add_filter('page_row_actions', [$this, 'removeQuickEdit'], 10, 1);
 
+        add_filter('user_row_actions', [$this, 'removeView'], 10, 1);
+
         add_filter('views_edit-post', [$this, "customPostTable"]);
     }
 
@@ -34,6 +36,12 @@ class Misc
     public function removeQuickEdit($actions)
     {
         unset($actions['inline hide-if-no-js']);
+        return $actions;
+    }
+
+    public function removeView($actions)
+    {
+        unset($actions['view']);
         return $actions;
     }
 


### PR DESCRIPTION
# Summary

This PR removes the "View" action for the users table. I've put the code in the `Cleanup/Misc.php` class, beside the code that removes the "Quick Edit" link for posts and pages, since it's related.

Merging this resolves: https://github.com/cds-snc/gc-articles-issues/issues/84

## Screenshot

| before | after |
|--------|-------|
|  <img width="330" alt="Screen Shot 2021-11-08 at 12 13 02" src="https://user-images.githubusercontent.com/2454380/140787629-02bb8a9b-90d8-478c-b1d2-469a18f4e9a8.png">    |   <img width="330" alt="Screen Shot 2021-11-08 at 12 12 13" src="https://user-images.githubusercontent.com/2454380/140787624-d52e562f-ba2f-4507-b420-f31740e5d101.png">  |


