### PR TITLE
Rough in header and footer menus

### DIFF
--- a/wordpress/wp-content/themes/cds-default/footer.php
+++ b/wordpress/wp-content/themes/cds-default/footer.php
@@ -4,4 +4,16 @@ declare(strict_types=1);
 
 $lang = get_active_language();
 echo '<div style="display:none;" id="version" style="margin-top:30px;">' . _S_VERSION . '</div>';
-require_once 'footer_' . $lang . '.php';
+?>
+
+<?php
+$footerMenu = wp_nav_menu(["menu" => "footer", "echo" => false]);
+if ($footerMenu) {
+    echo $footerMenu;
+} else {
+    require_once 'footer_' . $lang . '.php';
+}
+
+
+
+

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -75,7 +75,9 @@ if (!function_exists('cds_setup')) {
 
         // This theme uses wp_nav_menu() in one location.
         register_nav_menus([
-            'menu-1' => esc_html__('Primary', 'cds-snc'),
+            'header' => esc_html__('Primary', 'cds-snc'),
+            'side-left' => esc_html__('Secondary', 'cds-snc'),
+            'footer' => esc_html__('Footer', 'cds-snc'),
         ]);
 
         /*

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -95,15 +95,20 @@ declare(strict_types=1);
 
     </div>
   </div>
+
+  <?php $headerMenu = wp_nav_menu(["menu" => "header", "echo" => false]); ?>
+  <?php
+    if ($headerMenu) :
+        echo $headerMenu;
+    else :
+        ?>
   <nav class="gcweb-menu" typeof="SiteNavigationElement">
     <div class="container">
       <h2 class="wb-inv"><?php _e('Menu', 'cds-snc'); ?></h2>
-      <button type="button" aria-haspopup="true" aria-expanded="false"><span
-          class="wb-inv"><?php _e(
-              'Main',
-              'cds-snc',
-          ); ?> </span><?php _e('Menu', 'cds-snc'); ?> <span
-          class="expicon glyphicon glyphicon-chevron-down"></span></button>
+      <button type="button" aria-haspopup="true" aria-expanded="false">
+        <span class="wb-inv"><?php _e('Main', 'cds-snc'); ?> </span>
+          <?php _e('Menu', 'cds-snc'); ?> 
+          <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
       <ul role="menu" aria-orientation="vertical">
           <?php // pulls in menu items from Canada.ca endpoint
             echo file_get_contents(
@@ -114,5 +119,6 @@ declare(strict_types=1);
       </ul>
     </div>
   </nav>
-    <?php echo cds_breadcrumb(); ?>
+    <?php endif; ?>
+  <?php echo cds_breadcrumb(); ?>
 </header>


### PR DESCRIPTION
Registers - header, footer and side nav area

Checks to see if header and footer menus have content --- if not they will use the current Canada.ca defaults.

cc: @pcraig3 

## Testing

Add a menu and assign it to the header or footer location - Appearance -> Menus



Note:
I have left out the side nav which will need to be added to index.php, page.php etc...
I've also left the menu output fully unstyled i.e. this is prepping for the next sprint