### PR TITLE
Fixes for the top menu

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -388,32 +388,37 @@ function get_top_nav(): string
     ]);
 
     if ($headerMenu) {
-        $topMenu = __('Top menu', 'cds-snc');
-        $submenu = __('submenu', 'cds-snc');
-
         // Insert a button (markup taken from bootstrap)
         // It seems like we can't append an element using the PHP HTML Parser https://stackoverflow.com/q/51466367
         $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#' . $menuID . '" aria-controls="' . $menuID . '" aria-expanded="false">Menu</button></div>', $headerMenu);
 
-        $dom = new Dom();
-        $dom->loadStr($headerMenu);
+        try {
+            $topMenu = __('Top menu', 'cds-snc');
+            $submenu = __('submenu', 'cds-snc');
 
-        // Insert aria-label for top nav (otherwise axe complains)
-        $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
 
-        // Insert aria-label for submenu
-        $submenuNode = $dom->find('.sub-menu')[0];
-        if ($submenuNode) {
-            $submenuNode->setAttribute('aria-label', $submenu);
+            $dom = new Dom();
+            $dom->loadStr($headerMenu);
+
+            // Insert aria-label for top nav (otherwise axe complains)
+            $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
+
+            // Insert aria-label for submenu
+            $submenuNode = $dom->find('.sub-menu')[0];
+            if ($submenuNode) {
+                $submenuNode->setAttribute('aria-label', $submenu);
+            }
+
+            // Insert aria-expanded for link with submenu
+            $menuItemNode = $dom->find('.menu-item-has-children')[0];
+            if ($menuItemNode) {
+                $menuItemNode->setAttribute('aria-expanded', "false");
+            }
+
+            return $dom->outerHTML;
+        } catch (Exception) {
+            return $headerMenu;
         }
-
-        // Insert aria-expanded for link with submenu
-        $menuItemNode = $dom->find('.menu-item-has-children')[0];
-        if ($menuItemNode) {
-            $menuItemNode->setAttribute('aria-expanded', "false");
-        }
-
-        return $dom->outerHTML;
     }
 
     return '';

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -400,10 +400,18 @@ function get_top_nav(): string
 
         // Insert aria-label for top nav (otherwise axe complains)
         $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
+
         // Insert aria-label for submenu
-        $dom->find('.sub-menu')->setAttribute('aria-label', $submenu);
+        $submenuNode = $dom->find('.sub-menu')[0];
+        if ($submenuNode) {
+            $submenuNode->setAttribute('aria-label', $submenu);
+        }
+
         // Insert aria-expanded for link with submenu
-        $dom->find('.menu-item-has-children')->setAttribute('aria-expanded', "false");
+        $menuItemNode = $dom->find('.menu-item-has-children')[0];
+        if ($menuItemNode) {
+            $menuItemNode->setAttribute('aria-expanded', "false");
+        }
 
         return $dom->outerHTML;
     }

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -202,7 +202,7 @@ button.navbar-toggler[aria-expanded='true']::after {
         background: #e1e1e1;
     }
 
-    .menu-item-has-children > a::after {
+    .nav--primary > .menu-item-has-children > a::after {
         color: currentColor;
         border-style: solid;
         border-width: 2px 2px 0 0;
@@ -218,8 +218,8 @@ button.navbar-toggler[aria-expanded='true']::after {
         transition: all 0.2s ease;
     }
     
-    .menu-item-has-children:hover > a::after,
-    .menu-item-has-children:focus-within > a::after {
+    .nav--primary > .menu-item-has-children:hover > a::after,
+    .nav--primary > .menu-item-has-children:focus-within > a::after {
         transform: rotate(-45deg);
     }
 


### PR DESCRIPTION
# Summary | Résumé

There's 2 changes in this PR:
1. Fix the problem where the whole site disappears if there are no drop-down items on a custom menu
2. Fix the problem where nested submenus would get their own chevron

### The whole site disappears

WordPress returns menus as a big HTML string that you are supposed to `echo` out on the page, so you can only modify the HTML once you have the big string. I am using [PHP HTML Parser](https://github.com/paquettg/php-html-parser) to find elements in the menu and then add aria attributes.

However, I was finding the element, assuming it existed, and then trying to add attributes. When the element didn't exist (in our case, no submenu) PHP would error out and the page wouldn't be rendered.

| before | after |
|--------|-------|
|  nothing rendered to the page after the FIP      |   all good    |
| <img width="472" alt="Screen Shot 2021-12-01 at 11 21 12" src="https://user-images.githubusercontent.com/2454380/144273892-44ee3c34-7845-4802-a9ac-b636c1d612a0.png">  |   <img width="472" alt="Screen Shot 2021-12-01 at 11 21 43" src="https://user-images.githubusercontent.com/2454380/144273893-56317ea0-c1dd-4d4f-90e1-4679a092c130.png">  |

### Nested submenus would get their own chevron

Technically, the WordPress menu builder lets you create menus to an arbitrary depth, but we are limiting people to a depth of `2`.  However, the menu returned still adds the `has-children` class to leaf nodes that think they have a submenu (but they don't). 

Our CSS was adding chevrons to these second-level menu items, but we want that to go away.

| before | after |
|--------|-------|
|   `AUTHOR'S NOTE` has a chevron     |  `AUTHOR'S NOTE` _does not_ have a chevron     |
|   <img width="472" alt="Screen Shot 2021-12-01 at 11 20 36" src="https://user-images.githubusercontent.com/2454380/144274936-33ac8225-fa58-4153-beb2-d506f87daa31.png">   |  <img width="472" alt="Screen Shot 2021-12-01 at 11 20 05" src="https://user-images.githubusercontent.com/2454380/144274932-c284ef7b-eb77-4406-8425-6826becec9ee.png"> |

