### PR TITLE
[Hotfix] Don't require WPML for login page

### DIFF
--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -9,7 +9,7 @@ describe('Login', () => {
     cy.visit("/login");
 
     cy.get("#login h1 a").should("have.text", "Canadian Digital Service");
-    cy.get('#login h1 a').should('have.css', 'background-image', 'url("'+host+'/wp-content/plugins/cds-base/images/site-login-logo-fr.svg")')
+    cy.get('#login h1 a').should('have.css', 'background-image', 'url("'+host+'/wp-content/plugins/cds-base/images/site-login-logo.svg")')
     cy.get('.login form label').should('have.css', 'font-size', '16px')
   });
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
@@ -4,8 +4,14 @@ namespace CDS\Modules\Cleanup;
 
 class Login
 {
+    public string $lang;
+
     public function __construct()
     {
+        $this->lang = defined('ICL_LANGUAGE_CODE')
+            ? (ICL_LANGUAGE_CODE === 'fr' ? 'fr' : 'en')
+            : '';
+
         add_action('login_enqueue_scripts', [$this, 'loginLogo']);
         add_filter('login_headerurl', [$this, 'loginLogoUrl']);
         add_filter('login_headertext', [$this, 'customizeLoginHeaderText']);
@@ -19,7 +25,7 @@ class Login
 
     public function loginLogo(): void
     {
-        $logoPath = ICL_LANGUAGE_CODE === 'en' ? 'site-login-logo.svg' : 'site-login-logo-fr.svg';
+        $logoPath = $this->lang === 'fr' ? 'site-login-logo-fr.svg' : 'site-login-logo.svg';
         ?>
       <style>
           .login *, .login form label, .login form .button.button-large {
@@ -61,25 +67,28 @@ class Login
       </style>
     <?php }
 
-    public function addLangLink($message)
+    public function addLangLink($message): string
     {
-        $frPrefix = '/fr';
-        $loginPath = parse_url(wp_login_url(), PHP_URL_PATH);
-        $switchLangPath = str_starts_with($loginPath, $frPrefix) ?
-            str_replace($frPrefix, '', $loginPath) :
-            $frPrefix . $loginPath;
+        if (!empty($this->lang)) {
+            $frPrefix = '/fr';
+            $loginPath = parse_url(wp_login_url(), PHP_URL_PATH);
+            $switchLangPath = str_starts_with($loginPath, $frPrefix) ?
+                str_replace($frPrefix, '', $loginPath) :
+                $frPrefix . $loginPath;
 
-        $switchLangText = ICL_LANGUAGE_CODE === 'en' ? 'Français' : 'English';
-        $switchLangAttr = ICL_LANGUAGE_CODE === 'en' ? 'fr' : 'en';
+            $switchLangText = $this->lang === 'fr' ? 'English' : 'Français';
+            $switchLangAttr = $this->lang === 'fr' ? 'en' : 'fr';
 
-        $switchLangLink = sprintf(
-            '<div class="switch-lang"><a lang="%s" href="%s">%s</a></div>',
-            $switchLangAttr,
-            esc_url_raw($switchLangPath),
-            $switchLangText
-        );
+            $switchLangLink = sprintf(
+                '<div class="switch-lang"><a lang="%s" href="%s">%s</a></div>',
+                $switchLangAttr,
+                esc_url_raw($switchLangPath),
+                $switchLangText
+            );
 
-        return $switchLangLink . $message;
+            return $switchLangLink . $message;
+        }
+        return '';
     }
 
     public function loginLogoUrl(): string


### PR DESCRIPTION
# Summary | Résumé

Previously, the login page was breaking for my wp-env environment because I presumed WPML was installed in  https://github.com/cds-snc/gc-articles/pull/414.
If WPML isn't installed, the constant `ICL_LANGUAGE_CODE` doesn't exist, so we have to check that it's defined before we reference it.

This PR makes sure it is defined before using it. If not defined, use the english logo and don't show a language link.

| before | after |
|--------|-------|
|    oops    |   all good 👌     |
|  <img width="744" alt="Screen Shot 2021-12-20 at 09 25 33" src="https://user-images.githubusercontent.com/2454380/146782520-58c03ce8-adf5-4d38-a1ad-15710397d57d.png">   |  <img width="744" alt="Screen Shot 2021-12-20 at 09 25 54" src="https://user-images.githubusercontent.com/2454380/146782527-8cc5e33b-3bc7-411f-842b-879a260fe717.png">  |

