### PR TITLE
Add new "Accordion" block

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/Blocks.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/Blocks.php
@@ -9,7 +9,7 @@ class Blocks
 
     public function __construct()
     {
-        $this->version = "1.0.1";
+        $this->version = "1.0.2";
         add_action('admin_enqueue_scripts', [$this, 'register'], 10, 2);
         add_action('admin_enqueue_scripts', [$this, 'addStyles'], 10, 2);
         add_action('admin_enqueue_scripts', [$this, 'editorStyles'], 20000, 2);
@@ -23,6 +23,10 @@ class Blocks
         ]);
 
         register_block_type('cds-snc/alert', [
+            'editor_script' => 'cds-snc',
+        ]);
+
+        register_block_type('cds-snc/accordion', [
             'editor_script' => 'cds-snc',
         ]);
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/accordion/index.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/accordion/index.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { __ } from "@wordpress/i18n";
+import { registerBlockType } from "@wordpress/blocks";
+import { useBlockProps, RichText, InnerBlocks } from "@wordpress/block-editor";
+
+registerBlockType("cds-snc/accordion", {
+  title: __("Accordion", "cds-snc"),
+  icon: "plus-alt",
+  category: "layout",
+  attributes: {
+    title: {
+      type: "string",
+      source: "html",
+      selector: "summary",
+    },
+  },
+
+  edit({ attributes, setAttributes }) {
+    return (
+        <details open>
+          <RichText
+            tagName="summary" // The tag here is the element output and editable in the admin
+            value={attributes.title} // Any existing content, either from the database or an attribute default
+            allowedFormats={['core/bold', 'core/italics']}
+            onChange={(title) => setAttributes({ title })} // Store updated content as a block attribute
+            placeholder={__("Title", "cds-snc")} // Display this text before any content has been added by the user
+          />
+          <InnerBlocks />
+      </details>
+    );
+  },
+
+  save({ attributes }) {
+    const blockProps = useBlockProps.save();
+
+    return (
+      <details>
+        <summary>
+          {attributes.title}
+        </summary>
+        <InnerBlocks.Content />
+      </details>
+    );
+  },
+});

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/editor-styles/editor.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/editor-styles/editor.css
@@ -3,6 +3,7 @@
 .editor-styles-wrapper p,
 .editor-styles-wrapper ol, 
 .editor-styles-wrapper ul,
+.editor-styles-wrapper details,
 .wp-block-table table,
 .wp-block-table figcaption {
   font-family: 'Noto Sans', sans-serif;
@@ -130,4 +131,53 @@ width: 80px;
   margin: 0 0 23px;
   font-size: 20px;
   border-left: 5px solid #eee;
+}
+
+/* Details (we call this an "Accordion") */
+
+.editor-styles-wrapper details {
+  display: block;
+  padding-left: 1.1em;
+  padding-right: 1.1em;
+  margin-bottom: .25em;
+}
+
+.editor-styles-wrapper details[open] {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding-bottom: 1em;
+}
+
+.editor-styles-wrapper details summary {
+  display: list-item;
+  list-style-type: disclosure-closed;
+  visibility: visible;
+  cursor: pointer;
+
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #295376;
+  padding: 5px 15px;
+  margin-left: -1.1em;
+  margin-right: -1.1em;
+}
+
+.editor-styles-wrapper details[open] > summary {
+  border: 0;
+  border-bottom: 1px solid #ddd;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  list-style-type: disclosure-open;
+  margin-bottom: .25em;
+}
+
+.editor-styles-wrapper details summary:focus {
+  outline-style: dotted;
+  outline-width: 1px;
+}
+.editor-styles-wrapper details summary:focus,
+.editor-styles-wrapper details summary:hover {
+  background-color: transparent;
+  color: #0535d2;
+  text-decoration: underline;
 }

--- a/wordpress/wp-content/plugins/cds-base/src/index.tsx
+++ b/wordpress/wp-content/plugins/cds-base/src/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import "../classes/Modules/Blocks/src/expander";
+import "../classes/Modules/Blocks/src/accordion";
 import "../classes/Modules/Blocks/src/alert";
 import { render } from "@wordpress/element";
 import { LoginsPanel } from "../classes/Modules/TrackLogins/src/LoginsPanel";


### PR DESCRIPTION
# Summary | Résumé

Add an "Accordion" block that looks / acts the same as the Canada.ca "details" elements, both when you're editing and once it's published. (There are a bunch of them on [this page](https://www.canada.ca/en/government/system/digital-government/government-canada-digital-standards.html) if you want to test them out.)

To test this, create a new block and look for (or search for) an "Accordion" and try making some super complex set of blocks in the expanded half. Note that you will have to run an `npm run build` for it to show up.

Since this one is a new element instead of replacing the other Expanders, the existing ones will still work.

Once this is merged, we can close #360.

## gif

How it looks to use the new Accordion.

![Screen Recording 2021-12-06 at 17 15 16](https://user-images.githubusercontent.com/2454380/144932073-33888b05-ddf0-475b-b26d-86cf1abeb839.gif)


## Discussion

If you're fairly eagle-eyed, you will notice that it's almost all the same code as in my other open PR: #360. I spent a bunch of time on this one trying out some things that didn't actually work.

- Don't collapse the "details" element in the editing menu: I tried adding an `onClick` or defaulting `open={true}` but nothing I did worked. If we really wanted it to not collapse, we could replace the `summary` with a div and style it like a summary, but I thought this would be too much work.
- Set "tabIndex" on the expanded portion so that we can <kbd>Tab</kbd> into it: I tried this a number of ways, but it didn't work how I expected. It seems like those little context menus that pop up mess with everything, so focus management in Gutenberg gets really complicated.

### How does "deprecated" work?

[The WordPress docs on "deprecated" blocks](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/) are kind of hard to understand. I found two blog posts that were much more helpful in understanding what was going on:
- simple example: https://awhitepixel.com/blog/how-to-deprecate-gutenberg-blocks/ 
- more complex example: https://atomicblocks.com/how-to-deprecate-gutenberg-editor-blocks/

Basically, it seems like we will want to manually transition at some point, since we can't "deprecate" a block unless we are modifying it to be something else. It doesn't seem like the use case here is to say "this block is deprecated". 
If we wanted to approximate this behaviour, we could use `isSelected` to put a message on the screen. 👇 

![Screen Recording 2021-12-06 at 17 34 39](https://user-images.githubusercontent.com/2454380/144933795-a8f0a6fe-6f52-47c7-9215-dbadb88277c9.gif)

