### PR TITLE
Separate Notify and List Manager settings

### DIFF
--- a/cypress/integration/list-manager.settings.spec.js
+++ b/cypress/integration/list-manager.settings.spec.js
@@ -1,0 +1,38 @@
+describe('List Manager Settings', () => {
+  before(() => {
+    cy.exec('npm run wp-env:test:setup')
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('Displays settings screen', () => {
+    cy.visit('/wp-admin/admin.php?page=cds_list_manager_settings');
+
+    cy.get('h1').should('have.text', 'List Manager Settings');
+
+    cy.get('#list_manager_api_key').should('be.empty');
+    cy.get('#list_manager_notify_services').should('be.empty');
+    cy.get('#list_manager_service_id').should('be.empty');
+  });
+
+  it('Can save settings', () => {
+    cy.visit('/wp-admin/admin.php?page=cds_list_manager_settings');
+
+    cy.get('#list_manager_api_key').type('thisisthelistmanagerapikey');
+    cy.get('#list_manager_notify_services').type('listmanagerserviceslist');
+    cy.get('#list_manager_service_id').type('serviceidforlistmanager');
+    cy.get('#submit').click();
+
+    cy.get('#setting-error-settings_updated').should('contain.text', 'Settings saved');
+  })
+
+  it('Encrypted settings are not re-populated', () => {
+    cy.visit('/wp-admin/admin.php?page=cds_list_manager_settings');
+
+    cy.get('#list_manager_api_key').should('be.empty');
+    cy.get('#list_manager_notify_services').should('be.empty');
+    cy.get('#list_manager_service_id').should('be.empty');
+  })
+});

--- a/cypress/integration/list-manager.settings.spec.js
+++ b/cypress/integration/list-manager.settings.spec.js
@@ -12,7 +12,6 @@ describe('List Manager Settings', () => {
 
     cy.get('h1').should('have.text', 'List Manager Settings');
 
-    cy.get('#list_manager_api_key').should('be.empty');
     cy.get('#list_manager_notify_services').should('be.empty');
     cy.get('#list_manager_service_id').should('be.empty');
   });
@@ -20,7 +19,6 @@ describe('List Manager Settings', () => {
   it('Can save settings', () => {
     cy.visit('/wp-admin/admin.php?page=cds_list_manager_settings');
 
-    cy.get('#list_manager_api_key').type('thisisthelistmanagerapikey');
     cy.get('#list_manager_notify_services').type('listmanagerserviceslist');
     cy.get('#list_manager_service_id').type('serviceidforlistmanager');
     cy.get('#submit').click();
@@ -30,8 +28,7 @@ describe('List Manager Settings', () => {
 
   it('Encrypted settings are not re-populated', () => {
     cy.visit('/wp-admin/admin.php?page=cds_list_manager_settings');
-
-    cy.get('#list_manager_api_key').should('be.empty');
+    
     cy.get('#list_manager_notify_services').should('be.empty');
     cy.get('#list_manager_service_id').should('be.empty');
   })

--- a/cypress/integration/notify.settings.spec.js
+++ b/cypress/integration/notify.settings.spec.js
@@ -1,4 +1,4 @@
-describe('Encrypted options', () => {
+describe('Notify API Settings', () => {
   before(() => {
     cy.exec('npm run wp-env:test:setup')
   });
@@ -8,37 +8,28 @@ describe('Encrypted options', () => {
   });
 
   it('Displays settings screen', () => {
-    cy.visit('/wp-admin/admin.php?page=cds_notify_send_settings');
+    cy.visit('/wp-admin/options-general.php?page=notify-settings');
 
-    cy.get('h1').should('have.text', 'Notify and List Manager Settings');
+    cy.get('h1').should('have.text', 'Notify API Settings');
 
     cy.get('#notify_api_key').should('be.empty');
     cy.get('#notify_generic_template_id').should('be.empty');
-    cy.get('#list_manager_api_key').should('be.empty');
-    cy.get('#list_manager_notify_services').should('be.empty');
-    cy.get('#list_manager_service_id').should('be.empty');
   });
 
   it('Can save settings', () => {
-    cy.visit('/wp-admin/admin.php?page=cds_notify_send_settings');
+    cy.visit('/wp-admin/options-general.php?page=notify-settings');
 
     cy.get('#notify_api_key').type('abcdefghijklmnopqrstuvwxyz');
     cy.get('#notify_generic_template_id').type('12345678910111213');
-    cy.get('#list_manager_api_key').type('thisisthelistmanagerapikey');
-    cy.get('#list_manager_notify_services').type('listmanagerserviceslist');
-    cy.get('#list_manager_service_id').type('serviceidforlistmanager');
     cy.get('#submit').click();
 
     cy.get('#setting-error-settings_updated').should('contain.text', 'Settings saved');
   })
 
   it('Encrypted settings are not re-populated', () => {
-    cy.visit('/wp-admin/admin.php?page=cds_notify_send_settings');
+    cy.visit('/wp-admin/options-general.php?page=notify-settings');
 
     cy.get('#notify_api_key').should('be.empty');
     cy.get('#notify_generic_template_id').should('contain.value', '12345678910111213');
-    cy.get('#list_manager_api_key').should('be.empty');
-    cy.get('#list_manager_notify_services').should('be.empty');
-    cy.get('#list_manager_service_id').should('be.empty');
   })
 });

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -26,7 +26,7 @@ class Menus
             __('Posts'),
             __('Articles', 'cds'),
             __('Users'),
-            __('WPForms'),
+            __('Settings'),
         ];
 
         //  __('Settings'), __('Appearance')

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,7 +8,7 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.0.9', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.0.10', function () {
 
             if (is_blog_installed()) {
                 remove_role('editor');
@@ -42,6 +42,7 @@ class Roles
                 'manage_network_users' => 1, // enables "edit_users" for GC Admins'
                 'manage_options' => 0,
                 'manage_notify' => 1,
+                'manage_list_manager' => 1,
                 'read' => 1,
                 'level_1' => 1,
                 'level_0' => 1,

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Notify;
+
+use CDS\Modules\EncryptedOption\EncryptedOption;
+
+class ListManagerSettings
+{
+    protected EncryptedOption $encryptedOption;
+    protected string $admin_page = 'cds_notify_send';
+
+    private string $LIST_MANAGER_API_KEY;
+    private string $LIST_MANAGER_NOTIFY_SERVICES;
+    private string $LIST_MANAGER_SERVICE_ID;
+    private string $list_values;
+
+    public function __construct(EncryptedOption $encryptedOption)
+    {
+        $this->encryptedOption = $encryptedOption;
+    }
+
+    public static function register(EncryptedOption $encryptedOption)
+    {
+        $instance = new self($encryptedOption);
+
+        add_action('admin_menu', [$instance, 'listManagerSettingsAddPluginPage']);
+        add_action('admin_init', [$instance, 'listManagerSettingsPageInit']);
+        add_action('admin_head', [$instance, 'addStyles']); // @TODO
+
+        add_filter('option_page_capability_list_manager_settings_option_group', function ($capability) {
+            return 'manage_list_manager';
+        });
+
+        $encryptedOptions = [
+            'LIST_MANAGER_API_KEY',
+            'LIST_MANAGER_NOTIFY_SERVICES',
+            'LIST_MANAGER_SERVICE_ID' // @TODO: does this need to be encrypted?
+        ];
+
+        foreach ($encryptedOptions as $option) {
+            add_filter("pre_update_option_{$option}", [$instance, 'encryptOption']);
+            add_filter("option_{$option}", [$instance, 'decryptOption']);
+        }
+    }
+
+    public function listManagerSettingsAddPluginPage()
+    {
+        add_submenu_page(
+            $this->admin_page,
+            __('List Manager'),
+            __('List Manager'),
+            'manage_list_manager',
+            'cds_list_manager_settings',
+            [$this, 'listManagerSettingsCreateAdminPage'],
+        );
+    }
+
+    public function listManagerSettingsCreateAdminPage()
+    {
+        $this->LIST_MANAGER_API_KEY = get_option('LIST_MANAGER_API_KEY') ?: '';
+        $this->LIST_MANAGER_NOTIFY_SERVICES = get_option('LIST_MANAGER_NOTIFY_SERVICES') ?: '';
+        $this->LIST_MANAGER_SERVICE_ID = get_option('LIST_MANAGER_SERVICE_ID') ?: '';
+        $this->list_values = get_option('list_values') ?: '';
+        ?>
+
+        <div class="wrap">
+            <h1><?php _e('List Manager Settings', 'cds-snc') ?></h1>
+            <p></p>
+            <?php settings_errors(); ?>
+
+            <form method="post" action="options.php" id="list_manager_settings_form" class="gc-form-wrapper">
+                <?php
+                settings_fields('list_manager_settings_option_group');
+                do_settings_sections('list-manager-settings-admin');
+                submit_button();
+                ?>
+            </form>
+        </div>
+    <?php }
+
+    public function listManagerSettingsPageInit()
+    {
+        register_setting(
+            'list_manager_settings_option_group',
+            'list_values'
+        );
+
+        register_setting(
+            'list_manager_settings_option_group', // option_group
+            'LIST_MANAGER_API_KEY',
+            function ($input) {
+                if ($input == '') {
+                    return get_option('LIST_MANAGER_API_KEY');
+                }
+
+                return sanitize_text_field($input);
+            }
+        );
+
+        register_setting(
+            'list_manager_settings_option_group', // option_group
+            'LIST_MANAGER_NOTIFY_SERVICES',
+            function ($input) {
+                if ($input == '') {
+                    return get_option('LIST_MANAGER_NOTIFY_SERVICES');
+                }
+
+                return sanitize_text_field($input);
+            }
+        );
+
+        register_setting(
+            'list_manager_settings_option_group', // option_group
+            'LIST_MANAGER_SERVICE_ID',
+            function ($input) {
+                if ($input == '') {
+                    return get_option('LIST_MANAGER_SERVICE_ID');
+                }
+
+                return sanitize_text_field($input);
+            }
+        );
+
+        add_settings_section(
+            'list_manager_settings_section', // id
+            _('List manager', 'cds-snc'), // title
+            array( $this, 'listManagerSettingsSectionInfo'), // callback
+            'list-manager-settings-admin' // page
+        );
+
+        add_settings_field(
+            'list_values', // id
+            _('List Values JSON', 'cds-snc'), // title
+            array( $this, 'listValuesCallback'), // callback
+            'list-manager-settings-admin', // page
+            'list_manager_settings_section', // section
+            [
+                'label_for' => 'list_values'
+            ]
+        );
+
+        add_settings_field(
+            'list_manager_api_key', // id
+            _('List Manager API Key', 'cds-snc'), // title
+            array( $this, 'listManagerApiKeyCallback'), // callback
+            'list-manager-settings-admin', // page
+            'list_manager_settings_section', // section
+            [
+                'label_for' => 'list_manager_api_key'
+            ]
+        );
+
+        add_settings_field(
+            'list_manager_notify_services', // id
+            _('List Manager Notify Services', 'cds-snc'), // title
+            array( $this, 'listManagerNotifyServicesCallback'), // callback
+            'list-manager-settings-admin', // page
+            'list_manager_settings_section', // section
+            [
+                'label_for' => 'list_manager_notify_services'
+            ]
+        );
+
+        add_settings_field(
+            'list_manager_service_id', // id
+            _('List Manager Service Id', 'cds-snc'), // title
+            array( $this, 'listManagerServiceIdCallback'), // callback
+            'list-manager-settings-admin', // page
+            'list_manager_settings_section', // section
+            [
+                'label_for' => 'list_manager_service_id'
+            ]
+        );
+    }
+
+    public function listManagerSettingsSectionInfo()
+    {
+    }
+
+    public function getObfuscatedOutputLabel($string, $labelId)
+    {
+        $startsWith = substr($string, 0, 4);
+        $endsWith = substr($string, -4);
+
+
+        printf(
+            __('<span class="hidden_keys" id="%1$s">Current value: <span class="sr-only">Starts with </span>%2$s<span aria-hidden="true"> … </span><span class="sr-only"> and ends with</span>%3$s</span>', 'cds-snc'),
+            $labelId,
+            $startsWith,
+            $endsWith
+        );
+    }
+
+    public function listManagerApiKeyCallback()
+    {
+        if ($string = $this->LIST_MANAGER_API_KEY) {
+            $this->getObfuscatedOutputLabel($string, 'list_manager_api_key_value');
+        }
+        printf(
+            '<input class="regular-text" type="text" name="LIST_MANAGER_API_KEY" id="list_manager_api_key" aria-describedby="list_manager_api_key_value" value="">'
+        );
+    }
+
+    public function listManagerNotifyServicesCallback()
+    {
+        if ($string = $this->LIST_MANAGER_NOTIFY_SERVICES) {
+            $this->getObfuscatedOutputLabel($string, 'list_manager_notify_services_value');
+        }
+        printf(
+            '<input class="regular-text" type="text" name="LIST_MANAGER_NOTIFY_SERVICES" id="list_manager_notify_services" aria-describedby="list_manager_notify_services_value" value="">'
+        );
+    }
+
+    public function listManagerServiceIdCallback()
+    {
+        if ($string = $this->LIST_MANAGER_SERVICE_ID) {
+            $this->getObfuscatedOutputLabel($string, 'list_manager_service_id_value');
+        }
+        printf(
+            '<input class="regular-text" type="text" name="LIST_MANAGER_SERVICE_ID" id="list_manager_service_id" aria-describedby="list_manager_service_id_value" value="">'
+        );
+    }
+
+    public function listValuesCallback()
+    {
+        printf(
+            '<textarea name="list_values" id="list_values" rows="4" cols="50">%s</textarea>
+
+                <p class="description" id="new-admin-email-description">
+                    ' . _('Format', 'cds-snc') . ':
+                    <pre>[{"id":"123", "type":"email", "label":"my-list"}]</pre>
+                </p>',
+            $this->list_values ?: ''
+        );
+    }
+
+    public function addStyles()
+    {
+        ?><style type="text/css">
+        .hidden_keys {
+            padding-bottom: 3px;
+            display: block;
+            color: grey;
+        }
+    </style><?php
+    }
+
+    public function encryptOption($value): string
+    {
+        return $this->encryptedOption->encryptString($value);
+    }
+
+    public function decryptOption($value): string
+    {
+        return $this->encryptedOption->decryptString($value);
+    }
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -11,7 +11,6 @@ class ListManagerSettings
     protected EncryptedOption $encryptedOption;
     protected string $admin_page = 'cds_notify_send';
 
-    private string $LIST_MANAGER_API_KEY;
     private string $LIST_MANAGER_NOTIFY_SERVICES;
     private string $LIST_MANAGER_SERVICE_ID;
     private string $list_values;
@@ -34,7 +33,6 @@ class ListManagerSettings
         });
 
         $encryptedOptions = [
-            'LIST_MANAGER_API_KEY',
             'LIST_MANAGER_NOTIFY_SERVICES',
             'LIST_MANAGER_SERVICE_ID' // @TODO: does this need to be encrypted?
         ];
@@ -59,7 +57,6 @@ class ListManagerSettings
 
     public function listManagerSettingsCreateAdminPage()
     {
-        $this->LIST_MANAGER_API_KEY = get_option('LIST_MANAGER_API_KEY') ?: '';
         $this->LIST_MANAGER_NOTIFY_SERVICES = get_option('LIST_MANAGER_NOTIFY_SERVICES') ?: '';
         $this->LIST_MANAGER_SERVICE_ID = get_option('LIST_MANAGER_SERVICE_ID') ?: '';
         $this->list_values = get_option('list_values') ?: '';
@@ -85,18 +82,6 @@ class ListManagerSettings
         register_setting(
             'list_manager_settings_option_group',
             'list_values'
-        );
-
-        register_setting(
-            'list_manager_settings_option_group', // option_group
-            'LIST_MANAGER_API_KEY',
-            function ($input) {
-                if ($input == '') {
-                    return get_option('LIST_MANAGER_API_KEY');
-                }
-
-                return sanitize_text_field($input);
-            }
         );
 
         register_setting(
@@ -142,17 +127,6 @@ class ListManagerSettings
         );
 
         add_settings_field(
-            'list_manager_api_key', // id
-            _('List Manager API Key', 'cds-snc'), // title
-            array( $this, 'listManagerApiKeyCallback'), // callback
-            'list-manager-settings-admin', // page
-            'list_manager_settings_section', // section
-            [
-                'label_for' => 'list_manager_api_key'
-            ]
-        );
-
-        add_settings_field(
             'list_manager_notify_services', // id
             _('List Manager Notify Services', 'cds-snc'), // title
             array( $this, 'listManagerNotifyServicesCallback'), // callback
@@ -190,16 +164,6 @@ class ListManagerSettings
             $labelId,
             $startsWith,
             $endsWith
-        );
-    }
-
-    public function listManagerApiKeyCallback()
-    {
-        if ($string = $this->LIST_MANAGER_API_KEY) {
-            $this->getObfuscatedOutputLabel($string, 'list_manager_api_key_value');
-        }
-        printf(
-            '<input class="regular-text" type="text" name="LIST_MANAGER_API_KEY" id="list_manager_api_key" aria-describedby="list_manager_api_key_value" value="">'
         );
     }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -267,7 +267,7 @@ class ListManagerSettings
 
     public function listValuesCallback()
     {
-        $values = [];
+        $values = "[]";
 
         if ($this->list_values) {
             $values = json_decode($values);

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -25,21 +25,30 @@ class ListManagerSettings
     {
         $instance = new self($encryptedOption);
 
-        add_action('admin_menu', [$instance, 'listManagerSettingsAddPluginPage']);
+        add_action('admin_menu', [
+            $instance,
+            'listManagerSettingsAddPluginPage',
+        ]);
         add_action('admin_init', [$instance, 'listManagerSettingsPageInit']);
         add_action('admin_head', [$instance, 'addStyles']); // @TODO
 
-        add_filter('option_page_capability_list_manager_settings_option_group', function ($capability) {
-            return 'manage_list_manager';
-        });
+        add_filter(
+            'option_page_capability_list_manager_settings_option_group',
+            function ($capability) {
+                return 'manage_list_manager';
+            },
+        );
 
         $encryptedOptions = [
             'LIST_MANAGER_NOTIFY_SERVICES',
-            'LIST_MANAGER_SERVICE_ID' // @TODO: does this need to be encrypted?
+            'LIST_MANAGER_SERVICE_ID', // @TODO: does this need to be encrypted?
         ];
 
         foreach ($encryptedOptions as $option) {
-            add_filter("pre_update_option_{$option}", [$instance, 'encryptOption']);
+            add_filter("pre_update_option_{$option}", [
+                $instance,
+                'encryptOption',
+            ]);
             add_filter("option_{$option}", [$instance, 'decryptOption']);
         }
     }
@@ -58,13 +67,15 @@ class ListManagerSettings
 
     public function listManagerSettingsCreateAdminPage()
     {
-        $this->LIST_MANAGER_NOTIFY_SERVICES = get_option('LIST_MANAGER_NOTIFY_SERVICES') ?: '';
-        $this->LIST_MANAGER_SERVICE_ID = get_option('LIST_MANAGER_SERVICE_ID') ?: '';
+        $this->LIST_MANAGER_NOTIFY_SERVICES =
+            get_option('LIST_MANAGER_NOTIFY_SERVICES') ?: '';
+        $this->LIST_MANAGER_SERVICE_ID =
+            get_option('LIST_MANAGER_SERVICE_ID') ?: '';
         $this->list_values = get_option('list_values') ?: '';
         ?>
 
         <div class="wrap">
-            <h1><?php _e('List Manager Settings', 'cds-snc') ?></h1>
+            <h1><?php _e('List Manager Settings', 'cds-snc'); ?></h1>
             <p></p>
             <?php settings_errors(); ?>
 
@@ -72,18 +83,15 @@ class ListManagerSettings
                 <?php
                 settings_fields('list_manager_settings_option_group');
                 do_settings_sections('list-manager-settings-admin');
-                submit_button();
-                ?>
+                submit_button();?>
             </form>
         </div>
-    <?php }
+    <?php
+    }
 
     public function listManagerSettingsPageInit()
     {
-        register_setting(
-            'list_manager_settings_option_group',
-            'list_values'
-        );
+        register_setting('list_manager_settings_option_group', 'list_values');
 
         register_setting(
             'list_manager_settings_option_group', // option_group
@@ -94,7 +102,7 @@ class ListManagerSettings
                 }
 
                 return sanitize_text_field($input);
-            }
+            },
         );
 
         register_setting(
@@ -106,47 +114,47 @@ class ListManagerSettings
                 }
 
                 return sanitize_text_field($input);
-            }
+            },
         );
 
         add_settings_section(
             'list_manager_settings_section', // id
             _('List manager', 'cds-snc'), // title
-            array( $this, 'listManagerSettingsSectionInfo'), // callback
-            'list-manager-settings-admin' // page
+            [$this, 'listManagerSettingsSectionInfo'], // callback
+            'list-manager-settings-admin', // page
         );
 
         add_settings_field(
             'list_values', // id
             _('List Values JSON', 'cds-snc'), // title
-            array( $this, 'listValuesCallback'), // callback
+            [$this, 'listValuesCallback'], // callback
             'list-manager-settings-admin', // page
             'list_manager_settings_section', // section
             [
-                'label_for' => 'list_values'
-            ]
+                'label_for' => 'list_values',
+            ],
         );
 
         add_settings_field(
             'list_manager_notify_services', // id
             _('List Manager Notify Services', 'cds-snc'), // title
-            array( $this, 'listManagerNotifyServicesCallback'), // callback
+            [$this, 'listManagerNotifyServicesCallback'], // callback
             'list-manager-settings-admin', // page
             'list_manager_settings_section', // section
             [
-                'label_for' => 'list_manager_notify_services'
-            ]
+                'label_for' => 'list_manager_notify_services',
+            ],
         );
 
         add_settings_field(
             'list_manager_service_id', // id
             _('List Manager Service Id', 'cds-snc'), // title
-            array( $this, 'listManagerServiceIdCallback'), // callback
+            [$this, 'listManagerServiceIdCallback'], // callback
             'list-manager-settings-admin', // page
             'list_manager_settings_section', // section
             [
-                'label_for' => 'list_manager_service_id'
-            ]
+                'label_for' => 'list_manager_service_id',
+            ],
         );
     }
 
@@ -160,10 +168,13 @@ class ListManagerSettings
         $endsWith = substr($string, -4);
 
         $hint = sprintf(
-            __('<span class="hidden_keys" id="%1$s">Current value: <span class="sr-only">Starts with </span>%2$s<span aria-hidden="true"> … </span><span class="sr-only"> and ends with</span>%3$s</span>', 'cds-snc'),
+            __(
+                '<span class="hidden_keys" id="%1$s">Current value: <span class="sr-only">Starts with </span>%2$s<span aria-hidden="true"> … </span><span class="sr-only"> and ends with</span>%3$s</span>',
+                'cds-snc',
+            ),
             $labelId,
             $startsWith,
-            $endsWith
+            $endsWith,
         );
 
         if ($print) {
@@ -186,7 +197,7 @@ class ListManagerSettings
             $service_ids = [];
 
             for ($i = 0; $i < count($arr); $i++) {
-                $key_value = explode('~', $arr [$i]);
+                $key_value = explode('~', $arr[$i]);
                 $service_ids[$key_value[0]] = $key_value[1];
             }
 
@@ -209,18 +220,34 @@ class ListManagerSettings
         $values = [];
         $i = 0;
         foreach ($service_ids as $key => $value) {
-            $hint = $this->getObfuscatedOutputLabel($value, 'list_manager_notify_services_value', false);
-            array_push($values, ["id" => $i, "apiKey" => "", "name" => $key , "hint" => $hint]);
+            $hint = $this->getObfuscatedOutputLabel(
+                $value,
+                'list_manager_notify_services_value',
+                false,
+            );
+            array_push($values, [
+                'id' => $i,
+                'apiKey' => '',
+                'name' => $key,
+                'hint' => $hint,
+            ]);
             $i++;
         }
 
         if (count($values) < 1) {
-            array_push($values, ["id" => "", "apiKey" => "", "name" => "" , "hint" => ""]);
+            array_push($values, [
+                'id' => '',
+                'apiKey' => '',
+                'name' => '',
+                'hint' => '',
+            ]);
         }
 
         $values = json_encode($values);
 
-        printf('<div id="notify-services-repeater-form" style="margin-top:20px;">notify services</div>');
+        printf(
+            '<div id="notify-services-repeater-form" style="margin-top:20px;">notify services</div>',
+        );
         $data = 'CDS.renderNotifyServicesRepeaterForm(' . $values . ');';
         wp_add_inline_script('cds-snc-admin-js', $data, 'after');
     }
@@ -228,17 +255,36 @@ class ListManagerSettings
     public function listManagerServiceIdCallback()
     {
         if ($string = $this->LIST_MANAGER_SERVICE_ID) {
-            $this->getObfuscatedOutputLabel($string, 'list_manager_service_id_value');
+            $this->getObfuscatedOutputLabel(
+                $string,
+                'list_manager_service_id_value',
+            );
         }
         printf(
-            '<input class="regular-text" type="text" name="LIST_MANAGER_SERVICE_ID" id="list_manager_service_id" aria-describedby="list_manager_service_id_value" value="">'
+            '<input class="regular-text" type="text" name="LIST_MANAGER_SERVICE_ID" id="list_manager_service_id" aria-describedby="list_manager_service_id_value" value="">',
         );
     }
 
     public function listValuesCallback()
     {
+        $values = [];
+        
+        if ($this->list_values) {
+            $values = json_decode($values);
+        }
+
+        if (count($values) < 1) {
+            array_push($values, [
+                'id' => '',
+                'label' => '',
+                'type' => '',
+            ]);
+        }
+
+        $values = json_encode($values);
+
         printf('<div id="list-values-repeater-form"></div>');
-        $data = 'CDS.renderListValuesRepeaterForm(' . $this->list_values . ');';
+        $data = 'CDS.renderListValuesRepeaterForm(' . $values . ');';
         wp_add_inline_script('cds-snc-admin-js', $data, 'after');
     }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -270,7 +270,7 @@ class ListManagerSettings
         $values = "[]";
 
         if ($this->list_values) {
-            $values = json_decode($values);
+            $values = json_decode($this->list_values);
         }
 
         if (count($values) < 1) {

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CDS\Modules\Notify;
 
 use CDS\Modules\EncryptedOption\EncryptedOption;
+use InvalidArgumentException;
 
 class ListManagerSettings
 {

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -86,7 +86,7 @@ class ListManagerSettings
                 submit_button();?>
             </form>
         </div>
-    <?php
+        <?php
     }
 
     public function listManagerSettingsPageInit()
@@ -268,7 +268,7 @@ class ListManagerSettings
     public function listValuesCallback()
     {
         $values = [];
-        
+
         if ($this->list_values) {
             $values = json_decode($values);
         }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -267,7 +267,7 @@ class ListManagerSettings
 
     public function listValuesCallback()
     {
-        $values = "[]";
+        $values = [];
 
         if ($this->list_values) {
             $values = json_decode($this->list_values);

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -44,7 +44,7 @@ class NotifySettings
     public function notifyApiSettingsAddPluginPage()
     {
         add_options_page(
-            __('Notify Settings'), // page_title
+            __('Notify API Settings'), // page_title
             __('Notify API Settings'), // menu_title
             'manage_notify', // capability
             'notify-settings', // menu_slug
@@ -59,7 +59,7 @@ class NotifySettings
         ?>
 
         <div class="wrap">
-            <h1><?php _e('Notify and List Manager Settings', 'cds-snc') ?></h1>
+            <h1><?php _e('Notify API Settings', 'cds-snc') ?></h1>
             <p></p>
             <?php settings_errors(); ?>
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -13,10 +13,6 @@ class NotifySettings
 
     private string $NOTIFY_API_KEY;
     private string $NOTIFY_GENERIC_TEMPLATE_ID;
-    private string $LIST_MANAGER_API_KEY;
-    private string $LIST_MANAGER_NOTIFY_SERVICES;
-    private string $LIST_MANAGER_SERVICE_ID;
-    private string $list_values;
 
     public function __construct(EncryptedOption $encryptedOption)
     {
@@ -37,9 +33,6 @@ class NotifySettings
 
         $encryptedOptions = [
             'NOTIFY_API_KEY',
-            'LIST_MANAGER_API_KEY',
-            'LIST_MANAGER_NOTIFY_SERVICES',
-            'LIST_MANAGER_SERVICE_ID'
         ];
 
         foreach ($encryptedOptions as $option) {
@@ -50,13 +43,12 @@ class NotifySettings
 
     public function notifyApiSettingsAddPluginPage()
     {
-        add_submenu_page(
-            $this->admin_page,
-            __('Settings'),
-            __('Settings'),
-            'manage_notify',
-            $this->admin_page . '_settings',
-            [$this, 'notifyApiSettingsCreateAdminPage'],
+        add_options_page(
+            __('Notify Settings'), // page_title
+            __('Notify API Settings'), // menu_title
+            'manage_notify', // capability
+            'notify-settings', // menu_slug
+            array( $this, 'notifyApiSettingsCreateAdminPage' ) // function
         );
     }
 
@@ -64,10 +56,6 @@ class NotifySettings
     {
         $this->NOTIFY_API_KEY = get_option('NOTIFY_API_KEY') ?: '';
         $this->NOTIFY_GENERIC_TEMPLATE_ID = get_option('NOTIFY_GENERIC_TEMPLATE_ID') ?: '';
-        $this->LIST_MANAGER_API_KEY = get_option('LIST_MANAGER_API_KEY') ?: '';
-        $this->LIST_MANAGER_NOTIFY_SERVICES = get_option('LIST_MANAGER_NOTIFY_SERVICES') ?: '';
-        $this->LIST_MANAGER_SERVICE_ID = get_option('LIST_MANAGER_SERVICE_ID') ?: '';
-        $this->list_values = get_option('list_values') ?: '';
         ?>
 
         <div class="wrap">
@@ -87,11 +75,6 @@ class NotifySettings
 
     public function notifyApiSettingsPageInit()
     {
-        register_setting(
-            'notify_api_settings_option_group',
-            'list_values'
-        );
-
         register_setting(
             'notify_api_settings_option_group', // option_group
             'NOTIFY_API_KEY',
@@ -116,65 +99,11 @@ class NotifySettings
             }
         );
 
-        register_setting(
-            'notify_api_settings_option_group', // option_group
-            'LIST_MANAGER_API_KEY',
-            function ($input) {
-                if ($input == '') {
-                    return get_option('LIST_MANAGER_API_KEY');
-                }
-
-                return sanitize_text_field($input);
-            }
-        );
-
-        register_setting(
-            'notify_api_settings_option_group', // option_group
-            'LIST_MANAGER_NOTIFY_SERVICES',
-            function ($input) {
-                if ($input == '') {
-                    return get_option('LIST_MANAGER_NOTIFY_SERVICES');
-                }
-
-                return sanitize_text_field($input);
-            }
-        );
-
-        register_setting(
-            'notify_api_settings_option_group', // option_group
-            'LIST_MANAGER_SERVICE_ID',
-            function ($input) {
-                if ($input == '') {
-                    return get_option('LIST_MANAGER_SERVICE_ID');
-                }
-
-                return sanitize_text_field($input);
-            }
-        );
-
         add_settings_section(
             'notify_api_settings_setting_section', // id
             _('Notify', 'cds-snc'), // title
             array( $this, 'notifyApiSettingsSectionInfo'), // callback
             'notify-api-settings-admin' // page
-        );
-
-        add_settings_section(
-            'list_manager_settings_section', // id
-            'List manager', // title
-            array( $this, 'notifyApiSettingsSectionInfo'), // callback
-            'notify-api-settings-admin' // page
-        );
-
-        add_settings_field(
-            'list_values', // id
-            _('List Values JSON', 'cds-snc'), // title
-            array( $this, 'listValuesCallback'), // callback
-            'notify-api-settings-admin', // page
-            'list_manager_settings_section', // section
-            [
-                'label_for' => 'list_values'
-            ]
         );
 
         add_settings_field(
@@ -196,39 +125,6 @@ class NotifySettings
             'notify_api_settings_setting_section', // section
             [
                 'label_for' => 'notify_generic_template_id'
-            ]
-        );
-
-        add_settings_field(
-            'list_manager_api_key', // id
-            _('List Manager API Key', 'cds-snc'), // title
-            array( $this, 'listManagerApiKeyCallback'), // callback
-            'notify-api-settings-admin', // page
-            'list_manager_settings_section', // section
-            [
-                'label_for' => 'list_manager_api_key'
-            ]
-        );
-
-        add_settings_field(
-            'list_manager_notify_services', // id
-            _('List Manager Notify Services', 'cds-snc'), // title
-            array( $this, 'listManagerNotifyServicesCallback'), // callback
-            'notify-api-settings-admin', // page
-            'list_manager_settings_section', // section
-            [
-                'label_for' => 'list_manager_notify_services'
-            ]
-        );
-
-        add_settings_field(
-            'list_manager_service_id', // id
-            _('List Manager Service Id', 'cds-snc'), // title
-            array( $this, 'listManagerServiceIdCallback'), // callback
-            'notify-api-settings-admin', // page
-            'list_manager_settings_section', // section
-            [
-                'label_for' => 'list_manager_service_id'
             ]
         );
     }
@@ -266,49 +162,6 @@ class NotifySettings
         printf(
             '<input class="regular-text" type="text" name="NOTIFY_GENERIC_TEMPLATE_ID" id="notify_generic_template_id" value="%s">',
             $this->NOTIFY_GENERIC_TEMPLATE_ID ? $this->NOTIFY_GENERIC_TEMPLATE_ID : ''
-        );
-    }
-
-    public function listManagerApiKeyCallback()
-    {
-        if ($string = $this->LIST_MANAGER_API_KEY) {
-            $this->getObfuscatedOutputLabel($string, 'list_manager_api_key_value');
-        }
-        printf(
-            '<input class="regular-text" type="text" name="LIST_MANAGER_API_KEY" id="list_manager_api_key" aria-describedby="list_manager_api_key_value" value="">'
-        );
-    }
-
-    public function listManagerNotifyServicesCallback()
-    {
-        if ($string = $this->LIST_MANAGER_NOTIFY_SERVICES) {
-            $this->getObfuscatedOutputLabel($string, 'list_manager_notify_services_value');
-        }
-        printf(
-            '<input class="regular-text" type="text" name="LIST_MANAGER_NOTIFY_SERVICES" id="list_manager_notify_services" aria-describedby="list_manager_notify_services_value" value="">'
-        );
-    }
-
-    public function listManagerServiceIdCallback()
-    {
-        if ($string = $this->LIST_MANAGER_SERVICE_ID) {
-            $this->getObfuscatedOutputLabel($string, 'list_manager_service_id_value');
-        }
-        printf(
-            '<input class="regular-text" type="text" name="LIST_MANAGER_SERVICE_ID" id="list_manager_service_id" aria-describedby="list_manager_service_id_value" value="">'
-        );
-    }
-
-    public function listValuesCallback()
-    {
-        printf(
-            '<textarea name="list_values" id="list_values" rows="4" cols="50">%s</textarea>
-
-                <p class="description" id="new-admin-email-description">
-                    ' . _('Format', 'cds-snc') . ':
-                    <pre>[{"id":"123", "type":"email", "label":"my-list"}]</pre>
-                </p>',
-            $this->list_values ?: ''
         );
     }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -73,7 +73,7 @@ class NotifyTemplateSender
     {
         add_menu_page(
             __('Send Notify Template', "cds-snc"),
-            __('Notify', "cds-snc"),
+            __('Bulk Send', "cds-snc"),
             'level_0',
             $this->admin_page,
             [$this, 'renderForm'],

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/Setup.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/Setup.php
@@ -17,6 +17,7 @@ class Setup
         new NotifyTemplateSender(new FormHelpers(), new Notices());
 
         NotifySettings::register($encryptedOption);
+        ListManagerSettings::register($encryptedOption);
 
         if ($this->isNotifyConfigured()) {
             include __DIR__ . '/includes/wp-mail-notify-api.php';


### PR DESCRIPTION
# Summary | Résumé

Part of a bigger restructuring/refactoring of these sections and underlying data
- Move Notify Settings to Settings section
- Display Settings section to GC Admin users (with only Notify Settings available within)
- Rename section to Bulk Send
- Remove List Manager API Key setting as that has been moved to the environment in #232 

![image](https://user-images.githubusercontent.com/1187115/140823406-3c76e2b1-79a1-4655-979d-219022f0bb48.png)

...more in related PRs:
- Move List Manager API Key back to environment/global #232 
- Better List manager settings mgmt #231 
- Set default Notify API Key and Template ID #232 