### PR TITLE
Update match statement to CONTAINS for wp-json urls as well

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -102,7 +102,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                 field_to_match {
                   uri_path {}
                 }
-                positional_constraint = "STARTS_WITH"
+                positional_constraint = "CONTAINS"
                 search_string         = "/wp-json"
                 text_transformation {
                   type     = "NONE"
@@ -166,7 +166,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                 field_to_match {
                   uri_path {}
                 }
-                positional_constraint = "STARTS_WITH"
+                positional_constraint = "CONTAINS"
                 search_string         = "/wp-json"
                 text_transformation {
                   type     = "NONE"


### PR DESCRIPTION
# Summary | Résumé

Follow up to #256 where we changed the match statement on wp-admin urls to CONTAINS to catch sub sites. This also applies to wp-json prefixed urls.
