### PR TITLE
Add repeater settings interface

### DIFF
--- a/cypress/integration/notify.settings.spec.js
+++ b/cypress/integration/notify.settings.spec.js
@@ -16,7 +16,7 @@ describe('Encrypted options', () => {
     cy.get('#notify_api_key').should('be.empty');
     cy.get('#notify_generic_template_id').should('be.empty');
     cy.get('#list_manager_api_key').should('be.empty');
-    cy.get('#list_manager_notify_services').should('be.empty');
+    cy.get('.api-key').should('be.empty');
     cy.get('#list_manager_service_id').should('be.empty');
   });
 
@@ -26,7 +26,8 @@ describe('Encrypted options', () => {
     cy.get('#notify_api_key').type('abcdefghijklmnopqrstuvwxyz');
     cy.get('#notify_generic_template_id').type('12345678910111213');
     cy.get('#list_manager_api_key').type('thisisthelistmanagerapikey');
-    cy.get('#list_manager_notify_services').type('listmanagerserviceslist');
+    // @todo update test
+    // cy.get('#list_manager_notify_services').type('listmanagerserviceslist');
     cy.get('#list_manager_service_id').type('serviceidforlistmanager');
     cy.get('#submit').click();
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -177,3 +177,48 @@ input[type='week'] {
 th.column-disable_user_login {
   width: 90px;
 }
+
+.settings-repeater .items{
+  margin-top:10px;
+}
+
+.settings-repeater .items .item {
+  border: 1px solid #000000;
+  border-radius: 5px;
+  background-color: #f8f8f8;
+  padding: 1.25em;
+  position: relative;
+  max-width: 500px;
+  margin-bottom:10px;
+}
+.settings-repeater .items .item label {
+  display: block;
+  font-weight: 600;
+  margin-right: 10px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+.settings-repeater .items .item input {
+  width: 380px;
+}
+.settings-repeater .items .item .panel-actions {
+  display: flex;
+}
+.settings-repeater .items .item .panel-actions .mover {
+  display: flex;
+  flex-direction: column;
+  margin-right: 0.2em;
+}
+.settings-repeater .items .item .panel-actions .mover button {
+  width: 20px;
+  margin-bottom:5px;
+}
+.settings-repeater .panel-actions {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 5px;
+}
+.settings-repeater .panel-actions .actions {
+  display: flex;
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -160,7 +160,7 @@ class NotifyTemplateSender
 
             for ($i = 0; $i < count($arr); $i++) {
                 $key_value = explode('~', $arr [$i]);
-                $service_ids[$key_value [0]] = $key_value [1];
+                $service_ids[$key_value[0]] = $key_value[1];
             }
 
             return $service_ids;

--- a/wordpress/wp-content/mu-plugins/cds-base/package-lock.json
+++ b/wordpress/wp-content/mu-plugins/cds-base/package-lock.json
@@ -14,6 +14,7 @@
         "@wordpress/components": "^18.0.0",
         "@wordpress/element": "^4.0.2",
         "@wordpress/i18n": "^4.2.3",
+        "@wordpress/icons": "^6.1.0",
         "sweetalert2": "^11.1.9"
       },
       "devDependencies": {
@@ -4212,9 +4213,9 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.2.tgz",
-      "integrity": "sha512-qBNpkLb7Hh3r9aSwBOBMwRUevScbN5iR1M5B8/ZOuSZbeXYNcgWxX4WqVrt5Y52CNm8WwoQTdqcuIziNN6lhig==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.3.tgz",
+      "integrity": "sha512-uFL8Xx0Uq/C+nCL5aM4Fb6YVub//1wuHyQK9VDtKwYg9UBELrexSCHo1XaesYRiGUqVW0o837qC7RCP2NLUBJw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@types/react": "^16.9.0",
@@ -4399,13 +4400,13 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-6.0.0.tgz",
-      "integrity": "sha512-dLr7O2mu6JlCQhM3uSIRJHFyv1AeYpRosrcWF9+zlhUy7RBczfLfhf7lXO6gVxhyuUEiWYfvesB5pNha4HxsVg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-6.1.0.tgz",
+      "integrity": "sha512-XzPtisDJlAbh8uZIzNafCVf76KkitllJPrGLPPPTJjFFNgga+qGisCIuybKB79LrenPVEIvyBhZ388hrR5rmVw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/element": "^4.0.2",
-        "@wordpress/primitives": "^3.0.2"
+        "@wordpress/element": "^4.0.3",
+        "@wordpress/primitives": "^3.0.3"
       },
       "engines": {
         "node": ">=12"
@@ -4634,12 +4635,12 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.2.tgz",
-      "integrity": "sha512-/r7EuKEyzM8aPhjGS/NC1+lgr3Dk/mCbICndAh7sZP86OmWqoSpnh0VPZp/DxT4JdGiCa/NycXdOiP7ylngG6A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.3.tgz",
+      "integrity": "sha512-eG1UE5d9xnML7PCr1DpP1PEliwLM4KIuEFieHVpW1HkiybyENeTl33HdqXalOSuNAdYrnYa4KifThbjcTdzP2Q==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/element": "^4.0.2",
+        "@wordpress/element": "^4.0.3",
         "classnames": "^2.3.1"
       },
       "engines": {
@@ -22947,9 +22948,9 @@
       }
     },
     "@wordpress/element": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.2.tgz",
-      "integrity": "sha512-qBNpkLb7Hh3r9aSwBOBMwRUevScbN5iR1M5B8/ZOuSZbeXYNcgWxX4WqVrt5Y52CNm8WwoQTdqcuIziNN6lhig==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.3.tgz",
+      "integrity": "sha512-uFL8Xx0Uq/C+nCL5aM4Fb6YVub//1wuHyQK9VDtKwYg9UBELrexSCHo1XaesYRiGUqVW0o837qC7RCP2NLUBJw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@types/react": "^16.9.0",
@@ -23088,13 +23089,13 @@
       }
     },
     "@wordpress/icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-6.0.0.tgz",
-      "integrity": "sha512-dLr7O2mu6JlCQhM3uSIRJHFyv1AeYpRosrcWF9+zlhUy7RBczfLfhf7lXO6gVxhyuUEiWYfvesB5pNha4HxsVg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-6.1.0.tgz",
+      "integrity": "sha512-XzPtisDJlAbh8uZIzNafCVf76KkitllJPrGLPPPTJjFFNgga+qGisCIuybKB79LrenPVEIvyBhZ388hrR5rmVw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/element": "^4.0.2",
-        "@wordpress/primitives": "^3.0.2"
+        "@wordpress/element": "^4.0.3",
+        "@wordpress/primitives": "^3.0.3"
       }
     },
     "@wordpress/is-shallow-equal": {
@@ -23270,12 +23271,12 @@
       "dev": true
     },
     "@wordpress/primitives": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.2.tgz",
-      "integrity": "sha512-/r7EuKEyzM8aPhjGS/NC1+lgr3Dk/mCbICndAh7sZP86OmWqoSpnh0VPZp/DxT4JdGiCa/NycXdOiP7ylngG6A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.3.tgz",
+      "integrity": "sha512-eG1UE5d9xnML7PCr1DpP1PEliwLM4KIuEFieHVpW1HkiybyENeTl33HdqXalOSuNAdYrnYa4KifThbjcTdzP2Q==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/element": "^4.0.2",
+        "@wordpress/element": "^4.0.3",
         "classnames": "^2.3.1"
       }
     },

--- a/wordpress/wp-content/mu-plugins/cds-base/package.json
+++ b/wordpress/wp-content/mu-plugins/cds-base/package.json
@@ -21,6 +21,7 @@
     "@wordpress/components": "^18.0.0",
     "@wordpress/element": "^4.0.2",
     "@wordpress/i18n": "^4.2.3",
+    "@wordpress/icons": "^6.1.0",
     "sweetalert2": "^11.1.9"
   },
   "devDependencies": {

--- a/wordpress/wp-content/mu-plugins/cds-base/src/index.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/index.tsx
@@ -7,9 +7,12 @@ import { LoginsPanel } from "../classes/Modules/TrackLogins/src/LoginsPanel";
 import { CollectionsPanel } from "../classes/Modules/UserCollections/src/CollectionsPanel";
 import { NotifyPanel } from "../classes/Modules/Notify/src/NotifyPanel";
 import { List } from "../classes/Modules/Notify/src/Types";
-import { UserForm } from "../classes/Modules/Users/src/UserForm"
-import { writeInterstitialMessage } from "util/preview"
-
+import { UserForm } from "../classes/Modules/Users/src/UserForm";
+import { writeInterstitialMessage } from "util/preview";
+import {
+  ListValuesRepeaterForm,
+  NotifyServicesRepeaterForm
+} from "./repeater/RepeaterForm";
 declare global {
   interface Window {
     CDS: {
@@ -20,6 +23,8 @@ declare global {
           sendTemplateLink: boolean;
         }) => void;
       };
+      renderListValuesRepeaterForm?: (values) => void,
+      renderNotifyServicesRepeaterForm?: (values) => void,
       renderLoginsPanel?: () => void;
       renderCollectionsPanel?: () => void;
       renderUserForm?: () => void;
@@ -53,7 +58,6 @@ export const renderNotifyPanel = ({
   );
 };
 
-
 export const renderUserForm = () => {
   render(
     <UserForm />,
@@ -61,13 +65,26 @@ export const renderUserForm = () => {
   );
 };
 
+export const renderListValuesRepeaterForm = (values) => {
+  render(<ListValuesRepeaterForm defaultState={values} />,
+    document.getElementById("list-values-repeater-form")
+  );
+}
+
+export const renderNotifyServicesRepeaterForm = (values) => {
+  render(<NotifyServicesRepeaterForm defaultState={values} />,
+    document.getElementById("notify-services-repeater-form")
+  );
+}
 
 window.CDS = window.CDS || {};
 window.CDS.Notify = { renderPanel: renderNotifyPanel };
 window.CDS.renderLoginsPanel = renderLoginsPanel;
 window.CDS.renderCollectionsPanel = renderCollectionsPanel;
 window.CDS.renderUserForm = renderUserForm;
-window.CDS.writeInterstitialMessage =  writeInterstitialMessage;
+window.CDS.writeInterstitialMessage = writeInterstitialMessage;
+window.CDS.renderListValuesRepeaterForm = renderListValuesRepeaterForm;
+window.CDS.renderNotifyServicesRepeaterForm = renderNotifyServicesRepeaterForm;
 
 window.wp.hooks.addFilter(
 	'editor.PostPreview.interstitialMarkup',

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/RepeaterForm.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/RepeaterForm.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { __ } from "@wordpress/i18n";
+import { FormRepeater } from "./components/FormRepeater";
+import { ListValuesForm } from "./forms/ListValuesForm";
+import { NotifyServicesForm } from "./forms/NotifyServicesForm";
+
+enum ListType {
+  EMAIL = "email",
+  SMS = "sms"
+}
+export interface ListItem {
+  itemId?: string,
+  id: string,
+  name: string,
+  listId: string,
+  type: ListType
+}
+
+export const ListValuesRepeaterForm = ({ defaultState }: { defaultState: [ListItem] }) => {
+  const emptyItem: ListItem = { id: "", name: "", listId: "", type: ListType.EMAIL };
+  return (
+    <FormRepeater
+      addLabel={__("Add List", "cds-snc")}
+      formType={ListValuesForm}
+      emptyItem={emptyItem}
+      defaultState={defaultState}
+    />
+  )
+};
+
+export interface ServiceItem {
+  itemId?: string,
+  id: string,
+  label: string,
+  apiKey: string
+}
+
+export const NotifyServicesRepeaterForm = ({ defaultState }: { defaultState: [ServiceItem] }) => {
+  const emptyItem: ServiceItem = { id: "", label: "", apiKey: "" };
+  return (
+    <FormRepeater
+      addLabel={__("Add Service", "cds-snc")}
+      formType={NotifyServicesForm}
+      emptyItem={emptyItem}
+      defaultState={defaultState}
+    />
+  )
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/FormRepeater.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/FormRepeater.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { TopBar } from "./TopBar";
+import { RepeaterProvider } from "../store/RepeaterContext";
+import { Repeater } from "./Repeater";
+
+export const FormRepeater = ({ formType, addLabel, defaultState, emptyItem }) => {
+
+  const Form = formType;
+
+  if (!defaultState?.length) {
+    return null
+  }
+
+  return (
+    <RepeaterProvider defaultState={defaultState}>
+      <div className="settings-repeater">
+        <hr />
+        <TopBar addLabel={addLabel} emptyItem={emptyItem} />
+        <Repeater render={(item) => <Form item={item} />} />
+        <hr />
+      </div>
+    </RepeaterProvider>
+  );
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Icons.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Icons.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { SVG, Path } from '@wordpress/primitives';
+
+export const ChevronUp = () => {
+    return (
+        <SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <Path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" />
+        </SVG>)
+};
+
+export const ChevronDown = (
+    <SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <Path d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z" />
+    </SVG>
+);
+
+export const Close = (
+    <SVG width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <Path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
+    </SVG>
+);

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Item.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Item.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { Panel } from "./Panel";
+
+export const Item = ({ item, index, children }) => {
+    item.index = index;
+    return (
+        <div className={`item item-${index}`}>
+            {children}
+            <Panel item={item} />
+        </div>
+    );
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Panel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Panel.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { Button } from "@wordpress/components";
+import { ChevronUp, ChevronDown, Close } from "./Icons";
+import { useRepeater } from "../store/RepeaterContext";
+
+
+export const Panel = ({ item }) => {
+    const { state, dispatch } = useRepeater();
+
+    const handleMoveUp = (index) => {
+        dispatch({ type: "move_up", payload: { index } });
+    };
+
+    const handleMoveDown = (index) => {
+        dispatch({ type: "move_down", payload: { index } });
+    };
+
+    const handleRemoveItem = (itemId) => {
+        dispatch({ type: "remove", payload: { itemId } });
+    };
+
+    return (
+        <div className="panel-actions">
+            <div className="actions">
+                {state && state.length >= 2 &&
+                    <div className="block-editor-block-mover">
+                        <div className="mover components-toolbar-group block-editor-block-mover__move-button-container">
+                            <Button style={{ backgroundColor: "#f8f8f8" }} isSmall icon={ChevronUp} onClick={() => handleMoveUp(item.index)} />
+                            <Button style={{ backgroundColor: "#f8f8f8" }} isSmall icon={ChevronDown} onClick={() => handleMoveDown(item.index)} />
+                        </div>
+                    </div>
+                }
+                <div className="remove" data-id={item.itemId}>
+                    <Button
+                        isSmall
+                        icon={Close}
+                        onClick={() => {
+                            handleRemoveItem(item.itemId);
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Repeater.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/Repeater.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { useRepeater } from "../store/RepeaterContext";
+import { Item } from "./Item";
+import { ListItem, ServiceItem } from "../../repeater/RepeaterForm";
+
+export const Repeater = ({ render }) => {
+    const { state } = useRepeater();
+    return (
+        <div className="items">
+            {state.map((item: ListItem | ServiceItem, index) => {
+                return (
+                    <div key={item.itemId}>
+                        <Item item={item} index={index}>
+                            {render(item)}
+                        </Item>
+                    </div>)
+            })}
+        </div>
+    );
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/TopBar.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/components/TopBar.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { Button } from "@wordpress/components";
+import { useRepeater } from "../store/RepeaterContext";
+
+export const TopBar = ({ addLabel, emptyItem }) => {
+  const { dispatch } = useRepeater();
+  const handleAddItem = () => {
+    dispatch({ type: "add", payload: { value: emptyItem } });
+  };
+
+  return (
+    <div className="top-bar">
+      <div className="content">
+        <Button isPrimary onClick={handleAddItem}>
+          {addLabel}
+        </Button>
+      </div>
+      <div className="one-edge-shadow fadedScroller_fade"></div>
+    </div>
+  );
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/forms/ListValuesForm.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/forms/ListValuesForm.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { useRepeater } from "../store/RepeaterContext";
+export const ListValuesForm = ({ item }) => {
+  const { state, dispatch } = useRepeater();
+
+  const handleChange = (field, e, index) => {
+    dispatch({
+      type: "change",
+      payload: { field, value: e.target.value, index }
+    });
+  };
+
+  const cleanedState = state.map((item) => {
+    return (({ label, id, type }) => ({ label, id, type }))(item);
+  });
+
+  return (
+    <div>
+      {/* this element contains the value to save to the database */}
+      <input id="list-values" name="list_values" type="hidden" value={JSON.stringify(cleanedState)} />
+
+      <label htmlFor={`label-${item.index}`}>{`Label`}:</label>
+      <input
+        type="text"
+        name={`label-${item.index}`}
+        value={item.label}
+        onChange={(e) => {
+          handleChange("label", e, item.index);
+        }}
+      />
+
+      <label htmlFor={`id-${item.index}`}>{`ID`}:</label>
+      <input
+        type="text"
+        name={`id-${item.index}`}
+        value={item.id}
+        onChange={(e) => {
+          handleChange("id", e, item.index);
+        }}
+      />
+
+      <label htmlFor={`type-${item.index}`}>{`Type`}:</label>
+      <input
+        type="text"
+        name={`type-${item.index}`}
+        value={item.type}
+        onChange={(e) => {
+          handleChange("type", e, item.index);
+        }}
+      />
+    </div>
+  );
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/forms/NotifyServicesForm.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/forms/NotifyServicesForm.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import { useRepeater } from "../store/RepeaterContext";
+export const NotifyServicesForm = ({ item }) => {
+  const { state, dispatch } = useRepeater();
+
+  const handleChange = (field, e, index) => {
+    dispatch({
+      type: "change",
+      payload: { field, value: e.target.value, index }
+    });
+  };
+
+  let cleanedState = "";
+
+  // map cleanedState to existing format
+  state.forEach((item, index) => {
+    cleanedState += `${item.name}~${item.apiKey}|`;
+  });
+
+  cleanedState = cleanedState.slice(0, -1);
+
+  return (
+    <div>
+      {/* this element contains the value to save to the database */}
+      <input id="list_manager_notify_services" name="LIST_MANAGER_NOTIFY_SERVICES" type="hidden" value={cleanedState} />
+      <label htmlFor={`name-${item.index}`}>{`Name`}:</label>
+      <input
+        type="text"
+        name={`name-${item.index}`}
+        value={item.name}
+        onChange={(e) => {
+          handleChange("name", e, item.index);
+        }}
+      />
+
+      <label htmlFor={`apiKey-${item.index}`}>{`API Key`}:</label>
+      {item.hint && <div dangerouslySetInnerHTML={{ __html: item.hint }} />}
+      <input
+        type="text"
+        name={`apiKey-${item.index}`}
+        className="api-key"
+        value={item.apiKey}
+        onChange={(e) => {
+          handleChange("apiKey", e, item.index);
+        }}
+      />
+    </div>
+  );
+};

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/store/RepeaterContext.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/store/RepeaterContext.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import { createContext, useReducer, useContext } from '@wordpress/element';
+import { v4 as uuidv4 } from "uuid";
+import { swap } from "../util";
+
+const getPreviousIndex = (items, index) => {
+  return index === 0 ? items.length - 1 : index - 1;
+};
+
+const getNextIndex = (items, index) => {
+  return index === items.length - 1 ? 0 : index + 1;
+};
+
+const RepeaterContext = createContext({
+  state: [],
+  dispatch: ({ }) => { },
+  getPreviousIndex,
+  getNextIndex
+});
+
+const RepeaterReducer = (state, action) => {
+  switch (action.type) {
+    case "change": {
+      return state.map((item, i) => {
+        if (action.payload.index !== i) return item;
+        const field = action.payload.field;
+        return { ...item, [field]: action.payload.value };
+      });
+    }
+    case "move_up": {
+      const index = action.payload.index;
+      const previous = getPreviousIndex(state, index);
+      return [...swap(state, index, previous)];
+    }
+    case "move_down": {
+      const index = action.payload.index;
+      const next = getNextIndex(state, index);
+      return [...swap(state, index, next)];
+    }
+    case "remove": {
+      return [
+        ...state.filter((item) => {
+          return item.itemId !== action.payload.itemId;
+        })
+      ];
+    }
+    case "add": {
+      return [...state, { ...action.payload.value, itemId: uuidv4() }];
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+};
+
+const RepeaterProvider = ({ children, defaultState }) => {
+
+  defaultState = defaultState.map((item) => {
+    return { itemId: uuidv4(), ...item }
+  });
+
+  const [state, dispatch] = useReducer(RepeaterReducer, defaultState);
+
+  const value = {
+    state,
+    dispatch,
+    getPreviousIndex,
+    getNextIndex
+  };
+
+  return (
+    <RepeaterContext.Provider value={value}>
+      {children}
+    </RepeaterContext.Provider>
+  );
+};
+
+const useRepeater = () => {
+  const context = useContext(RepeaterContext);
+  if (context === undefined) {
+    throw new Error("useRepeater must be used within a RepeaterProvider");
+  }
+  return context;
+};
+
+export { RepeaterProvider, useRepeater };

--- a/wordpress/wp-content/mu-plugins/cds-base/src/repeater/util.ts
+++ b/wordpress/wp-content/mu-plugins/cds-base/src/repeater/util.ts
@@ -1,0 +1,15 @@
+export const swap = (arr, index1, index2) => {
+    const a = { ...arr[index1] };
+    const b = { ...arr[index2] };
+  
+    return arr.map((item, i) => {
+      if (i === index1) {
+        item = b;
+      }
+      if (i === index2) {
+        item = a;
+      }
+  
+      return item;
+    });
+  };


### PR DESCRIPTION
In support of Part 5 here - https://github.com/cds-snc/gc-articles-issues/issues/69#issuecomment-962096516

Adds a settings repeater to handle more complex data entry for example where the user needs to enter JSON values

```
[{"id":"123", "type":"email", "label":"my-list"}]
```

This splits the entries into form entry fields for each value.

<img width="1086" alt="Screen Shot 2021-11-09 at 7 46 29 AM" src="https://user-images.githubusercontent.com/62242/140926822-5a7a1e66-b07b-4c7c-ae58-d6cbada5c66d.png">

The resulting values are saved to a hidden field in the existing format to keep things backwards compatible.
