### PR TITLE
Add "unique" param to endpoint

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Notify/NotifyTemplateSender.php
@@ -48,7 +48,7 @@ class NotifyTemplateSender
 
             $response = $client->request(
                 'GET',
-                $endpoint . '/lists/' . $service_id . '/subscriber-count'
+                $endpoint . '/lists/' . $service_id . '/subscriber-count?unique=1'
             );
 
             return new WP_REST_Response(json_decode($response->getBody()->getContents()));


### PR DESCRIPTION
This PR aligns Notify send counts with subscriber list counts

See:
Closes https://github.com/cds-snc/gc-articles-issues/issues/100

Updated Endpoint
ref: https://github.com/cds-snc/list-manager/pull/100

## Testing 

Given the same Service ID is being used on staging you can compare staging vs local for the "GC Articles Updates" list.  The count should be lower when using this branch locally.

