### PR TITLE
Fix for setting default theme

### DIFF
--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -104,7 +104,7 @@ $table_prefix = getenv_docker('WORDPRESS_TABLE_PREFIX', 'wp_');
  * @link https://wordpress.org/support/article/debugging-in-wordpress/
  */
 
-define('WP_DEFAULT_THEME', !!getenv_docker('WP_DEFAULT_THEME', 'cds-default'));
+define('WP_DEFAULT_THEME', getenv_docker('WP_DEFAULT_THEME', 'cds-default'));
 
 define('WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', ''));
 define('WP_DEBUG_DISPLAY', !!getenv_docker('WORDPRESS_DEBUG_DISPLAY', 0));


### PR DESCRIPTION
We were unintentionally casting the default theme name to a boolean, which is why it wasn't getting set properly.

Removing the double negation operator and it works for me locally. Pretty sure it will work in staging/prod as well.

Resolves https://github.com/cds-snc/gc-articles-issues/issues/185