### PR TITLE
Make "expander" element true to life

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/editor-styles/editor.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/editor-styles/editor.css
@@ -3,6 +3,8 @@
 .editor-styles-wrapper p,
 .editor-styles-wrapper ol, 
 .editor-styles-wrapper ul,
+.editor-styles-wrapper details,
+.editor-styles-wrapper details *,
 .wp-block-table table,
 .wp-block-table figcaption {
   font-family: 'Noto Sans', sans-serif;
@@ -130,4 +132,53 @@ width: 80px;
   margin: 0 0 23px;
   font-size: 20px;
   border-left: 5px solid #eee;
+}
+
+/* Details (we call this an "Expander") */
+
+.editor-styles-wrapper details {
+  display: block;
+  padding-left: 1.1em;
+  padding-right: 1.1em;
+  margin-bottom: .25em;
+}
+
+.editor-styles-wrapper details[open] {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding-bottom: 1em;
+}
+
+.editor-styles-wrapper details summary {
+  display: list-item;
+  list-style-type: disclosure-closed;
+  visibility: visible;
+  cursor: pointer;
+
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #295376;
+  padding: 5px 15px;
+  margin-left: -1.1em;
+  margin-right: -1.1em;
+}
+
+.editor-styles-wrapper details[open] > summary {
+  border: 0;
+  border-bottom: 1px solid #ddd;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  list-style-type: disclosure-open;
+  margin-bottom: .25em;
+}
+
+.editor-styles-wrapper details summary:focus {
+  outline-style: dotted;
+  outline-width: 1px;
+}
+.editor-styles-wrapper details summary:focus,
+.editor-styles-wrapper details summary:hover {
+  background-color: transparent;
+  color: #0535d2;
+  text-decoration: underline;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/expander/index.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/expander/index.tsx
@@ -1,43 +1,32 @@
 import * as React from 'react';
 import { __ } from "@wordpress/i18n";
 import { registerBlockType } from "@wordpress/blocks";
-import { useBlockProps, RichText } from "@wordpress/block-editor";
+import { useBlockProps, RichText, InnerBlocks } from "@wordpress/block-editor";
 
 registerBlockType("cds-snc/expander", {
   title: __("Expander", "cds-snc"),
   icon: "megaphone",
   category: "layout",
   attributes: {
-    content: {
-      type: "string",
-      source: "html",
-      selector: "div",
-    },
     title: {
       type: "string",
       source: "html",
-      selector: "h3",
+      selector: "summary",
     },
   },
 
   edit({ attributes, setAttributes }) {
     return (
-      <>
-        <RichText
-          tagName="h3" // The tag here is the element output and editable in the admin
-          value={attributes.title} // Any existing content, either from the database or an attribute default
-          allowedFormats={[]} // Allow the content to be made bold or italic, but do not allow other formatting options
-          onChange={(title) => setAttributes({ title })} // Store updated content as a block attribute
-          placeholder={__("Title", "cds-snc")} // Display this text before any content has been added by the user
-        />
-        <RichText
-          tagName="div" // The tag here is the element output and editable in the admin
-          value={attributes.content} // Any existing content, either from the database or an attribute default
-          // allowedFormats={["core/bold", "core/italic", "core/list"]} // Allow the content to be made bold or italic, but do not allow other formatting options
-          onChange={(content) => setAttributes({ content })} // Store updated content as a block attribute
-          placeholder={__("Summary", "cds-snc")} // Display this text before any content has been added by the user
-        />
-      </>
+        <details>
+          <RichText
+            tagName="summary" // The tag here is the element output and editable in the admin
+            value={attributes.title} // Any existing content, either from the database or an attribute default
+            allowedFormats={[]}
+            onChange={(title) => setAttributes({ title })} // Store updated content as a block attribute
+            placeholder={__("Title", "cds-snc")} // Display this text before any content has been added by the user
+          />
+          <InnerBlocks />
+      </details>
     );
   },
 
@@ -47,13 +36,9 @@ registerBlockType("cds-snc/expander", {
     return (
       <details>
         <summary>
-          <h3>{attributes.title}</h3>
+          {attributes.title}
         </summary>
-        <RichText.Content
-          {...blockProps}
-          tagName="div"
-          value={attributes.content}
-        />
+        <InnerBlocks.Content />
       </details>
     );
   },


### PR DESCRIPTION
# Summary | Résumé

Added better markup and the WET CSS for the expander element in the block editor itself, removed the `h3`, and also made the previous "summary" block into an "Inner Block" so that you can just add different things.

Expanders can now house all the other blocks:
- headings
- lists
- images
- etc

The only annoying thing is that they will open and close during editing, which I don't know how to stop. 😬 

Note: make sure to do an npm build before testing this.

## Screenshots

| before | after |
|--------|-------|
|  hacking it together      |  can use multiple blocks  (lists, images, headings, etc)   |
|   <img width="1000" alt="Screen Shot 2021-12-03 at 16 57 35" src="https://user-images.githubusercontent.com/2454380/144678109-ba647e25-508b-4626-b4b8-373fe84650f7.png">    |  <img width="1000" alt="Screen Shot 2021-12-03 at 15 02 59" src="https://user-images.githubusercontent.com/2454380/144677843-f304cdd8-fc74-4f61-8173-a0ee8efdf32f.png">   |

Once it's actually published, it looks like how it looked in the editor.

<img width="1000" alt="Screen Shot 2021-12-03 at 15 03 18" src="https://user-images.githubusercontent.com/2454380/144677976-e92648a1-efc4-41eb-9fe6-d154401093d5.png">




