### PR TITLE
Clean up the side menu a bit

### DIFF
--- a/cypress/integration/menu.spec.js
+++ b/cypress/integration/menu.spec.js
@@ -1,0 +1,62 @@
+import { addPage } from "./util";
+
+/// <reference types="Cypress" />
+
+
+describe('Add Side Nav', () => {
+    before(() => {
+        cy.exec('npm run wp-env:test:setup')
+      });
+
+    it('GC Admin can add a child page', async () => {
+        const parentPage = {
+            title: "Parent page",
+            text: "Hello from GC Admin"
+        }
+
+        const childPage = {
+            title: "Child page",
+            text: "Hello again from GC Admin"
+        }
+
+        cy.addUser('gcadmin', 'secret', 'administrator');
+        cy.login('gcadmin', 'secret');
+        addPage(parentPage.text, parentPage.title);
+
+        // Publish the page (instead of preview it)
+        cy.get('button.editor-post-publish-panel__toggle').contains('Publish').click();
+        cy.get('.editor-post-publish-panel button.editor-post-publish-button__button').contains('Publish').click();
+        cy.get(".post-publish-panel__postpublish-header").contains(`${parentPage.title} is now live.`);
+
+        // Add 2nd page
+        addPage(childPage.text, childPage.title);
+        
+        // Open up the settings sidebar and select the parent page
+        cy.get('button[aria-label="Settings"]').click();
+        cy.get('button[data-label="Page"]').click();
+        cy.get('button.components-panel__body-toggle').contains('Page Attributes').click();
+        cy.get('label').contains('Parent Page:').invoke('attr', 'for').then(id => {
+            cy.get(`#${id}`).click();
+            cy.wait(1000);
+            cy.get('li[role="option"]').contains(parentPage.title).click();
+        });
+
+        // Publish the page (instead of preview it)
+        cy.get('button.editor-post-publish-panel__toggle').contains('Publish').click();
+        cy.get('.editor-post-publish-panel button.editor-post-publish-button__button').contains('Publish').click();
+        cy.get(".post-publish-panel__postpublish-header").contains(`${childPage.title} is now live.`);
+
+        // Visit the newly published page
+        cy.get('.post-publish-panel__postpublish-buttons a').contains('View Page').invoke('attr', 'href').then(href => {
+            cy.visit(href);
+        });
+
+        // Check for H1 and paragraph on child page
+        cy.get("h1").contains(childPage.title);
+        cy.get(".entry-content p").contains(childPage.text);
+
+        // Check for side nav
+        cy.get("#subpages .nav--about__desktop__title").contains(parentPage.title);
+        cy.get("#subpages .nav--about li").contains(childPage.title);
+    });
+});

--- a/cypress/integration/util.js
+++ b/cypress/integration/util.js
@@ -5,3 +5,13 @@ export const addArticle = (text) => {
     cy.get("body").type('{cmd}s');
     cy.wait(1000);
 }
+
+export const addPage = (text, title = "Title", childPage) => {
+    cy.visit("/wp-admin/post-new.php?post_type=page");
+    cy.setPostContent(text);
+    cy.wait(1000);
+    cy.get("textarea#post-title-0").type(title);
+    cy.wait(1000);
+    cy.get("body").type('{cmd}s');
+    cy.wait(1000);
+}

--- a/wordpress/wp-content/themes/cds-default/footer.php
+++ b/wordpress/wp-content/themes/cds-default/footer.php
@@ -14,7 +14,7 @@ $footerMenu = '';
         <nav class="container wb-navcurr">
             <h2 class="wb-inv"><?php echo $footerText['aboutGovernmentTitle']; ?></h2>
             <ul class="list-unstyled colcount-sm-2 colcount-md-3">
-                <?php echo print_menu_links($footerText['aboutGovernment']); ?>
+                <?php echo print_footer_links($footerText['aboutGovernment']); ?>
             </ul>
         </nav>
     </div>
@@ -34,7 +34,7 @@ $footerMenu = '';
 
                     $links = $footerMenu ? wp_get_nav_menu_items($footerMenu->name) : $footerText['aboutThisSite'];
 
-                    echo print_menu_links($links);
+                    echo print_footer_links($links);
                     ?>
                     </ul>
                 </nav>

--- a/wordpress/wp-content/themes/cds-default/footer.php
+++ b/wordpress/wp-content/themes/cds-default/footer.php
@@ -14,7 +14,7 @@ $footerMenu = '';
         <nav class="container wb-navcurr">
             <h2 class="wb-inv"><?php echo $footerText['aboutGovernmentTitle']; ?></h2>
             <ul class="list-unstyled colcount-sm-2 colcount-md-3">
-                <?php echo print_footer_links($footerText['aboutGovernment']); ?>
+                <?php echo get_footer_links($footerText['aboutGovernment']); ?>
             </ul>
         </nav>
     </div>
@@ -34,7 +34,7 @@ $footerMenu = '';
 
                     $links = $footerMenu ? wp_get_nav_menu_items($footerMenu->name) : $footerText['aboutThisSite'];
 
-                    echo print_footer_links($links);
+                    echo get_footer_links($links);
                     ?>
                     </ul>
                 </nav>

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -179,25 +179,6 @@ add_filter('body_class', function (array $classes) {
     return $classes;
 });
 
-/**
- * Function to print links for a wordpress menu. Used to create the Canada.ca footer.
- */
-function print_menu_links(array $links): string
-{
-    $string = '';
-
-    foreach ($links as $link) {
-        $link = (object)$link; // cast to object so that we can use arrow notation
-        $string .= sprintf(
-            "<li><a href='%s'>%s</a></li>",
-            esc_url($link->url),
-            esc_html($link->title)
-        );
-    }
-
-    return $string;
-}
-
 add_action('init', function () {
     remove_theme_support('core-block-patterns');
     unregister_block_pattern_category('buttons');
@@ -265,4 +246,3 @@ if (! function_exists('cds_get_block_pattern_markup')) :
         return ob_get_clean();
     }
 endif;
-//

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -292,7 +292,7 @@ function print_footer_links(array $links): string
         $link = (object)$link; // cast to object so that we can use arrow notation
         $string .= sprintf(
             "<li><a href='%s'>%s</a></li>",
-            clean_url($link->url),
+            esc_url($link->url),
             esc_html($link->title)
         );
     }

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -299,3 +299,60 @@ function print_footer_links(array $links): string
 
     return $string;
 }
+
+/**
+ * Function that will return a HTML for a side nav if the current page meets the following conditions:
+ *   - It is a "page"
+ *   - It has 'child' pages OR it has a 'parent' page
+ *
+ * If the current page doesn't have a side nav, return an empty string
+ */
+function getSideNav(): string
+{
+    global $post;
+    $parent_page_is_current_page = '';
+
+    $parents = get_post_ancestors($post->post_id);
+    krsort($parents);
+    $parents = array_merge(array(), $parents);
+
+    if (is_home() || is_single()) {
+        $id = get_option('page_for_posts');
+        $parent = get_post_ancestors($id);
+        $id = $parent[0];
+    } elseif ($parents) {
+        $id = $parents[0];
+    } else {
+        $id = $post->ID;
+        $parent_page_is_current_page = "current_page_item";
+    }
+
+    $children = wp_list_pages('title_li=&child_of=' . $id . '&echo=0');
+    $out = '';
+
+    if ($children) {
+        ob_start();
+        ?>
+            <div id="subpages" class="nav--about__desktop">
+                <div class="nav--about__desktop__title <?php echo $parent_page_is_current_page; ?>"><?php echo get_the_title($id); ?></div>
+                <nav class="nav--about" aria-label="Table of contents: <?php echo get_the_title($id); ?>">
+                    <ul>
+                        <?php echo $children; ?>
+                    </ul>
+                </nav>
+            </div><!-- end of .nav--about__desktop -->
+            <details class="nav--about__mobile">
+                <summary><div><?php echo get_the_title($id); ?></div></summary>
+                <nav class="nav--about" aria-label="Table of contents: <?php echo get_the_title($id); ?>">
+                    <ul>
+                        <?php echo $children; ?>
+                    </ul>
+                </nav>
+            </details>
+        <?php
+        $out = ob_get_contents();
+        ob_end_clean();
+    }
+
+    return $out;
+}

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -284,7 +284,7 @@ function language_switcher(): string
 /**
  * Function to print links for a wordpress menu. Used to create the Canada.ca footer.
  */
-function print_footer_links(array $links): string
+function get_footer_links(array $links): string
 {
     $string = '';
 
@@ -307,7 +307,7 @@ function print_footer_links(array $links): string
  *
  * If the current page doesn't have a side nav, return an empty string
  */
-function getSideNav(): string
+function get_side_nav(): string
 {
     global $post;
     $parent_page_is_current_page = '';

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -280,3 +280,22 @@ function language_switcher(): string
     error_log("language_switcher: not found");
     return "";
 }
+
+/**
+ * Function to print links for a wordpress menu. Used to create the Canada.ca footer.
+ */
+function print_footer_links(array $links): string
+{
+    $string = '';
+
+    foreach ($links as $link) {
+        $link = (object)$link; // cast to object so that we can use arrow notation
+        $string .= sprintf(
+            "<li><a href='%s'>%s</a></li>",
+            clean_url($link->url),
+            esc_html($link->title)
+        );
+    }
+
+    return $string;
+}

--- a/wordpress/wp-content/themes/cds-default/page.php
+++ b/wordpress/wp-content/themes/cds-default/page.php
@@ -15,7 +15,7 @@
 
 declare(strict_types=1);
 
-$side_nav = getSideNav();
+$side_nav = get_side_nav();
 $has_side_nav = !empty($side_nav) ? true : false;
 
 get_header();

--- a/wordpress/wp-content/themes/cds-default/page.php
+++ b/wordpress/wp-content/themes/cds-default/page.php
@@ -15,54 +15,8 @@
 
 declare(strict_types=1);
 
-function wpse33151_getSubpages()
-{
-    global $post;
-    $parent_page_is_current_page = '';
-
-    $parents = get_post_ancestors($post->post_id);
-    krsort($parents);
-    $parents = array_merge(array(), $parents);
-
-    if (is_home() || is_single()) {
-        $id = get_option('page_for_posts');
-        $parent = get_post_ancestors($id);
-        $id = $parent[0];
-    } elseif ($parents) {
-        $id = $parents[0];
-    } else {
-        $id = $post->ID;
-        $parent_page_is_current_page = "current_page_item";
-    }
-
-    $children = wp_list_pages('title_li=&child_of=' . $id . '&echo=0');
-
-    $out = null;
-
-    if ($children) {
-        $out = '<div id="subpages" class="nav--about__desktop">';
-        $out .= '<div class="nav--about__desktop__title ' . $parent_page_is_current_page . '">' . get_the_title($id) . '</div>';
-        $out .= '<nav class="nav--about" aria-label="Table of contents: ' . get_the_title($id) . '">';
-        $out .= '<ul>';
-        $out .= $children;
-        $out .= '</ul>';
-        $out .= '</nav>';
-        $out .= '</div>';
-        $out .= '<details class="nav--about__mobile">';
-        $out .= '<summary><div>' . get_the_title($id) . '</div></summary>';
-        $out .= '<nav class="nav--about" aria-label="Table of contents: ' . get_the_title($id) . '">';
-        $out .= '<ul>';
-        $out .= $children;
-        $out .= '</ul>';
-        $out .= '</nav>';
-        $out .= '</details>';
-    }
-
-    return $out;
-}
-
-$side_nav = wpse33151_getSubpages();
-$has_side_nav = $side_nav ? true : false;
+$side_nav = getSideNav();
+$has_side_nav = !empty($side_nav) ? true : false;
 
 get_header();
 ?>


### PR DESCRIPTION
# Summary | Résumé

This PR is about refactoring the codebase so that the "menu building" functions can be centralized in the "template-functions" file rather than just cluttering up the page templates.

- Move footer links function into `template-functions`
- Move side nav function into `template-functions`. User `ob_start` so that we can nest the HTML more easily (hard to see when it's a big string)
- Swap out use of `clean_url` (deprecated) for `esc_url` (not deprecated)
- Create cypress function to add 2 pages, assign the second one to be the child of the first, and then check there is a menu.

No functional / design changes are introduced by this PR.

If the cypress test is too much, I can put it on ice. It was a little tricky to get working, so it might turn out to be brittle in the future.
