### PR TITLE
Update which table user logins read and write to

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -17,7 +17,7 @@ class TrackLogins
         global $wpdb;
         $this->wpdb      = $wpdb;
 
-        if ($wpdb->base_prefix) {
+        if (property_exists($wpdb, 'base_prefix')) {
             $this->tableName = $wpdb->base_prefix . 'userlogins';
         } else {
             $this->tableName = $this->wpdb->prefix . 'userlogins';

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -16,7 +16,12 @@ class TrackLogins
     {
         global $wpdb;
         $this->wpdb      = $wpdb;
-        $this->tableName = $wpdb->base_prefix . 'userlogins';
+
+        if ($wpdb->base_prefix) {
+            $this->tableName = $wpdb->base_prefix . 'userlogins';
+        } else {
+            $this->tableName = $this->wpdb->prefix . 'userlogins';
+        }
     }
 
     public static function register()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -16,7 +16,7 @@ class TrackLogins
     {
         global $wpdb;
         $this->wpdb      = $wpdb;
-        $this->tableName = $this->wpdb->prefix . 'userlogins';
+        $this->tableName = $wpdb->base_prefix . 'userlogins';
     }
 
     public static function register()


### PR DESCRIPTION
Closes https://github.com/cds-snc/gc-articles-issues/issues/122

Updates the table used to read and write table logins 

We want to use the global vs the site tables

see: https://paulund.co.uk/get-database-table-prefix-in-wordpress