### PR TITLE
Add Workflow to build and push Production container

### DIFF
--- a/.github/workflows/build_push_prod_container.yml
+++ b/.github/workflows/build_push_prod_container.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.release.tag_name }} # @TODO: apply same to staging build-push?
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Configure AWS credentials
         id: aws-creds

--- a/.github/workflows/build_push_prod_container.yml
+++ b/.github/workflows/build_push_prod_container.yml
@@ -1,0 +1,63 @@
+name: Build and push Production container
+
+on:
+  release:
+    types:
+      - created
+
+env:
+  DOCKER_BUILDKIT: 1
+  REPO_NAME: platform/wordpress
+  PRODUCTION_ECR_REGISTRY: 472286471787.dkr.ecr.ca-central-1.amazonaws.com
+
+jobs:
+  build-push-prod-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }} # @TODO: apply same to staging build-push?
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker image tag
+        run: |
+          if [[ $GITHUB_EVENT_NAME == "release" ]]; then
+            echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=sha-${GITHUB_SHA}" >> $GITHUB_ENV
+          fi
+
+      - name: Add Composer auth credentials
+        run: |
+          cd wordpress
+          composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+          composer config http-basic.my.yoast.com token ${{ secrets.COMPOSER_YOAST_TOKEN }}
+
+      - name: Build container
+        run: |
+          docker build \
+          --build-arg git_sha="$GITHUB_SHA" \
+          --build-arg WPML_USER_ID="${{ secrets.WPML_USER_ID }}" \
+          --build-arg WPML_KEY="${{ secrets.WPML_KEY }}" \
+          -t "${{ env.PRODUCTION_ECR_REGISTRY }}/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}" \
+          -f ./wordpress/docker/production.Dockerfile .
+
+      - name: Push containers to ECR
+        run: |
+          docker push ${{ env.PRODUCTION_ECR_REGISTRY }}/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
+
+      - name: Logout of ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
# Summary | Résumé

Adds a workflow to build and push a tagged container to our Production ECR when a release is created.

Main differences between this workflow and the staging workflow:
- Only runs on release:created
- Checks out the git repo at the tag created during the release
- Pushes to Production ECR (obviously)