### PR TITLE
Shorten user sessions and remove Remember Me option

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserSessions.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserSessions.php
@@ -37,12 +37,23 @@ class UserSessions
 
     private function addHooks(): void
     {
+        // shorten session time to 48 hours
+        add_filter('auth_cookie_expiration', [$this, 'expireSessions'], 99, 3);
+
         // ~Heavily~ inspired by the "Remember Me Not" plugin: https://wordpress.org/plugins/remembermenot/
 
         // Remove the "Remember me" option from the login form
         add_action('login_form', [$this, 'removeRememberMe'], 99);
         // Reset any attempt to set the "Remember me" option
         add_action('login_head', [$this, 'resetRememberMeOption'], 99);
+    }
+
+    public function expireSessions(int $seconds, int $user_id, bool $remember): int
+    {
+        // Wordpress default is 14 or 2 days
+        $expiration = (60 * 60) * 48; // 48 hours
+
+        return $expiration;
     }
 
     public function resetRememberMeOption(): void
@@ -59,7 +70,7 @@ class UserSessions
     }
 
     public function processLoginForm($content): string
-    {   
+    {
         $content = preg_replace(
             '/<p class="forgetmenot">(.*)<\/p>/', // Remove the "remember me" checkbox
             '<style>#wp-submit {float: left;}</style>', // add CSS rules to left-align the button

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserSessions.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserSessions.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Users;
+
+class UserSessions
+{
+    /**
+     * Plugin singleton instance
+     *
+     * @var UserSessions
+     */
+    private static $instance;
+
+
+    /**
+     * Hide constructor for this singleton
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Singleton instance
+     */
+    public static function getInstance(): UserSessions
+    {
+        if (empty(self::$instance) && ! (self::$instance instanceof UserSessions)) {
+            self::$instance = new UserSessions();
+            self::$instance->addHooks();
+        }
+
+        return self::$instance;
+    }
+
+
+    private function addHooks(): void
+    {
+        // ~Heavily~ inspired by the "Remember Me Not" plugin: https://wordpress.org/plugins/remembermenot/
+
+        // Remove the "Remember me" option from the login form
+        add_action('login_form', [$this, 'removeRememberMe'], 99);
+        // Reset any attempt to set the "Remember me" option
+        add_action('login_head', [$this, 'resetRememberMeOption'], 99);
+    }
+
+    public function resetRememberMeOption(): void
+    {
+        // Remove the rememberme post value
+        if (isset($_POST['rememberme'])) {
+            unset($_POST['rememberme']);
+        }
+    }
+
+    public function removeRememberMe(): void
+    {
+        ob_start([$this, 'processLoginForm']);
+    }
+
+    public function processLoginForm($content): string
+    {   
+        $content = preg_replace(
+            '/<p class="forgetmenot">(.*)<\/p>/', // Remove the "remember me" checkbox
+            '<style>#wp-submit {float: left;}</style>', // add CSS rules to left-align the button
+            $content
+        );
+
+        return $content;
+    }
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/Users.php
@@ -9,6 +9,7 @@ use WP_REST_Response;
 use CDS\Modules\Users\EmailDomains;
 use CDS\Modules\Users\UserLockout;
 use CDS\Modules\Users\Usernames;
+use CDS\Modules\Users\UserSessions;
 use CDS\Modules\Users\ValidationException;
 
 class Users
@@ -31,6 +32,8 @@ class Users
         add_action('plugins_loaded', function () {
             new UserLockout();
         }, 12); // relies on "Disable User Login" plugin, which activates itself at priority 11
+
+        UserSessions::getInstance();
     }
 
     public function registerEndpoints(): void


### PR DESCRIPTION
# Summary

This plugin removes the "Remember me" option on the login page, and shortens all user sessions to 48 hours. 

Resolves https://github.com/cds-snc/gc-articles-issues/issues/45

## Discussion

Asked Bryan what we should do with "remember me", and he said:
> Just hide it, we will accept a session time out of 48 hours and the associated risk and I will reflect that in the Security report.

To remove the "Remember me" checkbox, I was heavily inspired by the [Remember Me Not](https://wordpress.org/plugins/remembermenot/) Plugin, so it removes the option on the login form and unsets the POST option if somehow someone sends it anyway.

Also return the session at 48 hours every time, using code suggested in [the article Tim shared](https://pc021.info/change-session-expire-time-in-wordpress/).

## Screenshots

Note that the lastpass extension is cluttering up the interface here but try and ignore it.

| before | after |
|--------|-------|
| Current login, allows "remember me" and button on right | New login, no more "remember me" and left-aligned button |
|  <img width="1397" alt="Screen Shot 2021-11-09 at 13 58 12" src="https://user-images.githubusercontent.com/2454380/140988458-f5e5d9eb-66e4-4000-b0e2-e88b4b939909.png">   |   <img width="1397" alt="Screen Shot 2021-11-09 at 13 58 15" src="https://user-images.githubusercontent.com/2454380/140988466-77f577ad-7292-4d9e-8743-27c9900c4594.png">  |


