### PR TITLE
Hooks to prevent new users being created on a new network site.

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
@@ -6,6 +6,9 @@ namespace CDS\Modules\Cleanup;
 
 class SitesToCollections
 {
+    public string $adminEmailMessage;
+    public string $collectionMessage;
+
     public function __construct()
     {
         if (is_admin()) {
@@ -15,6 +18,14 @@ class SitesToCollections
 
         // for non wp-admin replace only in Admin Bar
         add_action('wp_before_admin_bar_render', [$this, 'changeSitesLabelAdminBar'], 99, 0);
+
+        $this->adminEmailMessage = __('Admin Email <strong>must be</strong> a current Super Admin', 'cds-snc');
+        $this->collectionMessage = __('or else a Collection won’t be created', 'cds-snc');
+
+        // add message to the Add New Collection Form
+        add_action('network_site_new_form', [$this, 'editNewCollectionForm']);
+        // throw an error if a new user is attepted to be created when adding a New Collection
+        add_action('pre_network_site_new_created_user', [$this, 'dieIfNewUser']);
     }
 
     public function changeSitesLabel($translation, $text, $domain): string
@@ -36,5 +47,21 @@ class SitesToCollections
         // remove "My Sites"
         global $wp_admin_bar;
         $wp_admin_bar->remove_menu('my-sites');
+    }
+
+    public function editNewCollectionForm(): void
+    {
+        // remove the existing message
+        print "<style>.form-field:last-of-type {display: none;}</style>";
+        printf(
+            "<p>%s, %s.</p>",
+            $this->adminEmailMessage,
+            $this->collectionMessage
+        );
+    }
+
+    public function dieIfNewUser(): void
+    {
+        wp_die($this->adminEmailMessage . '.');
     }
 }


### PR DESCRIPTION
# Summary

This is a proof of concept PR with some working code that:
- _says_ you can only add Super Admins to a new collection 
- in reality, prevents _new users_ from being created when creating a new collection

You can still assign a non-super admin if you want — it's kind of arbitrary because all super admins are able to make changes to new sites after the fact. It would be nicer to actually restrict this to super users, but this is the best you can do without replacing the page.

![super-users](https://user-images.githubusercontent.com/2454380/141809929-24e3deef-7ddd-4e34-8c59-1ee2f2309d53.gif)

## Explanation

The code that creates a new network site is here: https://github.com/WordPress/WordPress/blob/a207dadc10e88208a82e6b94f204b0122df97d95/wp-admin/network/site-new.php#L36

It's a mix of functions and HTML code, so it's hard to extract anything in isolation without replacing the whole page. There are **3** hooks on this page, and no filters:

1. _Before_ adding a new user
2. _After_ adding a new user
3. _Before_ rendering the "submit" button (but _after_ the rest of the form has already been rendered)

- Using the 1st hook, we can prevent new users from being added (by using `wp_die` — returning a `WP_Error` is ignored).
- Using the 3rd hook, we can add more HTML to the page. In this case, I used CSS to hide the previous message about creating new users and I added new message saying that only Super Admins are accepted.

Unfortunately, there is no way to override parts of this form (for example, removing the "Admin Email" field and replacing it with a `<select>`), or the underlying logic for checking users (we can only stop sites being created for new users, we can't check the role of existing users).

As far as I can tell, it's either do something like this or replace the page.
