### PR TITLE
Add exception for WAF managed rule set

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -206,8 +206,8 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     name     = "Custom_LFI_QueryString"
     priority = 3
 
-    override_action {
-      none {}
+    action {
+      block {}
     }
 
     visibility_config {
@@ -249,8 +249,8 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     name     = "Custom_AWSManagedRulesLinuxRuleSet"
     priority = 4
 
-    override_action {
-      none {}
+    action {
+      block {}
     }
 
     visibility_config {
@@ -260,7 +260,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
 
     statement {
-      and_statement {
+      or_statement {
         statement {
           label_match_statement {
             scope = "LABEL"

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -51,136 +51,6 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "Custom_SizeRestrictions_BODY"
-    priority = 10
-    action {
-      block {}
-    }
-
-    visibility_config {
-      sampled_requests_enabled   = true
-      cloudwatch_metrics_enabled = true
-      metric_name                = "Custom_SizeRestrictions_BODY"
-    }
-
-    statement {
-      and_statement {
-        statement {
-          size_constraint_statement {
-            field_to_match {
-              body {}
-            }
-            comparison_operator = "GT"
-            size                = "8192"
-            text_transformation {
-              type     = "NONE"
-              priority = 0
-            }
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "CONTAINS"
-                search_string         = "/wp-admin"
-                text_transformation {
-                  type     = "NONE"
-                  priority = 0
-                }
-              }
-            }
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "CONTAINS"
-                search_string         = "/wp-json"
-                text_transformation {
-                  type     = "NONE"
-                  priority = 0
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  rule {
-    name     = "Custom_CrossSiteScripting_BODY"
-    priority = 11
-    action {
-      block {}
-    }
-
-    visibility_config {
-      sampled_requests_enabled   = true
-      cloudwatch_metrics_enabled = true
-      metric_name                = "Custom_CrossSiteScripting_BODY"
-    }
-
-    statement {
-      and_statement {
-        statement {
-          xss_match_statement {
-            field_to_match {
-              body {}
-            }
-            text_transformation {
-              type     = "NONE"
-              priority = 0
-            }
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "CONTAINS"
-                search_string         = "/wp-admin"
-                text_transformation {
-                  type     = "NONE"
-                  priority = 0
-                }
-              }
-            }
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "CONTAINS"
-                search_string         = "/wp-json"
-                text_transformation {
-                  type     = "NONE"
-                  priority = 0
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  rule {
     name     = "AWSManagedRulesKnownBadInputsRuleSet"
     priority = 2
 
@@ -362,6 +232,136 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
       cloudwatch_metrics_enabled = true
       metric_name                = "AWSManagedRulesAmazonIpReputationList"
       sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "Custom_SizeRestrictions_BODY"
+    priority = 10
+    action {
+      block {}
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "Custom_SizeRestrictions_BODY"
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              body {}
+            }
+            comparison_operator = "GT"
+            size                = "8192"
+            text_transformation {
+              type     = "NONE"
+              priority = 0
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "CONTAINS"
+                search_string         = "/wp-admin"
+                text_transformation {
+                  type     = "NONE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "CONTAINS"
+                search_string         = "/wp-json"
+                text_transformation {
+                  type     = "NONE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  rule {
+    name     = "Custom_CrossSiteScripting_BODY"
+    priority = 11
+    action {
+      block {}
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "Custom_CrossSiteScripting_BODY"
+    }
+
+    statement {
+      and_statement {
+        statement {
+          xss_match_statement {
+            field_to_match {
+              body {}
+            }
+            text_transformation {
+              type     = "NONE"
+              priority = 0
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "CONTAINS"
+                search_string         = "/wp-admin"
+                text_transformation {
+                  type     = "NONE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "CONTAINS"
+                search_string         = "/wp-json"
+                text_transformation {
+                  type     = "NONE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -203,6 +203,43 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
+    name     = "Custom_AWSManagedRulesLinuxRuleSet"
+    priority = 3
+
+    overrid_action {
+      none {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:linux-os:LFI_QueryString"
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "CONTAINS"
+                search_string         = "/wp-admin"
+                text_transformation {
+                  type     = "NONE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  rule {
     name     = "AWSManagedRulesLinuxRuleSet"
     priority = 3
 

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -343,49 +343,49 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
   }
 
-  # rule {
-  #   name     = "AWSManagedRulesAmazonIpReputationList"
-  #   priority = 7
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 8
 
-  #   override_action {
-  #     none {}
-  #   }
+    override_action {
+      none {}
+    }
 
-  #   statement {
-  #     managed_rule_group_statement {
-  #       name        = "AWSManagedRulesAmazonIpReputationList"
-  #       vendor_name = "AWS"
-  #     }
-  #   }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
 
-  #   visibility_config {
-  #     cloudwatch_metrics_enabled = true
-  #     metric_name                = "AWSManagedRulesAmazonIpReputationList"
-  #     sampled_requests_enabled   = true
-  #   }
-  # }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
 
-  # rule {
-  #   name     = "WordpressRateLimit"
-  #   priority = 101
+  rule {
+    name     = "WordpressRateLimit"
+    priority = 101
 
-  #   action {
-  #     block {}
-  #   }
+    action {
+      block {}
+    }
 
-  #   statement {
-  #     rate_based_statement {
-  #       limit              = 10000
-  #       aggregate_key_type = "IP"
-  #     }
-  #   }
+    statement {
+      rate_based_statement {
+        limit              = 10000
+        aggregate_key_type = "IP"
+      }
+    }
 
-  #   visibility_config {
-  #     cloudwatch_metrics_enabled = true
-  #     metric_name                = "WordpressRateLimit"
-  #     sampled_requests_enabled   = true
-  #   }
-  # }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "WordpressRateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
 
   visibility_config {
     cloudwatch_metrics_enabled = true

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -73,8 +73,31 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "Custom_LFI_QueryString"
+    name     = "AWSManagedRulesLinuxRuleSet"
     priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name          = "AWSManagedRulesLinuxRuleSet"
+        vendor_name   = "AWS"
+        excluded_rule = "awswaf:managed:aws:linux-os:LFI_QueryString"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesLinuxRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "Custom_LFI_QueryString"
+    priority = 4
 
     action {
       block {}
@@ -109,38 +132,6 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                 }
               }
             }
-          }
-        }
-      }
-    }
-  }
-
-  rule {
-    name     = "Custom_AWSManagedRulesLinuxRuleSet"
-    priority = 4
-
-    action {
-      block {}
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "Custom_AWSManagedRulesLinuxRuleSet"
-      sampled_requests_enabled   = true
-    }
-
-    statement {
-      or_statement {
-        statement {
-          label_match_statement {
-            scope = "LABEL"
-            key   = "awswaf:managed:aws:linux-os:LFI_URIPath"
-          }
-        }
-        statement {
-          label_match_statement {
-            scope = "LABEL"
-            key   = "awswaf:managed:aws:linux-os:LFI_Cookie"
           }
         }
       }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -125,7 +125,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "Custom_ AWSManagedRulesLinuxRuleSet"
+      metric_name                = "Custom_AWSManagedRulesLinuxRuleSet"
       sampled_requests_enabled   = true
     }
 

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -203,11 +203,17 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "Custom_AWSManagedRulesLinuxRuleSet"
+    name     = "Custom_LFI_QueryString"
     priority = 3
 
-    overrid_action {
+    override_action {
       none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "Custom_LFI_QueryString"
+      sampled_requests_enabled   = true
     }
 
     statement {
@@ -240,30 +246,40 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "AWSManagedRulesLinuxRuleSet"
-    priority = 3
+    name     = "Custom_AWSManagedRulesLinuxRuleSet"
+    priority = 4
 
     override_action {
       none {}
     }
 
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesLinuxRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "AWSManagedRulesLinuxRuleSet"
+      metric_name                = "Custom_ AWSManagedRulesLinuxRuleSet"
       sampled_requests_enabled   = true
+    }
+
+    statement {
+      and_statement {
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:linux-os:LFI_URIPath"
+          }
+        }
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:linux-os:LFI_Cookie"
+          }
+        }
+      }
     }
   }
 
   rule {
     name     = "AWSManagedRulesSQLiRuleSet"
-    priority = 4
+    priority = 5
 
     override_action {
       none {}
@@ -285,7 +301,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesPHPRuleSet"
-    priority = 5
+    priority = 6
 
     override_action {
       none {}
@@ -307,7 +323,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesWordPressRuleSet"
-    priority = 6
+    priority = 7
 
     override_action {
       none {}

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -82,9 +82,11 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
     statement {
       managed_rule_group_statement {
-        name          = "AWSManagedRulesLinuxRuleSet"
-        vendor_name   = "AWS"
-        excluded_rule = "awswaf:managed:aws:linux-os:LFI_QueryString"
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+        excluded_rule {
+          name = "awswaf:managed:aws:linux-os:LFI_QueryString"
+        }
       }
     }
 

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -85,7 +85,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
         name        = "AWSManagedRulesLinuxRuleSet"
         vendor_name = "AWS"
         excluded_rule {
-          name = "awswaf:managed:aws:linux-os:LFI_QueryString"
+          name = "LFI_QueryString"
         }
       }
     }
@@ -129,7 +129,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                 positional_constraint = "CONTAINS"
                 search_string         = "/wp-admin"
                 text_transformation {
-                  type     = "NONE"
+                  type     = "LOWERCASE"
                   priority = 0
                 }
               }


### PR DESCRIPTION
# Summary | Résumé

CloudFront started throwing a 403 error on the WPML installer path. This path is being rejected by a WAF managed ruleset, probably due to the `/` characters towards the end of the querystring

`https://articles.cdssandbox.xyz/daves-test/wp-admin/admin.php?page=sitepress-multilingual-cms/menu/setup.php`

This PR will add an exception to that rule for paths under `/wp-admin`
