### PR TITLE
Add check for $prev_post->ID

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -31,9 +31,9 @@ function cds_prev_next_links(): void
   <nav class="mrgn-tp-xl">
     <h2 class="wb-inv"> <?php _e('Document navigation', 'cds-snc'); ?> </h2>
     <ul class="pager">
-      <?php if ($prev_id) : ?>
+      <?php if ($next_id && $next_permalink) : ?>
       <li class="next">
-        <a id="<?php echo $prev_id ?>" href="<?php echo $next_permalink; ?>">
+        <a id="<?php echo $next_id ?>" href="<?php echo $next_permalink; ?>">
             <?php _e(
                 'Next blog post',
                 'cds-snc'
@@ -42,9 +42,9 @@ function cds_prev_next_links(): void
       </li>
       <?php endif; ?>
 
-      <?php if ($next_id) : ?>
+      <?php if ($prev_id && $prev_permalink) : ?>
       <li class="previous">
-        <a id="<?php echo $next_id ?>" href="<?php echo $prev_permalink; ?>"
+        <a id="<?php echo $prev_id ?>" href="<?php echo $prev_permalink; ?>"
            rel="prev">«&nbsp;<?php _e('Previous blog post', 'cds-snc'); ?></a>
       </li>
       <?php endif; ?>

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -12,11 +12,17 @@ use PHPHtmlParser\Dom;
 
 function cds_prev_next_links(): void
 {
+    $prev_id = false;
     $prev_post = get_previous_post();
-    $prev_id = $prev_post->ID;
-    $prev_permalink = get_permalink($prev_id);
-    $next_post = get_next_post();
+    
+    if ($prev_post && $prev_post->ID) {
+        $prev_id = $prev_post->ID;
+        $prev_permalink = get_permalink($prev_id);
+    }
+    
     $next_id = false;
+    $next_post = get_next_post();
+    
     if ($next_post && $next_post->ID) {
         $next_id = $next_post->ID;
         $next_permalink = get_permalink($next_id);

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -14,15 +14,15 @@ function cds_prev_next_links(): void
 {
     $prev_id = false;
     $prev_post = get_previous_post();
-    
+
     if ($prev_post && $prev_post->ID) {
         $prev_id = $prev_post->ID;
         $prev_permalink = get_permalink($prev_id);
     }
-    
+
     $next_id = false;
     $next_post = get_next_post();
-    
+
     if ($next_post && $next_post->ID) {
         $next_id = $next_post->ID;
         $next_permalink = get_permalink($next_id);

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -360,3 +360,7 @@ nav.nav--about li a:focus {
 .wp-block-button__link.has-red-background-color:hover, .wp-block-button__link.has-red-background-color:focus {
     background-color: #632226;
 }
+
+.pager .previous a::before{
+    content: "" !important;
+}


### PR DESCRIPTION
Fixes an error while trying to pull the ID off the previous post ... which may not exist. 

-- This is one of the fixes for https://github.com/cds-snc/gc-articles-issues/issues/128

<img width="1279" alt="Screen Shot 2021-11-29 at 9 23 21 AM" src="https://user-images.githubusercontent.com/62242/143885007-5825459b-352d-4600-adbf-48c20a280f39.png">


Fixes 2 x Arrow:
<img width="466" alt="Screen Shot 2021-11-29 at 10 31 29 AM" src="https://user-images.githubusercontent.com/62242/143896444-2921c183-53d4-4adf-a236-b3933db742bb.png">


