### PR TITLE
Drop-down + mobile top nav

### DIFF
--- a/wordpress/wp-content/themes/cds-default/footer.php
+++ b/wordpress/wp-content/themes/cds-default/footer.php
@@ -11,8 +11,8 @@ $footerMenu = '';
 <div style="display:none;" id="version" style="margin-top:30px;"><?php echo _S_VERSION; ?></div>
 <footer id="wb-info">
     <div class="landscape">
-        <nav class="container wb-navcurr">
-            <h2 class="wb-inv"><?php echo $footerText['aboutGovernmentTitle']; ?></h2>
+        <nav class="container wb-navcurr" aria-labelledby="footerNavAboutGovernment">
+            <h2 class="wb-inv" id="footerNavAboutGovernment"><?php echo $footerText['aboutGovernmentTitle']; ?></h2>
             <ul class="list-unstyled colcount-sm-2 colcount-md-3">
                 <?php echo get_footer_links($footerText['aboutGovernment']); ?>
             </ul>
@@ -21,8 +21,8 @@ $footerMenu = '';
     <div class="brand">
         <div class="container">
             <div class="row">
-                <nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-                    <h2 class="wb-inv"><?php echo $footerText['aboutThisSiteTitle']; ?></h2>
+                <nav class="col-md-9 col-lg-10 ftr-urlt-lnk" aria-labelledby="footerNavAbout">
+                    <h2 class="wb-inv" id="footerNavAbout"><?php echo $footerText['aboutThisSiteTitle']; ?></h2>
                     <ul>
                     <?php
                     $locations = get_nav_menu_locations();

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -100,16 +100,7 @@ declare(strict_types=1);
   </div>
 
   <?php
-    // Don't get the menu by name, but by theme location. Returns false if not found
-    $headerMenu = wp_nav_menu([
-      "theme_location" => "header",
-      "fallback_cb" => false,
-      "echo" => false,
-      "depth" => 1,
-      "menu_class" => "nav nav--primary container",
-      "container_class" => "nav--primary__container"
-    ]); ?>
-  <?php
+    $headerMenu = get_top_nav();
     if ($headerMenu) :
         echo $headerMenu;
     else :

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -400,8 +400,10 @@ function get_top_nav(): string
 
         // Insert aria-label for top nav (otherwise axe complains)
         $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
-        // // Insert aria-label for submenu
+        // Insert aria-label for submenu
         $dom->find('.sub-menu')->setAttribute('aria-label', $submenu);
+        // Insert aria-expanded for link with submenu
+        $dom->find('.menu-item-has-children')->setAttribute('aria-expanded', "false");
 
         return $dom->outerHTML;
     }

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -164,9 +164,9 @@ function cds_breadcrumb($sep = ''): string
         $html = $child->firstChild()->innerHtml;
         $parts = explode('|', $html);
 
-        $output = '<nav id="wb-bc" property="breadcrumb">';
+        $output = '<nav id="wb-bc" property="breadcrumb" aria-label="' .  __("Breadcrumbs") . '">';
         $output .= '<div class="container">';
-        $output .= '<h2><?php _e("You are here:"); ?></h2>';
+        $output .= '<h2>' . __("You are here:") . '</h2>';
         $output .= '<ol class="breadcrumb">';
         // note this will need to point to the correct language
         $output .= '<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>';
@@ -385,17 +385,20 @@ function get_top_nav(): string
     ]);
 
     if ($headerMenu) {
+        $topMenu = __('Top menu');
+        $submenu = __('submenu');
+
         // Insert a button (markup taken from bootstrap)
         // It seems like we can't append an element using the PHP HTML Parser https://stackoverflow.com/q/51466367
-        $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#menu-top-of-the-page" aria-controls="menu-top-of-the-page" aria-expanded="false" aria-label="Toggle navigation">Menu</button></div>', $headerMenu);
+        $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#menu-top-of-the-page" aria-controls="menu-top-of-the-page" aria-expanded="false">Menu</button></div>', $headerMenu);
 
         $dom = new Dom();
         $dom->loadStr($headerMenu);
 
         // Insert aria-label for top nav (otherwise axe complains)
-        $dom->find('.nav--primary__container')->setAttribute('aria-label', 'Top navigation');
+        $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
         // // Insert aria-label for submenu
-        $dom->find('.sub-menu')->setAttribute('aria-label', 'submenu');
+        $dom->find('.sub-menu')->setAttribute('aria-label', $submenu);
 
         return $dom->outerHTML;
     }

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -373,6 +373,8 @@ function get_side_nav(): string
  */
 function get_top_nav(): string
 {
+    $menuID = 'nav--primary';
+
     // Don't get the menu by name, but by theme location. Returns false if not found
     $headerMenu = wp_nav_menu([
         "theme_location" => "header",
@@ -380,6 +382,7 @@ function get_top_nav(): string
         "echo" => false,
         "depth" => 2,
         "menu_class" => "nav nav--primary container",
+        "menu_id" => $menuID,
         "container" => "nav",
         "container_class" => "nav--primary__container"
     ]);
@@ -390,7 +393,7 @@ function get_top_nav(): string
 
         // Insert a button (markup taken from bootstrap)
         // It seems like we can't append an element using the PHP HTML Parser https://stackoverflow.com/q/51466367
-        $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#menu-top-of-the-page" aria-controls="menu-top-of-the-page" aria-expanded="false">Menu</button></div>', $headerMenu);
+        $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#' . $menuID . '" aria-controls="' . $menuID . '" aria-expanded="false">Menu</button></div>', $headerMenu);
 
         $dom = new Dom();
         $dom->loadStr($headerMenu);

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -362,3 +362,43 @@ function get_side_nav(): string
 
     return $out;
 }
+
+/**
+ * Function that returns the menu assigned to the "Primary" location
+ * Also:
+ *   - Add a "menu" button similar to bootstrap
+ *   - Add aria-labels to the <nav> and <ul> submenu(s)
+ *
+ * If no menu is found, return an empty string
+ */
+function get_top_nav(): string
+{
+    // Don't get the menu by name, but by theme location. Returns false if not found
+    $headerMenu = wp_nav_menu([
+        "theme_location" => "header",
+        "fallback_cb" => false,
+        "echo" => false,
+        "depth" => 2,
+        "menu_class" => "nav nav--primary container",
+        "container" => "nav",
+        "container_class" => "nav--primary__container"
+    ]);
+
+    if ($headerMenu) {
+        // Insert a button (markup taken from bootstrap)
+        // It seems like we can't append an element using the PHP HTML Parser https://stackoverflow.com/q/51466367
+        $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#menu-top-of-the-page" aria-controls="menu-top-of-the-page" aria-expanded="false" aria-label="Toggle navigation">Menu</button></div>', $headerMenu);
+
+        $dom = new Dom();
+        $dom->loadStr($headerMenu);
+
+        // Insert aria-label for top nav (otherwise axe complains)
+        $dom->find('.nav--primary__container')->setAttribute('aria-label', 'Top navigation');
+        // // Insert aria-label for submenu
+        $dom->find('.sub-menu')->setAttribute('aria-label', 'submenu');
+
+        return $dom->outerHTML;
+    }
+
+    return '';
+}

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -90,10 +90,10 @@ function cds_the_posts_navigation($args = []): void
         $args = wp_parse_args(
             $args,
             [
-                'prev_text' => __('Older posts'),
-                'next_text' => __('Newer posts'),
-                'screen_reader_text' => __('Posts navigation'),
-                'aria_label' => __('Posts'),
+                'prev_text' => __('Older posts', 'cds-snc'),
+                'next_text' => __('Newer posts', 'cds-snc'),
+                'screen_reader_text' => __('Posts navigation', 'cds-snc'),
+                'aria_label' => __('Posts', 'cds-snc'),
                 'class' => 'posts-navigation',
             ]
         );
@@ -164,9 +164,9 @@ function cds_breadcrumb($sep = ''): string
         $html = $child->firstChild()->innerHtml;
         $parts = explode('|', $html);
 
-        $output = '<nav id="wb-bc" property="breadcrumb" aria-label="' .  __("Breadcrumbs") . '">';
+        $output = '<nav id="wb-bc" property="breadcrumb" aria-label="' .  __("Breadcrumbs", 'cds-snc') . '">';
         $output .= '<div class="container">';
-        $output .= '<h2>' . __("You are here:") . '</h2>';
+        $output .= '<h2>' . __("You are here:", 'cds-snc') . '</h2>';
         $output .= '<ol class="breadcrumb">';
         // note this will need to point to the correct language
         $output .= '<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>';
@@ -388,8 +388,8 @@ function get_top_nav(): string
     ]);
 
     if ($headerMenu) {
-        $topMenu = __('Top menu');
-        $submenu = __('submenu');
+        $topMenu = __('Top menu', 'cds-snc');
+        $submenu = __('submenu', 'cds-snc');
 
         // Insert a button (markup taken from bootstrap)
         // It seems like we can't append an element using the PHP HTML Parser https://stackoverflow.com/q/51466367

--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -1,8 +1,20 @@
 (function($) {
 
-  var search_form_value = $("#site-search").attr("action");
+  const search_form_value = $("#site-search").attr("action");
 
   $('#wb-srch-q').keyup(function() {
     $("#site-search").attr("action", search_form_value+ "?q=" + $(this).val());
   });
+
+  const $menuToggle = $('button.navbar-toggler');
+  $menuToggle.on('click', function(e) {
+    // toggle "aria-expanded"
+    const expanded = e.target.getAttribute('aria-expanded') === 'false' ? false : true;
+    $menuToggle.attr("aria-expanded", !expanded);
+
+    // toggle menu class
+    $menu = $(e.target.getAttribute('data-target'))
+    $menu.toggleClass('show');
+  })
+
 })(jQuery);

--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -7,14 +7,34 @@
   });
 
   const $menuToggle = $('button.navbar-toggler');
+  const $itemWithSubmenu = $('.menu-item-has-children');
+
   $menuToggle.on('click', function(e) {
     // toggle "aria-expanded"
-    const expanded = e.target.getAttribute('aria-expanded') === 'false' ? false : true;
-    $menuToggle.attr("aria-expanded", !expanded);
+    const expanded = e.target.getAttribute('aria-expanded') === 'false' ? true : false;
+    $menuToggle.attr("aria-expanded", expanded);
+
+    // set the submenu to "expanded" if the mobile nav is opened
+    if(expanded === true) {
+      $itemWithSubmenu.attr('aria-expanded', true);
+    }
 
     // toggle menu class
     $menu = $(e.target.getAttribute('data-target'))
     $menu.toggleClass('show');
   })
+
+  $itemWithSubmenu.on(
+    'focusin mouseover', function(e) {
+      // if target is within submenu, "aria-expanded" is true
+      if ($.contains($itemWithSubmenu[0], e.target)) {
+        $itemWithSubmenu.attr('aria-expanded', true);
+      }
+    }).on('focusout mouseout', function(e) {
+      // if the focused element is outside of submenu, "aria-expanded" is false
+      if (!$.contains($itemWithSubmenu[0], document.activeElement)) {
+        $itemWithSubmenu.attr('aria-expanded', false);
+      }
+    })
 
 })(jQuery);

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -79,19 +79,15 @@ nav a:visited {
     color: #284162;
 }
 
-nav ul {
+nav ul, .sub-menu {
     margin: 0;
     padding: 0;
     list-style-type: none;
 }
 
 /* Nav: header */
-.nav--primary__container {
+.nav--primary__container, .sub-menu {
     background-color: #eeeeee;
-}
-
-.nav--primary {
-    margin-top: 10px;
 }
 
 .nav.nav--primary > li,
@@ -99,20 +95,152 @@ nav ul {
     display: inline-block;
 }
 
-
 .nav.nav--primary a {
     padding-top: 14px;
-    border-bottom: 4px solid transparent;
+    border-left: 4px solid transparent;
 }
 
 .nav.nav--primary a:hover {
     color: #0535d2;
-    border-bottom: 4px solid #0535d2; 
+    border-left: 4px solid #0535d2; 
 }
 
-.nav--primary li.current-menu-item a {
+.nav--primary li.current-menu-item > a {
     color: #284162;
-    border-bottom: 4px solid #284162;
+    border-left: 4px solid #284162;
+}
+
+.nav--primary li:hover > .sub-menu,
+.nav--primary li:focus-within > .sub-menu,
+.nav--primary li > .sub-menu:hover,
+.nav--primary li > .sub-menu:focus {
+   visibility: visible;
+   opacity: 1;
+   display: block;
+}
+
+.sub-menu li {
+    padding: 5px 0 0 15px;
+}
+
+.nav--primary .sub-menu li a {
+    display: inline-block;
+    padding: 10px 15px 10px 11px;
+}
+
+.menu-item-has-children a {
+    padding-right: 25px;
+}
+
+button.navbar-toggler {
+    color: #284162;
+    padding: 10px 25px 10px 15px;
+    margin: 0;
+    cursor: pointer;
+    background: #e1e1e1;
+}
+
+button.navbar-toggler:hover {
+    color: #0535d2;
+    background: #d4d6da;
+}
+
+
+button.navbar-toggler[aria-expanded]::after {
+    color: currentColor;
+    border-style: solid;
+    border-width: 2px 2px 0 0;
+    content: '';
+    display: inline-block;
+    height: 8px;
+    left: 10px;
+    position: relative;
+    top: -3px;
+    transform: rotate(-225deg);
+    vertical-align: baseline;
+    width: 8px;
+    transition: all 0.2s ease;
+}
+
+button.navbar-toggler[aria-expanded='true']::after {
+    transform: rotate(-45deg);
+    top: -1px;
+}
+
+/* Large screens */
+@media screen and (min-width: 600px) {
+    .nav.nav--primary li a {
+        border-left: 0;
+        border-bottom: 4px solid transparent;
+    }
+
+    .nav.nav--primary li a {
+        border-left: 0;
+        border-bottom: 4px solid transparent;
+    }
+    
+    .nav.nav--primary li > a:hover {
+        border-left: 0;
+        border-bottom: 4px solid #0535d2;
+    }
+    
+    .nav--primary li.current-menu-item > a {
+        border-left: 0;
+        border-bottom: 4px solid #284162;
+    }
+
+    .nav--primary li .sub-menu {
+        min-width: calc(130% + 30px);
+        visibility: hidden;
+        opacity: 0;
+        position: absolute;
+        display: none;
+        z-index: 1;
+    }
+
+    .nav--primary li .sub-menu li:hover {
+        background: #e1e1e1;
+    }
+
+    .menu-item-has-children > a::after {
+        color: currentColor;
+        border-style: solid;
+        border-width: 2px 2px 0 0;
+        content: '';
+        display: inline-block;
+        height: 8px;
+        left: 10px;
+        position: relative;
+        top: -3px;
+        transform: rotate(-225deg);
+        vertical-align: baseline;
+        width: 8px;
+        transition: all 0.2s ease;
+    }
+    
+    .menu-item-has-children:hover > a::after,
+    .menu-item-has-children:focus-within > a::after {
+        transform: rotate(-45deg);
+    }
+
+    .nav--primary__container > div.container:first-child {
+        display: none;
+    }
+}
+
+/* Small screens */
+@media screen and (max-width: 599px) {
+    .nav.nav--primary:not(.show) {
+        display: none;
+    }
+
+    .nav--primary {
+        border-top: #e1e1e1 2px solid;
+    }
+
+    .nav.nav--primary > li {
+        display: block;
+    }
 }
 
 #wb-bc ol.breadcrumb {
@@ -120,7 +248,6 @@ nav ul {
 }
 
 /* Nav: left-hand menu */
-
 nav.nav--about ul {
     margin-left: 20px;
 }


### PR DESCRIPTION
# Summary | Résumé

Adding a top nav with a drop-down and a mobile "Menu" button. Also added some aria-labels because I ran an axe scan and it found some small things.
- Top nav now supports 1 level of drop-down (not 2)
- Top nav will collapse on mobile
- Removed the "landmarks must be unique" axe warning
- Removed the "empty header" axe warning

### Drop-down menu

The drop-down menu markup was taken from [CSS tricks](https://css-tricks.com/solved-with-css-dropdown-menus/). The idea was that we don't want to create a drop-down that's just a button, where you can't click the link anymore. It also suggests using an `aria-label`, so I added one.

- On large screens, it opens when you hover or focus the parent element.
- On small screens, we just list all the links, so it doesn't collapse.

### Mobile nav

The mobile nav is an "open/close" pattern that I copied from [the Bootstrap Navbar](https://getbootstrap.com/docs/5.1/components/navbar/). I've copied what bootstrap does with aria-roles, which is pretty minimal.

## gifs

![Screen Recording 2021-11-30 at 11 33 43](https://user-images.githubusercontent.com/2454380/144093780-13e08d24-e873-400b-b0c2-76743289a3e8.gif)

