### PR TITLE
Place s3 uploads bucket behind Cloudfront

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -19,7 +19,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
 
   origin {
     domain_name = var.s3_bucket_regional_domain_name
-    origin_id   = "wordpress-uploads-${var.environment}"
+    origin_id   = "wordpress-uploads"
 
     s3_origin_config {
       origin_access_identity = var.s3_cloudfront_origin_access_identity_iam_arn

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -1,7 +1,3 @@
-resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
-  comment = "Cloudfront origin access identity"
-}
-
 resource "aws_cloudfront_distribution" "wordpress" {
 
   origin {
@@ -26,7 +22,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
     origin_id   = "wordpress-uploads-${var.environment}"
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+      origin_access_identity = var.s3_cloudfront_origin_access_identity_iam_arn
     }
   }
 

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -109,6 +109,28 @@ resource "aws_cloudfront_distribution" "wordpress" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "/uploads/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_200"
 
   restrictions {

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -1,9 +1,5 @@
-locals {
-  s3_origin_id = "wordpress_uploads"
-}
-
-resource "aws_cloudfront_origin_access_identity" "wordpress_uploads" {
-  comment = "Wordpress uploads"
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = "Cloudfront origin access identity"
 }
 
 resource "aws_cloudfront_distribution" "wordpress" {
@@ -27,10 +23,10 @@ resource "aws_cloudfront_distribution" "wordpress" {
 
   origin {
     domain_name = var.s3_bucket_regional_domain_name
-    origin_id   = local.s3_origin_id
+    origin_id   = "wordpress-uploads-${var.environment}"
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.wordpress_uploads.cloudfront_access_identity_path
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
     }
   }
 

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -26,7 +26,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   origin {
-    domain_name = module.wordpress_storage.s3_bucket_regional_domain_name
+    domain_name = var.s3_bucket_regional_domain_name
     origin_id   = local.s3_origin_id
 
     s3_origin_config {

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -1,5 +1,8 @@
-resource "aws_cloudfront_distribution" "wordpress" {
+locals {
+  s3_origin_id = "wordpress_uploads"
+}
 
+resource "aws_cloudfront_distribution" "wordpress" {
   origin {
     domain_name = aws_lb.wordpress.dns_name
     origin_id   = aws_lb.wordpress.name
@@ -19,7 +22,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
 
   origin {
     domain_name = var.s3_bucket_regional_domain_name
-    origin_id   = "wordpress-uploads"
+    origin_id   = local.s3_origin_id
 
     s3_origin_config {
       origin_access_identity = var.s3_cloudfront_origin_access_identity_iam_arn

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -1,3 +1,11 @@
+locals {
+  s3_origin_id = "wordpress_uploads"
+}
+
+resource "aws_cloudfront_origin_access_identity" "wordpress_uploads" {
+  comment = "Wordpress uploads"
+}
+
 resource "aws_cloudfront_distribution" "wordpress" {
 
   origin {
@@ -14,6 +22,15 @@ resource "aws_cloudfront_distribution" "wordpress" {
       https_port             = 443
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  origin {
+    domain_name = module.wordpress_storage.s3_bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.wordpress_uploads.cloudfront_access_identity_path
     }
   }
 

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -34,3 +34,8 @@ variable "zone_id" {
   description = "Hosted zone ID for the DNS records"
   type        = string
 }
+
+variable "s3_bucket_regional_domain_name" {
+  description = "Domain name for uploads storage bucket"
+  type        = string
+}

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -39,3 +39,8 @@ variable "s3_bucket_regional_domain_name" {
   description = "Domain name for uploads storage bucket"
   type        = string
 }
+
+variable "s3_cloudfront_origin_access_identity_iam_arn" {
+  description = "Iam arn for the origin access identity"
+  type        = string
+}

--- a/infrastructure/terragrunt/aws/storage/outputs.tf
+++ b/infrastructure/terragrunt/aws/storage/outputs.tf
@@ -1,3 +1,7 @@
 output "s3_bucket_regional_domain_name" {
   value = module.wordpress_storage.s3_bucket_regional_domain_name
 }
+
+output "s3_cloudfront_origin_access_identity_iam_arn" {
+  value = aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn
+}

--- a/infrastructure/terragrunt/aws/storage/outputs.tf
+++ b/infrastructure/terragrunt/aws/storage/outputs.tf
@@ -1,0 +1,3 @@
+output "s3_bucket_regional_domain_name" {
+  value = module.wordpress_storage.s3_bucket_regional_domain_name
+}

--- a/infrastructure/terragrunt/aws/storage/s3.tf
+++ b/infrastructure/terragrunt/aws/storage/s3.tf
@@ -27,6 +27,29 @@ resource "aws_s3_bucket_policy" "wordpress_storage" {
   })
 }
 
+resource "aws_s3_bucket_policy" "wordpress_uploads" {
+  bucket = module.wordpress_storage.s3_bucket_id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "OnlyCloudfrontReadAccess",
+      "Principal": {
+        "AWS": "${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"
+      },
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "${module.wordpress_storage.s3_bucket_arn}/*"
+    }
+  ]
+}
+POLICY
+}
+
 resource "aws_iam_user" "wordpress_storage" {
   name = "wordpress_storage"
 }

--- a/infrastructure/terragrunt/aws/storage/s3.tf
+++ b/infrastructure/terragrunt/aws/storage/s3.tf
@@ -6,6 +6,10 @@ module "wordpress_storage" {
   restrict_public_buckets = false
 }
 
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = "Cloudfront origin access identity"
+}
+
 resource "aws_s3_bucket_policy" "wordpress_storage" {
   bucket = module.wordpress_storage.s3_bucket_id
 

--- a/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
@@ -41,6 +41,7 @@ inputs = {
   public_subnet_ids               = dependency.network.outputs.public_subnet_ids
   vpc_id                          = dependency.network.outputs.vpc_id
   zone_id                         = dependency.hosted-zone.outputs.zone_id
+  s3_bucket_regional_domain_name  = dependency.storage.outputs.s3_bucket_regional_domain_name
 }
 
 terraform {

--- a/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 dependencies {
-  paths = ["../network", "../hosted-zone"]
+  paths = ["../network", "../hosted-zone", "../storage"]
 }
 
 dependency "network" {
@@ -24,6 +24,15 @@ dependency "hosted-zone" {
   mock_outputs = {
     zone_id = ""
   }
+}
+
+dependency "storage" {
+  config_path = "../storage"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    s3_bucket_regional_domain_name = ""
+  }  
 }
 
 inputs = {

--- a/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
@@ -36,12 +36,13 @@ dependency "storage" {
 }
 
 inputs = {
-  domain_name                     = "articles.cdssandbox.xyz"
-  load_balancer_security_group_id = dependency.network.outputs.load_balancer_security_group_id
-  public_subnet_ids               = dependency.network.outputs.public_subnet_ids
-  vpc_id                          = dependency.network.outputs.vpc_id
-  zone_id                         = dependency.hosted-zone.outputs.zone_id
-  s3_bucket_regional_domain_name  = dependency.storage.outputs.s3_bucket_regional_domain_name
+  domain_name                                  = "articles.cdssandbox.xyz"
+  load_balancer_security_group_id              = dependency.network.outputs.load_balancer_security_group_id
+  public_subnet_ids                            = dependency.network.outputs.public_subnet_ids
+  vpc_id                                       = dependency.network.outputs.vpc_id
+  zone_id                                      = dependency.hosted-zone.outputs.zone_id
+  s3_bucket_regional_domain_name               = dependency.storage.outputs.s3_bucket_regional_domain_name
+  s3_cloudfront_origin_access_identity_iam_arn = dependency.storage.outputs.s3_cloudfront_origin_access_identity_iam_arn
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

When we rolled out the S3 Uploads plugin, we just opened up the S3 bucket to public reads and have been using direct links to the s3 objects. This PR places that S3 bucket behind a CloudFront origin, blocks public access to that S3 bucket, and configures the S3 Uploads plugin with the new url prefix.

Note that this PR does not contain the configuration code required for our s3 uploads plugin to serve from this new endpoint. This will follow in a subsequent PR.