### PR TITLE
Add s3 uploads url through environment

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -50,6 +50,10 @@
         "value": "${DEFAULT_DOMAIN}"
       },
       {
+        "name": "S3_UPLOADS_BUCKET_URL",
+        "value": "${S3_UPLOADS_BUCKET_URL}"
+      },
+      {
         "name": "WORDPRESS_CONFIG_EXTRA",
         "value": "${WORDPRESS_CONFIG_EXTRA}"
       }

--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -51,6 +51,7 @@ data "template_file" "wordpress_container_definition" {
     S3_UPLOADS_BUCKET            = aws_secretsmanager_secret_version.s3_uploads_bucket.arn
     S3_UPLOADS_KEY               = aws_secretsmanager_secret_version.s3_uploads_key.arn
     S3_UPLOADS_SECRET            = aws_secretsmanager_secret_version.s3_uploads_secret.arn
+    S3_UPLOADS_BUCKET_URL        = "https://${var.domain_name}"
     DEFAULT_DOMAIN               = var.domain_name
     WORDPRESS_IMAGE              = "${var.wordpress_image}:${var.wordpress_image_tag}"
     APACHE_IMAGE                 = "${var.apache_image}:${var.apache_image_tag}"

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -139,7 +139,7 @@ define('S3_UPLOADS_REGION', getenv_docker('S3_UPLOADS_REGION', 'ca-central-1'));
 define('S3_UPLOADS_KEY', getenv_docker('S3_UPLOADS_KEY', ''));
 define('S3_UPLOADS_SECRET', getenv_docker('S3_UPLOADS_SECRET', ''));
 define('S3_UPLOADS_OBJECT_ACL', 'private');
-define('S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz');
+define('S3_UPLOADS_BUCKET_URL', getenv_docker('S3_UPLOADS_BUCKET_URL', 'https://articles.cdssandbox.xyz'));
 
 define('OTGS_DISABLE_AUTO_UPDATES', true);
 define('WP_AUTO_UPDATE_CORE', false);


### PR DESCRIPTION
# Summary | Résumé

When we rolled out the S3 Uploads, we defaulted the S3_UPLOADS_BUCKET_URL to the staging url. This loads that property from the environment, set based on the var domain_name.