### PR TITLE
Prepare ECR container repository for new Apache container

### DIFF
--- a/infrastructure/terragrunt/aws/ecr/ecr.tf
+++ b/infrastructure/terragrunt/aws/ecr/ecr.tf
@@ -53,3 +53,59 @@ resource "aws_ecr_lifecycle_policy" "wordpress" {
     ]
   })
 }
+
+resource "aws_ecr_repository" "apache" {
+  name                 = "platform/apache"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "apache" {
+  repository = aws_ecr_repository.apache.name
+  policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Keep last 30 release tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["v"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 30
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 10,
+        "description" : "Keep last 10 git SHA tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["sha-"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 10
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 20,
+        "description" : "Expire untagged images older than 7 days",
+        "selection" : {
+          "tagStatus" : "untagged",
+          "countType" : "sinceImagePushed",
+          "countUnit" : "days",
+          "countNumber" : 7
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infrastructure/terragrunt/aws/ecr/outputs.tf
+++ b/infrastructure/terragrunt/aws/ecr/outputs.tf
@@ -5,3 +5,11 @@ output "wordpress_repository_arn" {
 output "wordpress_repository_url" {
   value = aws_ecr_repository.wordpress.repository_url
 }
+
+output "apache_repository_arn" {
+  value = aws_ecr_repository.apache.arn
+}
+
+output "apache_repository_url" {
+  value = aws_ecr_repository.apache.repository_url
+}


### PR DESCRIPTION
# Summary | Résumé

Prepare an ECR container repository for our new Apache container. This simply creates the container repository, will not affect any existing services.

In preparation for #305. 
