### PR TITLE
Revert placement strategy

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -124,11 +124,6 @@ resource "aws_ecs_service" "wordpress_service" {
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
 
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "attribute:ecs.availability-zone"
-  }
-
   deployment_controller {
     type = "ECS"
   }


### PR DESCRIPTION
# Summary | Résumé

Just reverting the failed change from #418 - Placement strategies are not supported on Fargate.
