### PR TITLE
Catch when the notify services option is empty (new site)

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/FormHelpers.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/FormHelpers.php
@@ -81,6 +81,8 @@ class FormHelpers
 
           <?php
             $sender = new NotifyTemplateSender();
+            $services = [];
+
             $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
             $services = Utils::deserializeServiceIds($serviceIdData);
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/FormHelpers.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/FormHelpers.php
@@ -80,9 +80,6 @@ class FormHelpers
         <div id="notify-panel"></div>
 
           <?php
-            $sender = new NotifyTemplateSender();
-            $services = [];
-
             $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
             $services = Utils::deserializeServiceIds($serviceIdData);
 
@@ -91,11 +88,11 @@ class FormHelpers
                 array_push($serviceIds, $value['service_id']);
             }
 
-            $data = 'CDS.Notify.renderPanel({ "sendTemplateLink" :false , serviceId: "' . $serviceIds[0] . '"});';
+            $defaultServiceId = $serviceIds[0] ?? '';
+
+            $data = 'CDS.Notify.renderPanel({ "sendTemplateLink" :false , serviceId: "' . $defaultServiceId . '"});';
             wp_add_inline_script('cds-snc-admin-js', $data, 'after');
             ?>
-
-
       </div>
         <?php
     }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerSettings.php
@@ -153,13 +153,8 @@ class ListManagerSettings
 
     public function listManagerNotifyServicesCallback()
     {
-        try {
-            $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
-            $service_ids = Utils::deserializeServiceIds($serviceIdData);
-        } catch (InvalidArgumentException $e) {
-            error_log($e->getMessage());
-            $service_ids = [];
-        }
+        $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
+        $service_ids = Utils::deserializeServiceIds($serviceIdData);
 
         $values = [];
         $i = 0;

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -222,19 +222,8 @@ class NotifyTemplateSender
             Notices::handleNotice($_GET['status']);
         }
 
-        $listValues = [];
-        $serviceIds = [];
-
-        try {
-            $serviceIds = Utils::deserializeServiceIds(get_option('LIST_MANAGER_NOTIFY_SERVICES'));
-        } catch (Exception $e) {
-            error_log("Empty or invalid LIST_MANAGER_NOTIFY_SERVICES option");
-        }
-        try {
-            $listValues = self::parseJsonOptions(get_option('list_values'));
-        } catch (Exception $e) {
-            error_log("Empty or invalid list_values option");
-        }
+        $serviceIds = Utils::deserializeServiceIds(get_option('LIST_MANAGER_NOTIFY_SERVICES'));
+        $listValues = self::parseJsonOptions(get_option('list_values'));
 
         FormHelpers::render([
             "service_ids" => $serviceIds,
@@ -245,7 +234,7 @@ class NotifyTemplateSender
     public static function parseJsonOptions($data)
     {
         if (empty($data)) {
-            throw new InvalidArgumentException('No list data');
+            return [];
         }
 
         $data = preg_replace(

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -222,20 +222,18 @@ class NotifyTemplateSender
             Notices::handleNotice($_GET['status']);
         }
 
-        $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
-
         $listValues = [];
         $serviceIds = [];
 
         try {
-            $serviceIds = Utils::deserializeServiceIds($serviceIdData);
+            $serviceIds = Utils::deserializeServiceIds(get_option('LIST_MANAGER_NOTIFY_SERVICES'));
         } catch (Exception $e) {
-            error_log($e->getMessage());
+            error_log("Empty or invalid LIST_MANAGER_NOTIFY_SERVICES option");
         }
         try {
             $listValues = self::parseJsonOptions(get_option('list_values'));
         } catch (Exception $e) {
-            error_log($e->getMessage());
+            error_log("Empty or invalid list_values option");
         }
 
         FormHelpers::render([

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
@@ -26,10 +26,11 @@ class SendTemplateDashboardPanel
     {
         $sender = new NotifyTemplateSender();
         $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
-        $services = Utils::deserializeServiceIds($serviceIdData);
-
         $serviceIds = [];
+        
         try {
+            $services = Utils::deserializeServiceIds($serviceIdData);
+
             foreach ($services as $key => $value) {
                 array_push($serviceIds, $value['service_id']);
             }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
@@ -24,18 +24,17 @@ class SendTemplateDashboardPanel
 
     public function notifyPanelHandler(): void
     {
-        $sender = new NotifyTemplateSender();
         $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
         $serviceIds = [];
 
-        try {
-            $services = Utils::deserializeServiceIds($serviceIdData);
+        $services = Utils::deserializeServiceIds($serviceIdData);
 
-            foreach ($services as $key => $value) {
-                array_push($serviceIds, $value['service_id']);
-            }
-        } catch (\Exception $e) {
-            // catch and add empty id
+        foreach ($services as $key => $value) {
+            array_push($serviceIds, $value['service_id']);
+        }
+
+        // catch and add empty id
+        if(empty($serviceIds)) {
             array_push($serviceIds, '');
         }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
@@ -27,7 +27,7 @@ class SendTemplateDashboardPanel
         $sender = new NotifyTemplateSender();
         $serviceIdData = get_option('LIST_MANAGER_NOTIFY_SERVICES');
         $serviceIds = [];
-        
+
         try {
             $services = Utils::deserializeServiceIds($serviceIdData);
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/SendTemplateDashboardPanel.php
@@ -34,7 +34,7 @@ class SendTemplateDashboardPanel
         }
 
         // catch and add empty id
-        if(empty($serviceIds)) {
+        if (empty($serviceIds)) {
             array_push($serviceIds, '');
         }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/Utils.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/Utils.php
@@ -12,7 +12,7 @@ class Utils
     public static function deserializeServiceIds($serviceIdData): array
     {
         if (!$serviceIdData) {
-            throw new InvalidArgumentException('No service data');
+            return [];
         }
 
         try {

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/src/NotifyPanel.tsx
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/src/NotifyPanel.tsx
@@ -132,8 +132,14 @@ export const NotifyPanel = ({ sendTemplateLink = false, serviceId = "" }) => {
     const fetchData = async () => {
 
       try {
+        if(!serviceId) {
+          setIsLoading(false);
+          return;
+        }
+
         const response = await getData(`wp-notify/v1/list_counts/${serviceId}`);
         setIsLoading(false);
+
         if (response.length >= 1) {
           setListCounts(await matchCountToList(response));
         }

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/tests/NotifyTest.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/tests/NotifyTest.php
@@ -6,7 +6,6 @@ use CDS\Modules\Notify\FormHelpers;
 use CDS\Modules\Notify\Notices;
 use CDS\Modules\Notify\NotifyTemplateSender;
 use CDS\Modules\Notify\Utils;
-use InvalidArgumentException;
 
 test('parseServiceIds', function () {
     $sender = new NotifyTemplateSender(new FormHelpers(), new Notices());
@@ -30,22 +29,20 @@ test('parseServiceIds', function () {
 test('parseServiceIdsBadInput', function () {
     $sender = new NotifyTemplateSender(new FormHelpers(), new Notices());
     $serviceIdEnv = "serviceID1";
-    Utils::deserializeServiceIds($serviceIdEnv);
-})->throws(InvalidArgumentException::class)->skip(); // @TODO: this doesn't throw an exception
+    $result = Utils::deserializeServiceIds($serviceIdEnv);
+    expect($result)->toEqual(["serviceID1" => NULL]);
+});
 
 test('parseServiceIdsNoInput', function () {
     $sender = new NotifyTemplateSender(new FormHelpers(), new Notices());
-    Utils::deserializeServiceIds(null);
-})->throws(InvalidArgumentException::class);
+    $result = Utils::deserializeServiceIds(null);
+    expect($result)->toEqual([]);
+});
 
 test('parseJsonOptions', function () {
-    try {
-        $sender = new NotifyTemplateSender(new FormHelpers(), new Notices());
-        $options = $sender->parseJsonOptions('[{"id":"123", "type":"email", "label":"my-list"}]');
-        expect($options)->toEqual([["id" => 123, "type" => "email", "label" => "my-list"]]);
-    } catch (Exception $e) {
-        echo $e->getMessage();
-    }
+    $sender = new NotifyTemplateSender(new FormHelpers(), new Notices());
+    $options = $sender->parseJsonOptions('[{"id":"123", "type":"email", "label":"my-list"}]');
+    expect($options)->toEqual([["id" => 123, "type" => "email", "label" => "my-list"]]);
 });
 
 test('parseJsonOptionsInvalidJson', function () {
@@ -57,4 +54,5 @@ test('parseJsonOptionsInvalidJson', function () {
 test('parseJsonOptionsEmpty', function () {
     $sender = new NotifyTemplateSender(new FormHelpers(), new Notices());
     $options = $sender->parseJsonOptions("");
-})->throws(InvalidArgumentException::class);
+    expect($options)->toEqual([]);
+});


### PR DESCRIPTION
# Summary | Résumé

On new sites, when the LIST_MANAGER_NOTIFY_SERVICES option doesn't exist yet, this was erroring out. ~~Moved the deserialize call into the try/catch to catch that problem~~.

After some digging, decided to change how the underlying methods work - instead of throwing an exception on empty or invalid input, they methods just return an empty array, which is what the try/catch blocks were doing anyway.
