### PR TITLE
Articles CLI Helper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,9 +18,14 @@ RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
         zsh \
         zsh-autosuggestions \
         zsh-syntax-highlighting \
-        gettext
+        gettext \
+        php8-xmlwriter \
+        php8-simplexml \
+        php8-tokenizer \
+        php8-dom \
+        php8-xml
 
-RUN pecl install pcov \
+RUN pecl install pcov  \
     && docker-php-ext-enable pcov
 
 # clean up

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ wordpress/wp-content/languages
 debug-this/
 
 auth.json
+vendor

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,12 +5,13 @@ A few helpful commands to get things running.
 To get started, run this command once:
 
 ```sh
-./cli/bin/articles install
+./cli/bin/articles init
 ```
 
 This will start up a few docker services and install some dependencies.
 
-Now, by default the cli is available at `./vendor/bin/articles` but we recommend adding an alias in your .zshrc file:
+Now, by default the cli is available at `./vendor/bin/articles` but we recommend 
+adding an alias in your .zshrc or .bash_profile file:
 
 ```sh
 alias articles='[ -f articles ] && bash articles || bash vendor/bin/articles'
@@ -18,7 +19,7 @@ alias articles='[ -f articles ] && bash articles || bash vendor/bin/articles'
 
 Now you can run the following commands:
 
-- `articles init`: Install composer dependencies at root
+- `articles init`: Prepare or update this CLI
 - `articles generate-encryption-key`: Generate Encryption Key
 - `articles install`: Install WordPress composer dependencies
 - `articles update`: Update WordPress compose dependencies
@@ -27,3 +28,17 @@ Now you can run the following commands:
 - `articles down`: Bring down the full docker-compose environment
 - `articles npm install`: Install and build npm dependencies
 
+## Starting fresh
+
+A typical onboarding might look like:
+
+- Clone this repo
+- Configure .env vars (except ENCRYPTION_KEY)
+- Run `./cli/bin/articles init`
+- Create an alias (see above - you only need to do this once if you put it in your .zshrc or .bash_profile)
+- Run `articles generate-encryption-key` and copy that key into your .env file
+- Run `articles install` to install WordPress dependencies
+- Run `articles npm install` to install and build npm and javascript dependencies
+- Run `articles wordpress install` to setup your database
+- Run `articles up` to bring up the rest of the environment
+- Visit `localhost` and profit!

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,6 +20,7 @@ Now you can run all of the following commands:
 
 - `articles install`: Install composer dependencies at root
 - `articles update`: Update composer dependencies at root
+- `articles generate-encryption-key`: Generate Encryption Key
 - `articles wordpress install`: Install WordPress composer dependencies
 - `articles wordpress update`: Update WordPress compose dependencies
 - `articles up`: Bring up the full docker-compose environment

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,27 @@
+# Articles CLI (ALPHA)
+
+A few helpful commands to get things running.
+
+To get started, run this command once:
+
+```sh
+./cli/bin/articles install
+```
+
+This will start up a few docker services and install some dependencies.
+
+Now, by default the cli is available at `./vendor/bin/articles` but we recommend adding an alias in your .zshrc file:
+
+```sh
+alias articles='[ -f articles ] && bash articles || bash vendor/bin/articles'
+```
+
+Now you can run all of the following commands:
+
+- `articles install`: Install composer dependencies at root
+- `articles update`: Update composer dependencies at root
+- `articles wordpress install`: Install WordPress composer dependencies
+- `articles wordpress update`: Update WordPress compose dependencies
+- `articles up`: Bring up the full docker-compose environment
+- `articles down`: Bring down the full docker-compose environment
+- `articles npm install`: Install and build npm dependencies

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,13 +16,14 @@ Now, by default the cli is available at `./vendor/bin/articles` but we recommend
 alias articles='[ -f articles ] && bash articles || bash vendor/bin/articles'
 ```
 
-Now you can run all of the following commands:
+Now you can run the following commands:
 
-- `articles install`: Install composer dependencies at root
-- `articles update`: Update composer dependencies at root
+- `articles init`: Install composer dependencies at root
 - `articles generate-encryption-key`: Generate Encryption Key
-- `articles wordpress install`: Install WordPress composer dependencies
-- `articles wordpress update`: Update WordPress compose dependencies
+- `articles install`: Install WordPress composer dependencies
+- `articles update`: Update WordPress compose dependencies
+- `articles wordpress install`: Run wp-cli installer to setup the database, theme, and plugins
 - `articles up`: Bring up the full docker-compose environment
 - `articles down`: Bring down the full docker-compose environment
 - `articles npm install`: Install and build npm dependencies
+

--- a/cli/bin/articles
+++ b/cli/bin/articles
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
+UNAMEOUT="$(uname -s)"
+
+WHITE='\033[1;37m'
+NC='\033[0m'
+
+# Verify operating system is supported...
+case "${UNAMEOUT}" in
+    Linux*)             MACHINE=linux;;
+    Darwin*)            MACHINE=mac;;
+    *)                  MACHINE="UNKNOWN"
+esac
+
+if [ "$MACHINE" == "UNKNOWN" ]; then
+    echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
+
+    exit 1
+fi
+
+# Source the ".env" file so Laravel's environment variables are available...
+if [ -f ./.env ]; then
+    source ./.env
+fi
+
+# Define environment variables...
+export APP_PORT=${APP_PORT:-80}
+export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export DB_PORT=${DB_PORT:-3306}
+export WWWUSER=${WWWUSER:-$UID}
+export WWWGROUP=${WWWGROUP:-$(id -g)}
+
+export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
+export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
+export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
+export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
+
+# Function that outputs Sail is not running...
+function sail_is_not_running {
+    echo -e "${WHITE}Sail is not running.${NC}" >&2
+    echo "" >&2
+    echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
+
+    exit 1
+}
+
+if [ -z "$SAIL_SKIP_CHECKS" ]; then
+    # Ensure that Docker is running...
+    if ! docker info > /dev/null 2>&1; then
+        echo -e "${WHITE}Docker is not running.${NC}" >&2
+
+        exit 1
+    fi
+
+    # Determine if Sail is currently up...
+    PSRESULT="$(docker-compose ps -q)"
+    if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
+        echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
+
+        docker-compose down > /dev/null 2>&1
+
+        EXEC="no"
+    elif [ -n "$PSRESULT" ]; then
+        EXEC="yes"
+    else
+        EXEC="no"
+    fi
+else
+    EXEC="yes"
+fi
+
+if [ $# -gt 0 ]; then
+    # Proxy PHP commands to the "php" binary on the application container...
+    if [ "$1" == "php" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                php "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy vendor binary commands on the application container...
+    elif [ "$1" == "bin" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                ./vendor/bin/"$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy Composer commands to the "composer" binary on the application container...
+    elif [ "$1" == "composer" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                composer "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy Artisan commands to the "artisan" binary on the application container...
+    elif [ "$1" == "artisan" ] || [ "$1" == "art" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                php artisan "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy the "debug" command to the "php artisan" binary on the application container with xdebug enabled...
+    elif [ "$1" == "debug" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                -e XDEBUG_SESSION=1 \
+                "$APP_SERVICE" \
+                php artisan "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy the "test" command to the "php artisan test" Artisan command...
+    elif [ "$1" == "test" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                php artisan test "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy the "dusk" command to the "php artisan dusk" Artisan command...
+    elif [ "$1" == "dusk" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                -e "APP_URL=http://${APP_SERVICE}" \
+                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
+                "$APP_SERVICE" \
+                php artisan dusk "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy the "dusk:fails" command to the "php artisan dusk:fails" Artisan command...
+    elif [ "$1" == "dusk:fails" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                -e "APP_URL=http://${APP_SERVICE}" \
+                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
+                "$APP_SERVICE" \
+                php artisan dusk:fails "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a Laravel Tinker session within the application container...
+    elif [ "$1" == "tinker" ] ; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                php artisan tinker
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy Node commands to the "node" binary on the application container...
+    elif [ "$1" == "node" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                node "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy NPM commands to the "npm" binary on the application container...
+    elif [ "$1" == "npm" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                npm "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy NPX commands to the "npx" binary on the application container...
+    elif [ "$1" == "npx" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                npx "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Proxy YARN commands to the "yarn" binary on the application container...
+    elif [ "$1" == "yarn" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                yarn "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a MySQL CLI terminal session within the "mysql" container...
+    elif [ "$1" == "mysql" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                mysql \
+                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a MySQL CLI terminal session within the "mariadb" container...
+    elif [ "$1" == "mariadb" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                mariadb \
+                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a PostgreSQL CLI terminal session within the "pgsql" container...
+    elif [ "$1" == "psql" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                 pgsql \
+                 bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a Bash shell within the application container...
+    elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                bash "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a root user Bash shell within the application container...
+    elif [ "$1" == "root-shell" ] ; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                "$APP_SERVICE" \
+                bash "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Initiate a Redis CLI terminal session within the "redis" container...
+    elif [ "$1" == "redis" ] ; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                redis \
+                redis-cli
+        else
+            sail_is_not_running
+        fi
+
+    # Share the site...
+    elif [ "$1" == "share" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+            --server-host="$SAIL_SHARE_SERVER_HOST" \
+            --server-port="$SAIL_SHARE_SERVER_PORT" \
+            --auth="$SAIL_SHARE_TOKEN" \
+            --subdomain="$SAIL_SHARE_SUBDOMAIN" \
+            "$@"
+        else
+            sail_is_not_running
+        fi
+
+    # Pass unknown commands to the "docker-compose" binary...
+    else
+        docker-compose "$@"
+    fi
+else
+    docker-compose ps
+fi

--- a/cli/bin/articles
+++ b/cli/bin/articles
@@ -77,23 +77,30 @@ fi
 
 if [ $# -gt 0 ]; then
     # Proxy Composer commands to the "composer" binary on the application container...
-    if [ "$1" == "install" ] || [ "$1" == "update" ] || [ "$1" == "generate-encryption-key" ]; then
+    if [ "$1" == "init" ]; then
 
         docker-compose run \
             "$CLI_SERVICE" \
-            bash -c "composer $1"
+            bash -c "composer update"
+
+    elif [ "$1" == "generate-encryption-key" ]; then
+
+      docker-compose run "$CLI_SERVICE" bash -c "composer generate-encryption-key"
+
+    elif [ "$1" == "install" ] || [ "$1" == "update" ]; then
+
+      docker-compose run \
+          "$CLI_SERVICE" \
+          bash -c "composer config -g http-basic.my.yoast.com token ${COMPOSER_YOAST_TOKEN} && cd wordpress && composer $@"
 
     elif [ "$1" == "wordpress" ]; then
         shift 1
 
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose run \
-                "$CLI_SERVICE" \
-                bash -c "composer config -g http-basic.my.yoast.com token ${COMPOSER_YOAST_TOKEN} && cd wordpress && composer $@"
+        if [ "$1" == "install" ]; then
+          docker-compose run install
         else
-            sail_is_not_running
+          echo "error"
         fi
-
     # Proxy the "test" command to the "php artisan test" Artisan command...
     elif [ "$1" == "test" ]; then
         shift 1

--- a/cli/bin/articles
+++ b/cli/bin/articles
@@ -77,11 +77,11 @@ fi
 
 if [ $# -gt 0 ]; then
     # Proxy Composer commands to the "composer" binary on the application container...
-    if [ "$1" == "install" ] || [ "$1" == "update" ]; then
+    if [ "$1" == "install" ] || [ "$1" == "update" ] || [ "$1" == "generate-encryption-key" ]; then
 
         docker-compose run \
             "$CLI_SERVICE" \
-            bash -c "composer config -g http-basic.my.yoast.com token ${COMPOSER_YOAST_TOKEN} && composer $1"
+            bash -c "composer $1"
 
     elif [ "$1" == "wordpress" ]; then
         shift 1

--- a/cli/bin/articles
+++ b/cli/bin/articles
@@ -18,19 +18,20 @@ case "${UNAMEOUT}" in
 esac
 
 if [ "$MACHINE" == "UNKNOWN" ]; then
-    echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
+    echo "Unsupported operating system [$(uname -s)]. Articles supports macOS, Linux, and Windows (WSL2)." >&2
 
     exit 1
 fi
 
-# Source the ".env" file so Laravel's environment variables are available...
+# Source the ".env" file so our environment variables are available...
 if [ -f ./.env ]; then
     source ./.env
 fi
 
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
-export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export APP_SERVICE=${APP_SERVICE:-"wordpress"}
+export CLI_SERVICE="cli"
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
@@ -75,68 +76,20 @@ else
 fi
 
 if [ $# -gt 0 ]; then
-    # Proxy PHP commands to the "php" binary on the application container...
-    if [ "$1" == "php" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy vendor binary commands on the application container...
-    elif [ "$1" == "bin" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                ./vendor/bin/"$@"
-        else
-            sail_is_not_running
-        fi
-
     # Proxy Composer commands to the "composer" binary on the application container...
-    elif [ "$1" == "composer" ]; then
+    if [ "$1" == "install" ] || [ "$1" == "update" ]; then
+
+        docker-compose run \
+            "$CLI_SERVICE" \
+            bash -c "composer config -g http-basic.my.yoast.com token ${COMPOSER_YOAST_TOKEN} && composer $1"
+
+    elif [ "$1" == "wordpress" ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                composer "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy Artisan commands to the "artisan" binary on the application container...
-    elif [ "$1" == "artisan" ] || [ "$1" == "art" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php artisan "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "debug" command to the "php artisan" binary on the application container with xdebug enabled...
-    elif [ "$1" == "debug" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                -e XDEBUG_SESSION=1 \
-                "$APP_SERVICE" \
-                php artisan "$@"
+            docker-compose run \
+                "$CLI_SERVICE" \
+                bash -c "composer config -g http-basic.my.yoast.com token ${COMPOSER_YOAST_TOKEN} && cd wordpress && composer $@"
         else
             sail_is_not_running
         fi
@@ -146,53 +99,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php artisan test "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "dusk" command to the "php artisan dusk" Artisan command...
-    elif [ "$1" == "dusk" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                -e "APP_URL=http://${APP_SERVICE}" \
-                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
-                "$APP_SERVICE" \
-                php artisan dusk "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "dusk:fails" command to the "php artisan dusk:fails" Artisan command...
-    elif [ "$1" == "dusk:fails" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                -e "APP_URL=http://${APP_SERVICE}" \
-                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
-                "$APP_SERVICE" \
-                php artisan dusk:fails "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a Laravel Tinker session within the application container...
-    elif [ "$1" == "tinker" ] ; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php artisan tinker
+            docker-compose run \
+                "$CLI_SERVICE" \
+                bash -c "cd wordpress && ./vendor/bin/pest"
         else
             sail_is_not_running
         fi
@@ -204,7 +113,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "$CLI_SERVICE" \
                 node "$@"
         else
             sail_is_not_running
@@ -215,9 +124,8 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
+            docker-compose run \
+                "$CLI_SERVICE" \
                 npm "$@"
         else
             sail_is_not_running
@@ -230,57 +138,8 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "$CLI_SERVICE" \
                 npx "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy YARN commands to the "yarn" binary on the application container...
-    elif [ "$1" == "yarn" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                yarn "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a MySQL CLI terminal session within the "mysql" container...
-    elif [ "$1" == "mysql" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                mysql \
-                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a MySQL CLI terminal session within the "mariadb" container...
-    elif [ "$1" == "mariadb" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                mariadb \
-                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a PostgreSQL CLI terminal session within the "pgsql" container...
-    elif [ "$1" == "psql" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                 pgsql \
-                 bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
         else
             sail_is_not_running
         fi
@@ -292,7 +151,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "$CLI_SERVICE" \
                 bash "$@"
         else
             sail_is_not_running
@@ -304,35 +163,8 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                "$APP_SERVICE" \
+                "$CLI_SERVICE" \
                 bash "$@"
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a Redis CLI terminal session within the "redis" container...
-    elif [ "$1" == "redis" ] ; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                redis \
-                redis-cli
-        else
-            sail_is_not_running
-        fi
-
-    # Share the site...
-    elif [ "$1" == "share" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
-            --server-host="$SAIL_SHARE_SERVER_HOST" \
-            --server-port="$SAIL_SHARE_SERVER_PORT" \
-            --auth="$SAIL_SHARE_TOKEN" \
-            --subdomain="$SAIL_SHARE_SUBDOMAIN" \
-            "$@"
         else
             sail_is_not_running
         fi

--- a/cli/bin/articles
+++ b/cli/bin/articles
@@ -105,13 +105,9 @@ if [ $# -gt 0 ]; then
     elif [ "$1" == "test" ]; then
         shift 1
 
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose run \
-                "$CLI_SERVICE" \
-                bash -c "cd wordpress && ./vendor/bin/pest"
-        else
-            sail_is_not_running
-        fi
+        docker-compose run \
+            "$CLI_SERVICE" \
+            bash -c "cd wordpress && ./vendor/bin/pest"
 
     # Proxy Node commands to the "node" binary on the application container...
     elif [ "$1" == "node" ]; then
@@ -130,13 +126,9 @@ if [ $# -gt 0 ]; then
     elif [ "$1" == "npm" ]; then
         shift 1
 
-        if [ "$EXEC" == "yes" ]; then
-            docker-compose run \
-                "$CLI_SERVICE" \
-                npm "$@"
-        else
-            sail_is_not_running
-        fi
+        docker-compose run \
+            "$CLI_SERVICE" \
+            npm "$@"
 
     # Proxy NPX commands to the "npx" binary on the application container...
     elif [ "$1" == "npx" ]; then

--- a/cli/composer.json
+++ b/cli/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "articles/cli",
+  "bin": [
+    "bin/articles"
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,16 @@
     {
       "type": "composer",
       "url": "https://wpackagist.org"
+    },
+    {
+      "type": "path",
+      "url": "./cli"
     }
   ],
+  "require": {
+    "articles/cli": "*"
+  },
+  "minimum-stability": "dev",
   "scripts": {
     "generate-encryption-key": "CDS\\Modules\\Cli\\GenerateEncryptionKey::composerGenerateEncryptionKey"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,35 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4a791f59a22a63a0c5c394cfc91b4340",
+    "packages": [
+        {
+            "name": "articles/cli",
+            "version": "dev-infra/change_apache_port_number",
+            "dist": {
+                "type": "path",
+                "url": "./cli",
+                "reference": "69ae1f9f5cd6992f87127666c52b721b75050d73"
+            },
+            "bin": [
+                "bin/articles"
+            ],
+            "type": "library",
+            "transport-options": {
+                "relative": true
+            }
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "articles/cli",
-            "version": "dev-infra/change_apache_port_number",
+            "version": "dev-feature/add_cli_helper",
             "dist": {
                 "type": "path",
                 "url": "./cli",
@@ -31,5 +31,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,7 @@ services:
 
   cli:
     container_name: cli
+    working_dir: /home/default/project
     depends_on:
       - db
       - wordpress

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,9 +121,6 @@ services:
   cli:
     container_name: cli
     working_dir: /home/default/project
-    depends_on:
-      - db
-      - wordpress
     build: 
       context: .
       dockerfile: .devcontainer/Dockerfile


### PR DESCRIPTION
# Summary | Résumé

A little CLI helper for interacting with the docker-compose environment and cli commands.

## Usage

To get started, run this command once:

```sh
./cli/bin/articles init
```

This will start up a few docker services and install some dependencies.

Now, by default the cli is available at `./vendor/bin/articles` but we recommend adding an alias in your .zshrc file:

```sh
alias articles='[ -f articles ] && bash articles || bash vendor/bin/articles'
```

Now you can run the following commands:

- `articles init`: Prepare or update this CLI
- `articles generate-encryption-key`: Generate Encryption Key
- `articles install`: Install WordPress composer dependencies
- `articles update`: Update WordPress composer dependencies
- `articles wordpress install`: Run wp-cli installer to setup the database, theme, and plugins
- `articles up`: Bring up the full docker-compose environment
- `articles down`: Bring down the full docker-compose environment
- `articles npm install`: Install and build npm dependencies

## Onboarding

A typical onboarding workflow might be:

- Clone this repo
- Configure .env vars (except ENCRYPTION_KEY)
- Run `./cli/bin/articles init`
- Create an alias (see above - you only need to do this once if you put it in your .zshrc or .bash_profile)
- Run `articles generate-encryption-key` and copy that key into your .env file
- Run `articles install` to install WordPress dependencies
- Run `articles npm install` to install and build npm and javascript dependencies
- Run `articles up` to bring up the rest of the environment
- Run `articles wordpress install` to setup your database
- Visit `localhost` and profit!