### PR TITLE
Enable notify for default notify api key

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/Setup.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/Setup.php
@@ -28,6 +28,6 @@ class Setup
      */
     protected function isNotifyConfigured(): bool
     {
-        return (bool)get_option('NOTIFY_API_KEY');
+        return (bool)get_option('NOTIFY_API_KEY') || (bool)getenv('DEFAULT_NOTIFY_API_KEY');
     }
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where the DEFAULT_NOTIFY_API_KEY wasn't being used when the site didn't have its own configured.