### PR TITLE
Allow list wp-wpml cookies

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -39,11 +39,13 @@ resource "aws_cloudfront_distribution" "wordpress" {
           "comment_author_url_*",
           "wordpress_*",
           "wordpress_logged_in_*",
+          "wordpress_sec_*",
           "wordpress_test_cookie",
           "wp-settings-*",
           "wp-resetpass-*",
           "wp-saving-post",
-          "wp-postpass_*"
+          "wp-postpass_*",
+          "wp-wpml_*"
         ]
       }
     }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -85,7 +85,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                 field_to_match {
                   uri_path {}
                 }
-                positional_constraint = "STARTS_WITH"
+                positional_constraint = "CONTAINS"
                 search_string         = "/wp-admin"
                 text_transformation {
                   type     = "NONE"
@@ -149,7 +149,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                 field_to_match {
                   uri_path {}
                 }
-                positional_constraint = "STARTS_WITH"
+                positional_constraint = "CONTAINS"
                 search_string         = "/wp-admin"
                 text_transformation {
                   type     = "NONE"


### PR DESCRIPTION
# Summary | Résumé

- Adds a `wp-wpml_*` wildcard to allow cookies from wpml
- Also adds a `wordpress_sec_*` wildcard
- Switches the match statement on the `/wp-admin` url exceptions on custom waf rules to CONTAINS so we catch the sub-site urls
