### PR TITLE
Fix en_US 404

### DIFF
--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 ?>
 <!doctype html>
-<html <?php language_attributes(); ?>>
+<html lang="<?php echo get_active_language(); ?>">
 <head>
   <meta charset="<?php bloginfo('charset'); ?>">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Tracked down the code that sets the url path for i18n

<img width="1110" alt="Screen Shot 2021-11-26 at 2 22 14 PM" src="https://user-images.githubusercontent.com/62242/143623371-83644217-4bba-461e-bf37-6863b8e61a4c.png">

The code uses document.documentElement.lang 

Which was returning `en-US`

<img width="1144" alt="Screen Shot 2021-11-26 at 2 21 13 PM" src="https://user-images.githubusercontent.com/62242/143623355-9fe078cf-15fd-4554-b2bf-f23ccd37f2b7.png">

Canada.ca -- sets the val as `en`.

This PR updates the lang attribute and in turn fixes the request.
