### PR TITLE
List Manager API Key and Default Notify API Key Environment Variables

### DIFF
--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -25,7 +25,7 @@ env:
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_list_manager_endpoint: ${{ secrets.STAGING_LIST_MANAGER_ENDPOINT }}
   TF_VAR_list_manager_api_key: ${{ secrets.STAGING_LIST_MANAGER_API_KEY }}
-  TF_VAR_default_notify_api_key: ${{ secrets.DEFAULT_NOTIFY_API_KEY }}
+  TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}
   TF_VAR_s3_uploads_key: ${{ secrets.STAGING_S3_UPLOADS_KEY }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -24,6 +24,8 @@ env:
   TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_list_manager_endpoint: ${{ secrets.STAGING_LIST_MANAGER_ENDPOINT }}
+  TF_VAR_list_manager_api_key: ${{ secrets.STAGING_LIST_MANAGER_API_KEY }}
+  TF_VAR_default_notify_api_key: ${{ secrets.DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}
   TF_VAR_s3_uploads_key: ${{ secrets.STAGING_S3_UPLOADS_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -22,6 +22,8 @@ env:
   TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_list_manager_endpoint: ${{ secrets.STAGING_LIST_MANAGER_ENDPOINT }}
+  TF_VAR_list_manager_api_key: ${{ secrets.STAGING_LIST_MANAGER_API_KEY }}
+  TF_VAR_default_notify_api_key: ${{ secrets.DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}
   TF_VAR_s3_uploads_key: ${{ secrets.STAGING_S3_UPLOADS_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -23,7 +23,7 @@ env:
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_list_manager_endpoint: ${{ secrets.STAGING_LIST_MANAGER_ENDPOINT }}
   TF_VAR_list_manager_api_key: ${{ secrets.STAGING_LIST_MANAGER_API_KEY }}
-  TF_VAR_default_notify_api_key: ${{ secrets.DEFAULT_NOTIFY_API_KEY }}
+  TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}
   TF_VAR_s3_uploads_key: ${{ secrets.STAGING_S3_UPLOADS_KEY }}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -27,6 +27,8 @@ The following Terraform variables are required:
 * `s3_uploads_key`: S3 credentials for uploads storage IAM user
 * `s3_uploads_secret`: S3 credentials for uploads storage IAM user
 * `list_manager_endpoint`: Platform ListManager API endpoint
+* `list_manager_api_key`: API key used for Platform ListManager request auth
+* `default_notify_api_key`: Default Notify API key used before a site has one configured
 * `slack_webhook_url`: Slack incoming webhook to post SNS notifications to
 
 WordPress [generated secret keys](https://api.wordpress.org/secret-key/1.1/salt/):

--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -44,6 +44,14 @@
         "valueFrom": "${LIST_MANAGER_ENDPOINT}"
       },
       {
+        "name": "LIST_MANAGER_API_KEY",
+        "valueFrom": "${LIST_MANAGER_API_KEY}"
+      },
+      {
+        "name": "DEFAULT_NOTIFY_API_KEY",
+        "valueFrom": "${DEFAULT_NOTIFY_API_KEY}"
+      },
+      {
         "name": "ENCRYPTION_KEY",
         "valueFrom": "${ENCRYPTION_KEY}"
       },

--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -45,6 +45,8 @@ data "template_file" "wordpress_container_definition" {
     ENABLE_EFS = var.enable_efs
 
     LIST_MANAGER_ENDPOINT      = aws_secretsmanager_secret_version.list_manager_endpoint.arn
+    LIST_MANAGER_API_KEY       = aws_secretsmanager_secret_version.list_manager_api_key.arn
+    DEFAULT_NOTIFY_API_KEY     = aws_secretsmanager_secret_version.default_notify_api_key.arn
     ENCRYPTION_KEY             = aws_secretsmanager_secret_version.encryption_key.arn
     S3_UPLOADS_BUCKET          = aws_secretsmanager_secret_version.s3_uploads_bucket.arn
     S3_UPLOADS_KEY             = aws_secretsmanager_secret_version.s3_uploads_key.arn

--- a/infrastructure/terragrunt/aws/ecs/iam.tf
+++ b/infrastructure/terragrunt/aws/ecs/iam.tf
@@ -78,6 +78,8 @@ data "aws_iam_policy_document" "wordpress_ecs_task_get_secret_value" {
       var.database_username_secret_arn,
       var.database_password_secret_arn,
       aws_secretsmanager_secret_version.list_manager_endpoint.arn,
+      aws_secretsmanager_secret_version.list_manager_api_key.arn,
+      aws_secretsmanager_secret_version.default_notify_api_key.arn,
       aws_secretsmanager_secret_version.encryption_key.arn,
       aws_secretsmanager_secret_version.s3_uploads_bucket.arn,
       aws_secretsmanager_secret_version.s3_uploads_key.arn,

--- a/infrastructure/terragrunt/aws/ecs/inputs.tf
+++ b/infrastructure/terragrunt/aws/ecs/inputs.tf
@@ -52,6 +52,18 @@ variable "list_manager_endpoint" {
   sensitive   = true
 }
 
+variable "list_manager_api_key" {
+  description = "API key used for Platform ListManager request auth"
+  type        = string
+  sensitive   = true
+}
+
+variable "default_notify_api_key" {
+  description = "Default Notify API key used before a site has one configured"
+  type        = string
+  sensitive   = true
+}
+
 variable "encryption_key" {
   description = "Application encryption key"
   type        = string

--- a/infrastructure/terragrunt/aws/ecs/secrets.tf
+++ b/infrastructure/terragrunt/aws/ecs/secrets.tf
@@ -13,6 +13,24 @@ resource "aws_secretsmanager_secret_version" "list_manager_endpoint" {
   secret_string = var.list_manager_endpoint
 }
 
+resource "aws_secretsmanager_secret" "list_manager_api_key" {
+  name = "list_manager_api_key_${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "list_manager_api_key" {
+  secret_id     = aws_secretsmanager_secret.list_manager_api_key.id
+  secret_string = var.list_manager_api_key
+}
+
+resource "aws_secretsmanager_secret" "default_notify_api_key" {
+  name = "default_notify_api_key_${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "default_notify_api_key" {
+  secret_id     = aws_secretsmanager_secret.default_notify_api_key.id
+  secret_string = var.default_notify_api_key
+}
+
 resource "aws_secretsmanager_secret" "encryption_key" {
   name = "encryption_key_${random_string.random.result}"
 }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyClient.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyClient.php
@@ -18,7 +18,7 @@ class NotifyClient
     private function setupClient(): ?\Alphagov\Notifications\Client
     {
         try {
-            $NOTIFY_API_KEY = get_option('NOTIFY_API_KEY');
+            $NOTIFY_API_KEY = get_option('NOTIFY_API_KEY') ?: getenv('DEFAULT_NOTIFY_API_KEY');
 
             if (!$NOTIFY_API_KEY) {
                 return null;


### PR DESCRIPTION
# Summary | Résumé

Moves the List Manager API Key back to the environment as it just needs to be configured globally.

Also creates a new Default Notify API Key for use before a site has one configured.

## To test
- Set a DEFAULT_NOTIFY_API_KEY in your environment
- Make sure you don't have a NOTIFY_API_KEY set in the Notify Settings section
- Trigger an email (password reset) and verify that an email was sent