### PR TITLE
Add css fix -- for live preview menu button

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Styles/template/css/fixes.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Styles/template/css/fixes.css
@@ -84,3 +84,7 @@ body:not(.wp-admin) table tbody tr td {
 .users-php .subsubsub{
     display:none;
 }
+
+.hide-if-no-customize{
+	display: none !important;
+}


### PR DESCRIPTION

Turns off the live preview button .
<img width="647" alt="Screen Shot 2021-11-30 at 1 35 35 PM" src="https://user-images.githubusercontent.com/62242/144107355-29ee62a8-866d-45ed-beea-d357ca10ee48.png">

Think this is a bad idea?

Checkout the WP source code :)

wp-admin/css/themes.css
<img width="903" alt="Screen Shot 2021-11-30 at 1 31 22 PM" src="https://user-images.githubusercontent.com/62242/144107313-842a0eea-bfa2-4785-a092-205df8f194fb.png">



