### PR TITLE
Add ECS placement strategy

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -124,6 +124,11 @@ resource "aws_ecs_service" "wordpress_service" {
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
 
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
   deployment_controller {
     type = "ECS"
   }


### PR DESCRIPTION
# Summary | Résumé

Re: cds-snc/gc-articles-issues#3

Adds an ECS placement strategy set so that the ECS tasks are spread evenly across the Virtual Private Cloud (VPC) availability zones
