### PR TITLE
Update change sites label to search for strings that contain ###

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
@@ -24,7 +24,7 @@ class SitesToCollections
             return $translation;
         }
 
-        if (str_contains($translation, '###')) { 
+        if (str_contains($translation, '###')) {
             return $translation;
         }
 

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
@@ -24,7 +24,7 @@ class SitesToCollections
             return $translation;
         }
 
-        if ($text === "###SITENAME###") {
+        if (str_contains($translation, '###')) { 
             return $translation;
         }
 


### PR DESCRIPTION
Closes: https://github.com/cds-snc/gc-articles-issues/issues/10

Updating `changeSitesLabel` to use string contains 

The issue with the previous PR was the string being passed in != `the text` because the string contains a sentence vs a word. 

```... This notice confirms that your password was changed on ###SITENAME### more text ...```


Ref: https://github.com/cds-snc/gc-articles/pull/216
Ref: https://github.com/cds-snc/gc-articles/pull/61

Note: Ultimately we need to find a more efficient way to fix these translations but this will fix the current implementation

### Testing 

> Ensure you have your Notify API key etc... setup i.e. you are receiving WP emails

On the current `main` branch 

1) On your local installation edit a user 
```
http://localhost/wp-admin/user-edit.php?user_id=YOUR_USER_ID
```


2) Click on the `reset password` button --- no further action needed after the click
<img width="500" alt="Screen Shot 2021-11-17 at 8 21 44 AM" src="https://user-images.githubusercontent.com/62242/142208818-0afd6195-562e-4d41-819c-d721afcc8982.png">

3)  Click `update user`
<img width="500" alt="Screen Shot 2021-11-17 at 8 22 12 AM" src="https://user-images.githubusercontent.com/62242/142208915-18135d31-8556-4bac-a9df-c65abfe903b6.png">

4) Wait for the email from Notify email 
<img width="500" alt="Screen Shot 2021-11-17 at 8 25 47 AM" src="https://user-images.githubusercontent.com/62242/142209323-cf725601-bb1c-467e-bc7f-c2320d3db8d0.png">

Not the string replacement is failing.

<hr>

Switch to the `chore/10` branch

... repeat the steps above and note the string now gets replaced.







