### PR TITLE
Add bulk send cap profile checkbox

### DIFF
--- a/cypress/integration/notify.template.sender.spec.js
+++ b/cypress/integration/notify.template.sender.spec.js
@@ -25,6 +25,7 @@ describe('Notify Template Sender', () => {
             req.redirect("/wp-admin/admin.php?page=cds_notify_send&status=200");
         }).as('bulkSender');
 
+        cy.addUserCap("admin", "list_manager_bulk_send");
         cy.login();
     });
 

--- a/cypress/integration/user.roles.spec.js
+++ b/cypress/integration/user.roles.spec.js
@@ -9,8 +9,7 @@ const allowedPages200 = [
     'edit.php',
     'post-new.php',
     'edit.php?post_type=page',
-    'post-new.php?post_type=page',
-    'admin.php?page=cds_notify_send'
+    'post-new.php?post_type=page'
 ];
 
 // user should not be able to access these pages
@@ -18,7 +17,8 @@ const allowedPages200 = [
 const blockedPages403 = [
     'upload.php',
     'themes.php',
-    'options-general.php'
+    'options-general.php',
+    'admin.php?page=cds_notify_send'
 ];
 
 const blockedPages500 = [

--- a/cypress/support/commands/add-user-cap.js
+++ b/cypress/support/commands/add-user-cap.js
@@ -1,0 +1,3 @@
+Cypress.Commands.add('addUserCap', (userName, cap) => {
+  cy.exec(`wp-env run tests-cli "wp user add-cap ${userName} ${cap}"`, { failOnNonZeroExit: false });
+});

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -5,3 +5,4 @@ import './visit-notify';
 import './visit-profile';
 import './add-user';
 import './login-user';
+import './add-user-cap';

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -24,7 +24,8 @@ class Menus
         $allowed = [
             __('Pages'),
             __('Posts'),
-            __('Articles', 'cds'),
+            __('Articles', 'cds-snc'),
+            __('Bulk', 'cds-snc'),
             __('Users'),
             __('Settings'),
         ];

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -41,7 +41,7 @@ class Roles
                 'manage_network_users' => 1, // enables "edit_users" for GC Admins'
                 'manage_options' => 0,
                 'manage_notify' => 1,
-                'manage_list_manager' => 1,  // by default this is off 
+                'manage_list_manager' => 1,  // by default this is off
                 'list_manager_bulk_send' => 0, // this is managed per user (see user profile)
                 'manage_categories' => 1,
                 'read' => 1,

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,8 +8,7 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.0.11', function () {
-
+        Utils::checkOptionCallback('cds_base_activated', '1.0.15', function () {
             if (is_blog_installed()) {
                 remove_role('editor');
                 remove_role('author');
@@ -42,7 +41,8 @@ class Roles
                 'manage_network_users' => 1, // enables "edit_users" for GC Admins'
                 'manage_options' => 0,
                 'manage_notify' => 1,
-                'manage_list_manager' => 1,
+                'manage_list_manager' => 1,  // by default this is off 
+                'list_manager_bulk_send' => 0, // this is managed per user (see user profile)
                 'manage_categories' => 1,
                 'read' => 1,
                 'level_1' => 1,

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerUserProfile.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerUserProfile.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace CDS\Modules\Notify;
+
+use WP_User;
+
+class ListManagerUserProfile
+{
+
+    public function __construct()
+    {
+    }
+
+    public static function register()
+    {
+        $instance = new self();
+
+        add_action('show_user_profile', [$instance, 'displayListManagerMeta']);
+        add_action('edit_user_profile', [$instance, 'displayListManagerMeta']);
+
+        add_action('personal_options_update', [$instance, 'updateListManagerMeta']);
+        add_action('edit_user_profile_update', [$instance,'updateListManagerMeta']);
+    }
+
+    public function displayListManagerMeta($user)
+    {
+        if (!is_super_admin()) {
+            return;
+        }
+
+        $list_manager_bulk_send = user_can($user, "list_manager_bulk_send");
+
+        if ($list_manager_bulk_send) {
+            $checked = 'checked';
+        } else {
+            $checked = '';
+        }
+
+        printf('<h3>%s</h3>', __('List Manager', 'cds-snc'));
+        print "<table class='form-table'>";
+        print '<tr>';
+        printf(
+            "<th><label for='list_manager_bulk_send'>%s</label></th>",
+            __('Bulk Send', 'cds-snc'),
+        );
+        printf(
+            "<td><input value='true' type='checkbox' name='list_manager_bulk_send' id='list_manager_bulk_send' %s /> %s</td>",
+            $checked,
+            __('Allow bulk send', 'cds-snc'),
+        );
+        print '</tr>';
+        print '</table>';
+    }
+
+    public function updateListManagerMeta($userId)
+    {
+        if (!is_super_admin()) {
+            return;
+        }
+
+        $user = new WP_User($userId);
+        $user->remove_cap('list_manager_bulk_send');
+
+        if (isset($_POST['list_manager_bulk_send']) && $_POST['list_manager_bulk_send'] === "true") {
+            $user->add_cap('list_manager_bulk_send');
+        }
+    }
+}

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerUserProfile.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/ListManagerUserProfile.php
@@ -15,7 +15,6 @@ class ListManagerUserProfile
     {
         $instance = new self();
 
-        add_action('show_user_profile', [$instance, 'displayListManagerMeta']);
         add_action('edit_user_profile', [$instance, 'displayListManagerMeta']);
 
         add_action('personal_options_update', [$instance, 'updateListManagerMeta']);

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use JetBrains\PhpStorm\ArrayShape;
 use WP_REST_Response;
 use CDS\Modules\Notify\Utils;
+use CDS\Modules\Notify\ListManagerUserProfile;
 
 class NotifyTemplateSender
 {
@@ -28,6 +29,9 @@ class NotifyTemplateSender
 
         add_action('admin_menu', [$instance, 'addMenu']);
         add_action('rest_api_init', [$instance, 'registerEndpoints']);
+
+        $listManagerProfile = new ListManagerUserProfile();
+        $listManagerProfile->register();
     }
 
     public static function processListCounts($data): WP_REST_Response
@@ -59,7 +63,7 @@ class NotifyTemplateSender
             'methods' => 'POST',
             'callback' => [$this, 'processSend'],
             'permission_callback' => function () {
-                return current_user_can('delete_posts');
+                return current_user_can('list_manager_bulk_send');
             }
         ]);
 
@@ -70,7 +74,7 @@ class NotifyTemplateSender
                 'service_id' => [],
             ],
             'permission_callback' => function () {
-                return current_user_can('delete_posts');
+                return current_user_can('list_manager_bulk_send');
             }
         ]);
     }
@@ -80,7 +84,7 @@ class NotifyTemplateSender
         add_menu_page(
             __('Send Notify Template', "cds-snc"),
             __('Bulk Send', "cds-snc"),
-            'level_0',
+            'list_manager_bulk_send',
             $this->admin_page,
             [$this, 'renderForm'],
             'dashicons-email'


### PR DESCRIPTION
Adds a checkbox for bulk sending permission under a users profile.

<img width="433" alt="Screen Shot 2021-11-16 at 10 07 07 AM" src="https://user-images.githubusercontent.com/62242/142020907-30afca5f-997a-4e7d-97d0-ffe0b424dff3.png">

Closes https://github.com/cds-snc/gc-articles-issues/issues/23
