### PR TITLE
[Hotfix] Create empty $footerMenu variable

### DIFF
--- a/wordpress/wp-content/themes/cds-default/footer.php
+++ b/wordpress/wp-content/themes/cds-default/footer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 $lang = get_active_language();
 $footerText = require_once('footer_text_' . $lang . '.php');
+$footerMenu = '';
 
 ?>
 


### PR DESCRIPTION
Previously, this variable was only created / assigned to when the "if" statement wrapping it ([line 31](https://github.com/cds-snc/gc-articles/blob/7bf22dd3bce4a8007251914b083e2537890066d1/wordpress/wp-content/themes/cds-default/footer.php#L31)) was true. Then on [line 34](https://github.com/cds-snc/gc-articles/blob/7bf22dd3bce4a8007251914b083e2537890066d1/wordpress/wp-content/themes/cds-default/footer.php#L34), it was referenced as though it already existed, so you would get a console warning about it.

To test this: you should not have a `footer` menu location in your theme.