### PR TITLE
Fix side nav styles with really specific CSS

### DIFF
--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -192,24 +192,35 @@ nav.nav--about li a:focus {
     }
 }
 
-/* Side nav layout */
-@media screen and (min-width: 768px) {
-    .page__side-nav {
-        flex-basis: 35%;
+/* Side nav layout between 600px and 768px */
+@media screen and (min-width: 600px) and (max-width: 768px) {
+    .wp-block-column:not(:only-child).page__side-nav {
+        flex: 3 !important;
     }
-    .page__content {
-        flex-basis: 65%;
+    .wp-block-column:not(:only-child).page__content {
+        flex: 5 !important;
     }
 }
 
-@media screen and (min-width: 1200px) {
-    .page__side-nav {
-        flex-basis: 25%;
+/* Side nav layout over 768px */
+@media screen and (min-width: 768px) {
+    .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__side-nav {
+        flex: 3.5;
     }
-    .page__content {
-        flex-basis: 75%;
+    .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__content {
+        flex: 6.5;
     }
 }
+/* Side nav layout over 1200px */
+@media screen and (min-width: 1200px) {
+    .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__side-nav {
+        flex: 1;
+    }
+    .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__content {
+        flex: 3;
+    }
+}
+
 
 .has-black-color {
     color: #000;


### PR DESCRIPTION
# Summary | Résumé

It looks like the CSS file for gutenberg block library (`block-library/style.css?ver=11.9.1`) got updated, so it started forcing columns to be 50% width even for our side nav, which is using the same classes as the default wordpress column classes. The solution? Make our CSS more specific and now it works. This is the kind of thing that would look a lot better in SCSS but w/e, we can live with it.

### FAQ

> Why are we using wordpress classes if they conflict with our own CSS?

Basically, it's because I want to keep the markup as similar as possible to what you would get using Gutenberg. It's kind of a weak rationale, but there it is.

## Screenshots 


| before | after |
|--------|-------|
|   <img width="1400" alt="Screen Shot 2021-11-26 at 13 25 20" src="https://user-images.githubusercontent.com/2454380/143619833-2055659a-de5b-4407-98a2-2c8a6669722a.png">   |  <img width="1399" alt="Screen Shot 2021-11-26 at 13 25 41" src="https://user-images.githubusercontent.com/2454380/143619835-83df2b33-e29c-4321-89a6-e5aa9931cc5d.png">   |


