### PR TITLE
Force "all" for category link

### DIFF
--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Wpml.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Wpml.php
@@ -12,12 +12,21 @@ class Wpml
     public static function setup()
     {
         add_action('admin_footer', function () {
+            
+            // update category url in side nav to default to "all"
+            echo "<script>
+                    jQuery(jQuery('a[href*=\"edit-tags.php?taxonomy=category\"]'))
+                    .attr('href', 'edit-tags.php?taxonomy=category&lang=all' )
+                  </script>";
+            
             if (!isset($_GET["taxonomy"])) {
                 return;
             }
+            
             echo '<script>jQuery("#icl_subsubsub").clone().removeAttr("id").prependTo(".search-form");</script>';
             echo '<style>#icl_subsubsub{display:none !important;}</style>';
         });
+
         /**
          * We need to set this option to an empty array. This is supposed to be an array of directories that WPML will
          * scan looking for language switchers, but it has problems with s3: prefixed URLs. We don't use these

--- a/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Wpml.php
+++ b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Cleanup/Wpml.php
@@ -12,17 +12,17 @@ class Wpml
     public static function setup()
     {
         add_action('admin_footer', function () {
-            
+
             // update category url in side nav to default to "all"
             echo "<script>
                     jQuery(jQuery('a[href*=\"edit-tags.php?taxonomy=category\"]'))
                     .attr('href', 'edit-tags.php?taxonomy=category&lang=all' )
                   </script>";
-            
+
             if (!isset($_GET["taxonomy"])) {
                 return;
             }
-            
+
             echo '<script>jQuery("#icl_subsubsub").clone().removeAttr("id").prependTo(".search-form");</script>';
             echo '<style>#icl_subsubsub{display:none !important;}</style>';
         });


### PR DESCRIPTION
Forces "all" languages url for category link click
https://github.com/cds-snc/gc-articles-issues/issues/43

Note: I tried to do this using PHP but looks like WPML does a redirect to EN to get around that using jQuery


## Testing
- Click categories from the left nav of the WP Admin --- it should default to "all" languages.