### PR TITLE
Sync staging/prod tg environments

### DIFF
--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -94,5 +94,5 @@ inputs = {
 }
 
 terraform {
-  source = "../../../aws//alarms"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/alarms?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -10,6 +10,7 @@ dependency "hosted-zone" {
   config_path = "../hosted-zone"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     zone_id = ""
   }
@@ -19,6 +20,7 @@ dependency "load-balancer" {
   config_path = "../load-balancer"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     alb_arn                     = ""
     alb_arn_suffix              = ""
@@ -33,6 +35,7 @@ dependency "database" {
   config_path = "../database"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     rds_cluster_id = ""
   }
@@ -42,6 +45,7 @@ dependency "ecs" {
   config_path = "../ecs"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     ecs_cloudfront_log_group_name = ""
     ecs_cluster_name              = ""
@@ -85,7 +89,7 @@ inputs = {
   rds_cpu_maxiumum               = 80
   rds_freeable_memory_minimum    = 64000000
 
-  wordpress_failed_login_maximum = "50"
+  wordpress_failed_login_maximum = "5"
   wordpress_log_group_name       = dependency.ecs.outputs.ecs_cloudfront_log_group_name
 }
 

--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -64,8 +64,8 @@ inputs = {
   alb_target_5xx_maximum                   = 0
   alb_target_4xx_maximum                   = 100
 
-  canary_healthcheck_url_eng = "https://ircc.digital.canada.ca/"
-  canary_healthcheck_url_fra = "https://ircc.digital.canada.ca/"
+  canary_healthcheck_url_eng = "https://articles.alpha.canada.ca/"
+  canary_healthcheck_url_fra = "https://articles.alpha.canada.ca/"
 
   cloudfront_arn              = dependency.load-balancer.outputs.cloudfront_arn
   cloudfront_distribution_id  = dependency.load-balancer.outputs.cloudfront_distribution_id

--- a/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
@@ -24,5 +24,5 @@ inputs = {
 }
 
 terraform {
-  source = "../../../aws//database"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/database?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
@@ -10,6 +10,7 @@ dependency "network" {
   config_path = "../network"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     private_subnet_ids = [""]
     vpc_id             = ""

--- a/infrastructure/terragrunt/env/prod/ecr/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/ecr/terragrunt.hcl
@@ -3,5 +3,5 @@ include {
 }
 
 terraform {
-  source = "../../../aws//ecr"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/ecr?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
@@ -92,5 +92,5 @@ inputs = {
 }
 
 terraform {
-  source = "../../../aws//ecs"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/ecs?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
@@ -10,6 +10,7 @@ dependency "network" {
   config_path = "../network"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     ecs_events_lambda_security_group_id = ""
     ecs_service_security_group_id       = ""
@@ -22,9 +23,12 @@ dependency "ecr" {
   config_path = "../ecr"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     wordpress_repository_arn = ""
     wordpress_repository_url = ""
+    apache_repository_arn = ""
+    apache_repository_url = ""
   }
 }
 
@@ -32,6 +36,7 @@ dependency "load-balancer" {
   config_path = "../load-balancer"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     alb_target_group_arn = ""
     domain_name          = ""
@@ -42,6 +47,7 @@ dependency "database" {
   config_path = "../database"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     database_host_secret_arn         = ""
     database_name_secret_arn         = ""
@@ -62,7 +68,11 @@ inputs = {
 
   wordpress_repository_arn = dependency.ecr.outputs.wordpress_repository_arn
   wordpress_image          = dependency.ecr.outputs.wordpress_repository_url
-  wordpress_image_tag      = "v1.3.1"
+  wordpress_image_tag      = "v2.7.0"
+
+  apache_repository_arn = dependency.ecr.outputs.apache_repository_arn
+  apache_image          = dependency.ecr.outputs.apache_repository_url
+  apache_image_tag      = "v1.0.14"
 
   database_host_secret_arn         = dependency.database.outputs.database_host_secret_arn
   database_name_secret_arn         = dependency.database.outputs.database_name_secret_arn

--- a/infrastructure/terragrunt/env/prod/env_vars.hcl
+++ b/infrastructure/terragrunt/env/prod/env_vars.hcl
@@ -3,5 +3,5 @@ inputs = {
   enable_efs        = false
   env               = "prod"
   billing_tag_key   = "CostCentre"
-  billing_tag_value = "PlatformIRCC"
+  billing_tag_value = "PlatformGCArticles"
 }

--- a/infrastructure/terragrunt/env/prod/hosted-zone/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/hosted-zone/terragrunt.hcl
@@ -3,9 +3,9 @@ include {
 }
 
 inputs = {
-  zone_name = "ircc.digital.canada.ca"
+  zone_name = "articles.alpha.canada.ca"
 }
 
 terraform {
-  source = "../../../aws//hosted-zone"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/hosted-zone?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/load-balancer/terragrunt.hcl
@@ -51,5 +51,5 @@ inputs = {
 }
 
 terraform {
-  source = "../../../aws//load-balancer"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/load-balancer?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/load-balancer/terragrunt.hcl
@@ -3,13 +3,14 @@ include {
 }
 
 dependencies {
-  paths = ["../network", "../hosted-zone"]
+  paths = ["../network", "../hosted-zone", "../storage"]
 }
 
 dependency "network" {
   config_path = "../network"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     load_balancer_security_group_id = ""
     public_subnet_ids               = [""]
@@ -21,18 +22,32 @@ dependency "hosted-zone" {
   config_path = "../hosted-zone"
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     zone_id = ""
   }
 }
 
+dependency "storage" {
+  config_path = "../storage"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    s3_bucket_regional_domain_name = ""
+    s3_cloudfront_origin_access_identity_iam_arn = ""
+  }  
+}
+
 inputs = {
-  allow_wordpress_uploads         = false
-  domain_name                     = "ircc.digital.canada.ca"
-  load_balancer_security_group_id = dependency.network.outputs.load_balancer_security_group_id
-  public_subnet_ids               = dependency.network.outputs.public_subnet_ids
-  vpc_id                          = dependency.network.outputs.vpc_id
-  zone_id                         = dependency.hosted-zone.outputs.zone_id
+  domain_name                                  = "articles.alpha.canadad.ca"
+  load_balancer_security_group_id              = dependency.network.outputs.load_balancer_security_group_id
+  public_subnet_ids                            = dependency.network.outputs.public_subnet_ids
+  vpc_id                                       = dependency.network.outputs.vpc_id
+  zone_id                                      = dependency.hosted-zone.outputs.zone_id
+  s3_bucket_regional_domain_name               = dependency.storage.outputs.s3_bucket_regional_domain_name
+  s3_cloudfront_origin_access_identity_iam_arn = dependency.storage.outputs.s3_cloudfront_origin_access_identity_iam_arn
+  s3_cloudfront_origin_access_identity_path    = dependency.storage.outputs.s3_cloudfront_origin_access_identity_path
 }
 
 terraform {

--- a/infrastructure/terragrunt/env/prod/load-balancer/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/load-balancer/terragrunt.hcl
@@ -40,7 +40,7 @@ dependency "storage" {
 }
 
 inputs = {
-  domain_name                                  = "articles.alpha.canadad.ca"
+  domain_name                                  = "articles.alpha.canada.ca"
   load_balancer_security_group_id              = dependency.network.outputs.load_balancer_security_group_id
   public_subnet_ids                            = dependency.network.outputs.public_subnet_ids
   vpc_id                                       = dependency.network.outputs.vpc_id

--- a/infrastructure/terragrunt/env/prod/network/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/network/terragrunt.hcl
@@ -3,5 +3,5 @@ include {
 }
 
 terraform {
-  source = "../../../aws//network"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/network?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/storage/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/storage/terragrunt.hcl
@@ -3,5 +3,5 @@ include {
 }
 
 terraform {
-  source = "../../../aws//storage"
+  source = "git::https://github.com/cds-snc/gc-articles/infrastructure/terragrunt//aws/storage?ref=${get_env("TARGET_VERSION")}"
 }

--- a/infrastructure/terragrunt/env/prod/storage/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/storage/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../aws//storage"
+}


### PR DESCRIPTION
# Summary | Résumé

In preparation for production infrastructure cds-snc/gc-articles-issues#159

Syncs Terragrunt settings and properties that have changed in staging to production files.
Also updates any references to the old `ircc.digital.canada.ca` hostname to `articles.alpha.canada.ca`
Also configures production tg sources to use version-tagged sources.