### PR TITLE
Allow Referer header for WPML

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -30,7 +30,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host", "Options"]
+      headers      = ["Host", "Options", "Referer"]
       cookies {
         forward = "whitelist"
         whitelisted_names = [


### PR DESCRIPTION
# Summary | Résumé

This fixes the issue where creating a new translation for a page or article would not create the association between the translated item and original. This was only happening in our Staging environment, so the assumption was that this was due to the infra/environment.

Turns out, WPML requires the REFERER header to be present and CloudFront was blocking it by default. This PR enables that header.

I am not sure if this will affect our caching since this is applied as a default rule on the entire site. I attempted to add this to just the wp-admin path to apply it more narrowly, but that didn't work. It's possible we could narrow this through further investigation.