### PR TITLE
Set root Filesystem to read-only

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -23,7 +23,8 @@
           "sourceContainer": "wordpress",
           "readOnly": true
         }
-     ]
+     ],
+     "readonlyRootFilesystem": true
   },
   {
     "name" : "wordpress",
@@ -131,6 +132,7 @@
         "name": "WORDPRESS_NONCE_SALT",
         "valueFrom": "${WORDPRESS_NONCE_SALT}"
       }
-    ]
+    ],
+    "readonlyRootFilesystem": true
   }
 ]


### PR DESCRIPTION
# Summary | Résumé

In preparation for Production infrastructure, re: cds-snc/gc-articles-issues#162

Locks down the containers root filesystem