### PR TITLE
Allow GC Admins and Editors to edit Menus 

### DIFF
--- a/cypress/integration/user.roles.spec.js
+++ b/cypress/integration/user.roles.spec.js
@@ -18,6 +18,7 @@ const allowedPages200 = [
 // defaults for "GC Editor"
 const blockedPages403 = [
     'themes.php',
+    'customize.php',
     'options-general.php',
     'admin.php?page=cds_notify_send'
 ];
@@ -47,7 +48,7 @@ describe('User - GC Editor', () => {
         cy.login('gceditor', 'secret');
 
         checkPages(allowedPages200, 200);
-        checkPages([...blockedPages403, 'users.php', 'customize.php'], 403);
+        checkPages([...blockedPages403, 'users.php'], 403);
         checkPages(blockedPages500, 500);
     });
 

--- a/cypress/integration/user.roles.spec.js
+++ b/cypress/integration/user.roles.spec.js
@@ -10,7 +10,8 @@ const allowedPages200 = [
     'post-new.php',
     'edit.php?post_type=page',
     'post-new.php?post_type=page',
-    'upload.php'
+    'upload.php',
+    'nav-menus.php'
 ];
 
 // user should not be able to access these pages
@@ -46,7 +47,7 @@ describe('User - GC Editor', () => {
         cy.login('gceditor', 'secret');
 
         checkPages(allowedPages200, 200);
-        checkPages([...blockedPages403, 'users.php'], 403);
+        checkPages([...blockedPages403, 'users.php', 'customize.php'], 403);
         checkPages(blockedPages500, 500);
     });
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -10,6 +10,11 @@ class Menus
     {
         add_action('admin_menu', [$this, 'removeMenuPages'], 2147483647);
         add_filter('wp_mail_smtp_admin_adminbarmenu_has_access', '__return_false');
+
+        // add "Menus" link for GC Admins and GC Editors
+        add_action('admin_menu', [$this, 'addMenusLinkToAdmin'], 11);
+        // BlockGC Admins and GC Editors from seeing "themes" or "customize" pages
+        add_action('admin_init', [$this, 'blockAppearancePages']);
     }
 
     public function removeMenuPages(): void
@@ -42,6 +47,44 @@ class Menus
         }
 
         $this->hideWPMailSmtpMenus();
+    }
+
+    public function blockAppearancePages(): void
+    {
+        if (is_super_admin()) {
+            return;
+        }
+
+        $appearanceSubPages = ["themes.php", "customize.php"];
+        $currentUrlPath = $_SERVER['REQUEST_URI'];
+
+        foreach ($appearanceSubPages as $subpage) {
+            if (strpos($currentUrlPath, $subpage) !== false) { // If subpage URL appears in current URL path
+                wp_die(
+                    __("Sorry, you are not allowed to access this page."),
+                    403 // status code
+                );
+            }
+        }
+    }
+
+    public function addMenusLinkToAdmin(): void
+    {
+        // Super Admins can see the "Appearance" menu, so they don't need this.
+        if (is_super_admin()) {
+            return;
+        }
+
+        $menusTitle = __('Menus');
+        add_menu_page(
+            $menusTitle,
+            $menusTitle,
+            'edit_theme_options',
+            'nav-menus.php',
+            '',
+            'dashicons-editor-ul',
+            60
+        );
     }
 
     public function hideWPMailSmtpMenus(): void

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CDS\Modules\Cleanup;
 
+use CDS\Utils;
+
 class Menus
 {
     public function __construct()
@@ -51,7 +53,7 @@ class Menus
 
     public function blockAppearancePages(): void
     {
-        if (is_super_admin()) {
+        if (is_super_admin() && !Utils::isWPEnvAdmin()) {
             return;
         }
 
@@ -71,7 +73,7 @@ class Menus
     public function addMenusLinkToAdmin(): void
     {
         // Super Admins can see the "Appearance" menu, so they don't need this.
-        if (is_super_admin()) {
+        if (is_super_admin() && !Utils::isWPEnvAdmin()) {
             return;
         }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,7 +8,7 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.1.1', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.1.2', function () {
             if (is_blog_installed()) {
                 $wp_roles = wp_roles();
                 $allRoles = array_keys($wp_roles->roles); // array_keys returns only the slug
@@ -77,7 +77,8 @@ class Roles
                 'delete_pages' => 1,
                 'delete_others_pages' => 1,
                 'delete_published_pages' => 1,
-                'upload_files' => 1
+                'upload_files' => 1,
+                'edit_theme_options' => 1 // allows editing the "menu" options
             ],
             'editor' => [
                 'moderate_comments' => 1,
@@ -163,7 +164,8 @@ class Roles
                 'delete_pages' => 1,
                 'delete_others_pages' => 1,
                 'delete_published_pages' => 1,
-                'upload_files' => 1
+                'upload_files' => 1,
+                'edit_theme_options' => 1 // allows editing the "menu" options
             ],
             'display_name' => [
                 'administrator' => 'GC Admin',

--- a/wordpress/wp-content/plugins/cds-base/classes/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Utils.php
@@ -44,4 +44,19 @@ class Utils
         }
         return false;
     }
+
+    public static function isWPEnvAdmin(): bool
+    {
+        $current_user = wp_get_current_user();
+
+        if ($current_user) {
+            $current_username = $current_user->user_login;
+
+            if ($current_username === 'gcadmin') {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -194,10 +194,10 @@ nav.nav--about li a:focus {
 
 /* Side nav layout between 600px and 768px */
 @media screen and (min-width: 600px) and (max-width: 768px) {
-    .wp-block-column:not(:only-child).page__side-nav {
+    .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__side-nav {
         flex: 3 !important;
     }
-    .wp-block-column:not(:only-child).page__content {
+    .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__content {
         flex: 5 !important;
     }
 }


### PR DESCRIPTION
# Summary

The wordpress capability that governs this is called [`edit_theme_options`](https://wordpress.org/support/article/roles-and-capabilities/#edit_theme_options), but it also allows users to edit the theme itself and use that "Customize" menu, which we don't want to allow.

Therefore, there are a few things in this commit:
- Add "edit_theme_options" capabilites for GC Admin and GC Editor
- Add "Menus" link in admin menu ("Appearance" remains hidden)
- Explicitly return `wp_die` error if a non-superadmin is trying to edit themes or reach the "customize" menu

## Screenshots

### Current Admin menu

| as a GC Editor | As a GC Admin |
|---------------------|----------------------------|
|        <img width="161" alt="Screen Shot 2021-11-25 at 15 32 45" src="https://user-images.githubusercontent.com/2454380/143497955-35c270bc-4e0e-4626-be04-53f1a730098e.png">        |        <img width="161" alt="Screen Shot 2021-11-25 at 15 32 23" src="https://user-images.githubusercontent.com/2454380/143497953-3bfc0e0d-370e-4120-a104-3a0ee54c528f.png">       |


### Trying to visit a disallowed page

Visiting: http://localhost/wp-admin/themes.php

| Visiting as GC Editor | 
|---------------------|
|  returns this error (the same as they currently see)                  |   
|     <img width="1295" alt="Screen Shot 2021-11-25 at 15 36 29" src="https://user-images.githubusercontent.com/2454380/143497958-0fb8329d-1f15-4a69-8cc5-1c2cdce10a90.png">   |  


