### PR TITLE
Fix FR link the login screen

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
@@ -79,9 +79,17 @@ class Login
         if (!empty($lang)) {
             $frPrefix = '/fr';
             $loginPath = parse_url(wp_login_url(), PHP_URL_PATH);
-            $switchLangPath = str_starts_with($loginPath, $frPrefix) ?
-                str_replace($frPrefix, '', $loginPath) :
-                $frPrefix . $loginPath;
+
+            if (str_contains($loginPath, $frPrefix)) {
+                // there is a french prefix, remove it
+                $switchLangPath = str_replace($frPrefix, '', $loginPath);
+            } else {
+                // no french prefix, add it as the second-last url item
+                $pathParts = explode('/', rtrim($loginPath, '/'));
+                $loginPart = array_pop($pathParts);
+                array_push($pathParts, ltrim($frPrefix, '/'), $loginPart);
+                $switchLangPath = (implode("/", $pathParts));
+            }
 
             $switchLangText = $lang === 'fr' ? 'English' : 'Français';
             $switchLangAttr = $lang === 'fr' ? 'en' : 'fr';


### PR DESCRIPTION
# Summary

This PR fixes two behaviours:
1. When the login link shows up on the login page
2. How the login link is generated

## 1. When the login link shows up

The last fix I shipped would set the language value _when the class was constructed_, but this would be before WPML was set up, so it would always say there were no additional languages.

Now, is called after the plugins have been initiated, and it will look for:
- the existence of WPML functions and constants
- make sure that 'fr' is a language option (otherwise, WPML could exist but not be initiated)

## 2. How the login link is generated

The old logic was naive: it would just prepend or remove the `login_url` with `fr/`. Unfortunately, this didn't work for multisites. Multisites have a path prefix, so the french link needs to go _after_ their path prefix. 

If I had a multisite called `new-site`, this is what I would get:
- Previous FR login link (wrong): `/fr/new-site/login`
- Current FR login link (right): `/new-site/fr/login`

## Testing

I have tested this in lots of scenarios now:
1. On localhost, with Multisite and WPML set up
2. On a localhost new site, with WPML installed but not activated
3. On a localhost new site, with WPML installed *and* activated
2. On a new wp-env, with CDS-base activated but no WPML
3. On a new wp-env, with CDS-base activated and WPML activated up but _not_ configured

Seems to work across all of them, and cypress tests are green.