### PR TITLE
Use broader wildcards on cookie allow-list

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -38,14 +38,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
           "comment_author_email_*",
           "comment_author_url_*",
           "wordpress_*",
-          "wordpress_logged_in_*",
-          "wordpress_sec_*",
-          "wordpress_test_cookie",
-          "wp-settings-*",
-          "wp-resetpass-*",
-          "wp-saving-post",
-          "wp-postpass_*",
-          "wp-wpml_*"
+          "wp-*"
         ]
       }
     }


### PR DESCRIPTION
# Summary | Résumé

Follow-up to #256 CloudFront has a maximum of 10 cookie entries per allow-list. To account for this, just using broader wildcards.
