### PR TITLE
Update S3_Uploads to use new cloudfront endpoint

### DIFF
--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -139,6 +139,7 @@ define('S3_UPLOADS_REGION', getenv_docker('S3_UPLOADS_REGION', 'ca-central-1'));
 define('S3_UPLOADS_KEY', getenv_docker('S3_UPLOADS_KEY', ''));
 define('S3_UPLOADS_SECRET', getenv_docker('S3_UPLOADS_SECRET', ''));
 define('S3_UPLOADS_OBJECT_ACL', 'private');
+define( 'S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz/uploads' );
 
 define('OTGS_DISABLE_AUTO_UPDATES', true);
 define('WP_AUTO_UPDATE_CORE', false);

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -139,7 +139,7 @@ define('S3_UPLOADS_REGION', getenv_docker('S3_UPLOADS_REGION', 'ca-central-1'));
 define('S3_UPLOADS_KEY', getenv_docker('S3_UPLOADS_KEY', ''));
 define('S3_UPLOADS_SECRET', getenv_docker('S3_UPLOADS_SECRET', ''));
 define('S3_UPLOADS_OBJECT_ACL', 'private');
-define( 'S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz/uploads' );
+define( 'S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz' );
 
 define('OTGS_DISABLE_AUTO_UPDATES', true);
 define('WP_AUTO_UPDATE_CORE', false);

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -139,7 +139,7 @@ define('S3_UPLOADS_REGION', getenv_docker('S3_UPLOADS_REGION', 'ca-central-1'));
 define('S3_UPLOADS_KEY', getenv_docker('S3_UPLOADS_KEY', ''));
 define('S3_UPLOADS_SECRET', getenv_docker('S3_UPLOADS_SECRET', ''));
 define('S3_UPLOADS_OBJECT_ACL', 'private');
-define( 'S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz' );
+define('S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz');
 
 define('OTGS_DISABLE_AUTO_UPDATES', true);
 define('WP_AUTO_UPDATE_CORE', false);


### PR DESCRIPTION
# Summary | Résumé

Configures the S3_Uploads plugin to use the new Cloudfront origin for user uploads.

## To test
Running locally, pull in this PR, then go to the Media section. If you don't have any uploaded images, upload one. Then inspect an image and check the URL from which it is being served. It used to be served directly from the bucket, but now is proxied through our cloudfront origin, and is served from our domain:

![image](https://user-images.githubusercontent.com/1187115/144933630-6df805c4-dfec-4a2f-837d-09d46287d955.png)

