### PR TITLE
Remove public access from S3 bucket

### DIFF
--- a/infrastructure/terragrunt/aws/storage/s3.tf
+++ b/infrastructure/terragrunt/aws/storage/s3.tf
@@ -10,27 +10,6 @@ resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
   comment = "Cloudfront origin access identity"
 }
 
-resource "aws_s3_bucket_policy" "wordpress_storage" {
-  bucket = module.wordpress_storage.s3_bucket_id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "PublicReadGetObject"
-        Effect    = "Allow"
-        Principal = "*"
-        "Action" : [
-          "s3:GetObject"
-        ],
-        Resource = [
-          "${module.wordpress_storage.s3_bucket_arn}/*",
-        ]
-      },
-    ]
-  })
-}
-
 resource "aws_s3_bucket_policy" "wordpress_uploads" {
   bucket = module.wordpress_storage.s3_bucket_id
 


### PR DESCRIPTION
# Summary | Résumé

Once we get the S3 Uploads config (#369) deployed to production, we can remove public access to the S3 bucket.

**Heads-up** Don't merge this until after our next deployment.