### PR TITLE
Load env file for composer action

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
   composer:
     restart: 'no'
     image: composer/composer:latest
+    env_file: .env
     command: >
       /bin/bash -c '
       composer config -g http-basic.my.yoast.com token ${COMPOSER_YOAST_TOKEN};


### PR DESCRIPTION
# Summary | Résumé

Fixes a bug where the env file wasn't being loaded for the composer install action in docker-compose.
