### PR TITLE
Scale down Staging database

### DIFF
--- a/infrastructure/terragrunt/aws/database/inputs.tf
+++ b/infrastructure/terragrunt/aws/database/inputs.tf
@@ -3,7 +3,7 @@ variable "database_instances_count" {
 }
 
 variable "database_instance_class" {
-  type = number
+  type = string
 }
 
 variable "database_name" {

--- a/infrastructure/terragrunt/aws/database/inputs.tf
+++ b/infrastructure/terragrunt/aws/database/inputs.tf
@@ -2,7 +2,7 @@ variable "database_instances_count" {
   type = number
 }
 
-variable "database_instances_class" {
+variable "database_instance_class" {
   type = number
 }
 

--- a/infrastructure/terragrunt/aws/database/inputs.tf
+++ b/infrastructure/terragrunt/aws/database/inputs.tf
@@ -2,6 +2,10 @@ variable "database_instances_count" {
   type = number
 }
 
+variable "database_instances_class" {
+  type = number
+}
+
 variable "database_name" {
   type      = string
   sensitive = true

--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -2,19 +2,20 @@
 # RDS MySQL cluster across 3 subnets
 #
 module "rds_cluster" {
-  source = "github.com/cds-snc/terraform-modules?ref=v0.0.33//rds"
+  source = "github.com/cds-snc/terraform-modules?ref=v0.0.47//rds"
   name   = "wordpress"
 
   database_name  = var.database_name
   engine         = "aurora-mysql"
   engine_version = "5.7.mysql_aurora.2.10.0"
   instances      = var.database_instances_count
-  instance_class = "db.r4.large"
+  instance_class = var.database_instance_class
   username       = var.database_username
   password       = var.database_password
 
-  backup_retention_period = 14
-  preferred_backup_window = "02:00-04:00"
+  backup_retention_period      = 14
+  preferred_backup_window      = "02:00-04:00"
+  performance_insights_enabled = false
 
   vpc_id     = var.vpc_id
   subnet_ids = var.private_subnet_ids

--- a/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
@@ -19,6 +19,7 @@ dependency "network" {
 
 inputs = {
   database_instances_count = 3
+  database_instance_class = "db.r4.large"
   private_subnet_ids       = dependency.network.outputs.private_subnet_ids
   vpc_id                   = dependency.network.outputs.vpc_id
 }

--- a/infrastructure/terragrunt/env/staging/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/database/terragrunt.hcl
@@ -19,6 +19,7 @@ dependency "network" {
 
 inputs = {
   database_instances_count = 2
+  database_instance_class = "db.t3.small"
   private_subnet_ids       = dependency.network.outputs.private_subnet_ids
   vpc_id                   = dependency.network.outputs.vpc_id
 }


### PR DESCRIPTION
# Summary | Résumé

Scales down the Staging database cluster, and parameterizes instance_class so we can have different settings for staging/production.

cds-snc/gc-articles-issues#116