### PR TITLE
Remove the SEO roles

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,16 +8,16 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.0.15', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.0.16', function () {
             if (is_blog_installed()) {
-                remove_role('editor');
-                remove_role('author');
-                remove_role('contributor');
-                remove_role('subscriber');
-                remove_role('gceditor');
-                remove_role('gcadmin');
-                // the ircc role should be removed in the next version update (leaving to cleanup current db)
-                remove_role('ircc');
+                $wp_roles = wp_roles();
+                $allRoles = array_keys($wp_roles->roles); // array_keys returns only the slug
+
+                // remove ALL roles, not just ones we know about
+                foreach ($allRoles as $role) {
+                    remove_role($role);
+                }
+
                 $this->cleanupRoles('gceditor');
                 $this->cleanupRoles('administrator');
 
@@ -25,6 +25,15 @@ class Roles
                 update_network_option(null, 'add_new_users', 1);
             }
         });
+
+        add_action('wpseo_activate', [$this, 'removeSEORoles'], 99);
+    }
+
+    public function removeSEORoles()
+    {
+        /* Installed by Yoast when plugin is activated */
+        remove_role('wpseo_manager');
+        remove_role('wpseo_editor');
     }
 
     protected function cleanupRoles($role)


### PR DESCRIPTION
# Summary

When Yoast is activated, [it adds 2 new roles to the site](https://github.com/Yoast/wordpress-seo/blob/0742e9b6ba4c0d6ae9d65223267a106b92a6a4a1/admin/roles/class-register-roles.php#L27): `wpseo_manager`, and `wpseo_editor`. We don't care about these roles at all, so we want to remove them.

Our current way of removing default roles assumes we know what they all are, and that they are set up _one_ time. It doesn't account for plugins activating/re-activating themselves and their new roles back.

This PR makes 2 changes:

1. Loop through roles to remove them in the `Roles.php` __construct() method. This means we don't have to know in advance all the roles that may or may not exist.
2. Adds a hook for removing Yoast roles when the plugin is activated.

Resolves https://github.com/cds-snc/gc-articles-issues/issues/86

## How to test

You can see a list of user roles by trying to add a new user and checking the drop-down menu. Deactivate and reactivate Yoast, and the "SEO"-named roles shouldn't show up. 