### PR TITLE
Give GC Admins ability to see and manage categories

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,7 +8,7 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.0.10', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.0.11', function () {
 
             if (is_blog_installed()) {
                 remove_role('editor');
@@ -43,6 +43,7 @@ class Roles
                 'manage_options' => 0,
                 'manage_notify' => 1,
                 'manage_list_manager' => 1,
+                'manage_categories' => 1,
                 'read' => 1,
                 'level_1' => 1,
                 'level_0' => 1,


### PR DESCRIPTION
# Summary

Super simple PR: adds "manage categories" permission to all GC Admins, and bumps the DB version so that roles are cleaned up with their new permissions.

Resolves this issue: https://github.com/cds-snc/gc-articles-issues/issues/40

And also, interestingly, GC Admins don't see the line of text about tags referenced in this issue:  https://github.com/cds-snc/gc-articles-issues/issues/44
(superadmins can still see it but we don't care about them)