### PR TITLE
Wire up and use the origin access identity path

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -25,7 +25,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
     origin_id   = local.s3_origin_id
 
     s3_origin_config {
-      origin_access_identity = var.s3_cloudfront_origin_access_identity_iam_arn
+      origin_access_identity = var.s3_cloudfront_origin_access_identity_path
     }
   }
 

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -44,3 +44,8 @@ variable "s3_cloudfront_origin_access_identity_iam_arn" {
   description = "Iam arn for the origin access identity"
   type        = string
 }
+
+variable "s3_cloudfront_origin_access_identity_path" {
+  description = "Path for the origin access identity"
+  type        = string
+}

--- a/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/load-balancer/terragrunt.hcl
@@ -44,6 +44,7 @@ inputs = {
   zone_id                                      = dependency.hosted-zone.outputs.zone_id
   s3_bucket_regional_domain_name               = dependency.storage.outputs.s3_bucket_regional_domain_name
   s3_cloudfront_origin_access_identity_iam_arn = dependency.storage.outputs.s3_cloudfront_origin_access_identity_iam_arn
+  s3_cloudfront_origin_access_identity_path    = dependency.storage.outputs.s3_cloudfront_origin_access_identity_path
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

Cloudfront wants the path not the arn for the origin
