### PR TITLE
Re-add the "Network" admin menu

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/SitesToCollections.php
@@ -33,6 +33,10 @@ class SitesToCollections
 
     public function changeSitesLabelAdminBar(): void
     {
+        if (is_super_admin()) {
+            return;
+        }
+
         // remove "My Sites"
         global $wp_admin_bar;
         $wp_admin_bar->remove_menu('my-sites');


### PR DESCRIPTION
# Summary 

I don't know why it's missing but I am pretty sure we want it back. Adds back the "My Collections" (ie, "my sites") menu into the top menu bar for superadmins.

Note that if you're a regular GC Admin, you can be signed up to multiple sites, but you don't see the "My Collections" option in the top menu. This means we will eventually want a way of routing people between the sites they are a part of, but for now we can re-add this option without other roles being able to see it.

## Screenshot

| before | after |
|--------|-------|
|  <img width="675" alt="Screen Shot 2021-11-17 at 12 13 54" src="https://user-images.githubusercontent.com/2454380/142249102-e69fe7ef-aa9a-47a9-9c0d-eca71edf964a.png">    |   <img width="675" alt="Screen Shot 2021-11-17 at 12 13 26" src="https://user-images.githubusercontent.com/2454380/142249095-d977a61d-46bd-4136-a14e-a5a54f605e67.png">  |

