### PR TITLE
Single session for signed-in users

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Profile.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Profile.php
@@ -102,6 +102,11 @@ class Profile
          *--------------------------------------------*/
         $crawler->filter('.application-passwords')->remove();
 
+        /*--------------------------------------------*
+         * Remove "Log Out Everywhere Else" button
+         *--------------------------------------------*/
+        $crawler->filter('.user-sessions-wrap')->remove();
+
         echo $crawler->save();
     }
 


### PR DESCRIPTION
# Summary | Résumé

This PR does a couple of things:
- Remove existing sessions after successfully logging in
- Hides the "Log Me Out Everywhere" button in profile for GC Admins, GC Editors

Resolves https://github.com/cds-snc/gc-articles-issues/issues/103

### Description

The code to destroy sessions is pretty similar to what WordPress does now when you press the "Log me out everywhere" button: [wp_ajax_destroy_sessions](https://github.com/WordPress/WordPress/blob/3ab8d52d78cb9f3b8a8eb27ed22971b00509119e/wp-admin/includes/ajax-actions.php#L3841)

You can test this by logging in on a second browser, and then reloading your screen on your original, already-logged-in browser. You can also log in as a GC Admin and check your profile.

## Screenshots

| before | after |
|--------|-------|
|  <img width="964" alt="Screen Shot 2021-11-15 at 17 37 28" src="https://user-images.githubusercontent.com/2454380/141863876-4762d989-f444-47b8-8f5a-c39f85037c47.png">   | <img width="964" alt="Screen Shot 2021-11-15 at 17 37 39" src="https://user-images.githubusercontent.com/2454380/141863878-5f350ee8-8ec3-4014-b7a9-59fc60e449bc.png">    |

