### PR TITLE
Disable auto updates of WPML, Themes, and Plugins

### DIFF
--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -138,7 +138,7 @@ define('S3_UPLOADS_SECRET', getenv_docker('S3_UPLOADS_SECRET', ''));
 define('S3_UPLOADS_OBJECT_ACL', 'private');
 
 define('OTGS_DISABLE_AUTO_UPDATES', true);
-define( 'WP_AUTO_UPDATE_CORE', false );
+define('WP_AUTO_UPDATE_CORE', false);
 
 /* That's all, stop editing! Happy publishing. */
 

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -136,6 +136,10 @@ define('S3_UPLOADS_REGION', getenv_docker('S3_UPLOADS_REGION', 'ca-central-1'));
 define('S3_UPLOADS_KEY', getenv_docker('S3_UPLOADS_KEY', ''));
 define('S3_UPLOADS_SECRET', getenv_docker('S3_UPLOADS_SECRET', ''));
 define('S3_UPLOADS_OBJECT_ACL', 'private');
+
+define('OTGS_DISABLE_AUTO_UPDATES', true);
+define( 'WP_AUTO_UPDATE_CORE', false );
+
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -246,3 +246,6 @@ if (! function_exists('cds_get_block_pattern_markup')) :
         return ob_get_clean();
     }
 endif;
+
+add_filter( 'auto_update_plugin', '__return_false' );
+add_filter( 'auto_update_theme', '__return_false' );

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -247,5 +247,5 @@ if (! function_exists('cds_get_block_pattern_markup')) :
     }
 endif;
 
-add_filter( 'auto_update_plugin', '__return_false' );
-add_filter( 'auto_update_theme', '__return_false' );
+add_filter('auto_update_plugin', '__return_false');
+add_filter('auto_update_theme', '__return_false');


### PR DESCRIPTION
# Summary | Résumé

Will get rid of this nag:
![image](https://user-images.githubusercontent.com/1187115/143606756-2d82ca01-f96d-4c73-bc45-3d16332afb66.png)

...and ensure our plugins and wordpress core don't auto-update themselves.