### PR TITLE
Hide default maple leaf if a default icon is set (and stop goofy CSS)

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminStyles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminStyles.php
@@ -9,6 +9,7 @@ class AdminStyles
     public function __construct()
     {
         add_action('admin_enqueue_scripts', [$this, 'enqueueStyles'], 99);
+        add_action('admin_head', [$this, 'gutenbergIconCSS'], 99);
     }
 
     public function enqueueStyles()
@@ -27,5 +28,32 @@ class AdminStyles
             [],
             BASE_PLUGIN_NAME_VERSION,
         );
+    }
+
+    public function gutenbergIconCSS()
+    {
+        ob_start();
+        ?>
+        <style>
+            .edit-post-fullscreen-mode-close.has-icon svg,
+            .edit-post-fullscreen-mode-close.has-icon img {
+                display:none;
+            }
+
+            .edit-post-fullscreen-mode-close.has-icon:before {
+                display: inline-block;
+            }
+        </style>
+        <?php
+
+        $show_maple_leaf_css = ob_get_clean();
+        ob_end_clean();
+
+        $hasIcon = get_site_icon_url() !== "";
+
+        if (!$hasIcon) {
+            // If there is an icon, show the default maple leaf and hide the WP logo
+            echo $show_maple_leaf_css;
+        }
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -207,7 +207,7 @@ input[type='week'] {
 }
 
 .edit-post-fullscreen-mode-close.has-icon:before {
-  display: inline-block;
+  display: none;
   font-family: 'cds';
   content: '\0041';
   color:#f8eae9;
@@ -221,8 +221,18 @@ input[type='week'] {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.edit-post-fullscreen-mode-close.has-icon svg{
+.edit-post-fullscreen-mode-close.has-icon svg {
   display:none;
+}
+
+.edit-post-fullscreen-mode-close.has-icon img {
+  transform: none !important;
+  border-radius: 3px !important;
+}
+
+.edit-post-fullscreen-mode-close.has-icon img:hover {
+  outline: 2px solid #757575;
+  outline-offset: 2px;
 }
 
 th.column-disable_user_login {


### PR DESCRIPTION
# Summary | Résumé

Small PR that hides the maple leaf icon if the blog has an 'icon' configured. If not, we show the maple leaf.
Also, stop that dumb transition effect where the image doubles in size, replace it with an outline so that it looks like what the maple leaf was doing.

## gifs

### Before

The image would be loaded _behind_ the maple leaf icon, but then overlap it and grow to twice the size when it was hovered. It looked obviously bad.

| red maple leaf logo | blue maple leaf logo |
|--------|-------|
| ![Screen Recording 2021-12-22 at 10 25 09](https://user-images.githubusercontent.com/2454380/147279347-92f6d9a9-0db7-413e-aa05-1eecd9a18bf7.gif)  |  ![Screen Recording 2021-12-23 at 11 23 55](https://user-images.githubusercontent.com/2454380/147279352-ed401251-f5ac-4565-8293-63d964178f7d.gif)  |


### After

Now the image stays the same size and has an outline, like the white maple leaf icon does (default if no icon is set).

| with 'icon' set | if no 'icon' set (same as we have now) |
|--------|-------|
|  ![Screen Recording 2021-12-23 at 11 15 51](https://user-images.githubusercontent.com/2454380/147279581-fc43802a-9366-4bbe-b81e-e3cf1f2aa841.gif)  |  ![Screen Recording 2021-12-23 at 11 16 08](https://user-images.githubusercontent.com/2454380/147279584-f0e0d5b3-9f0e-435f-9982-b4f3eb2cdcf1.gif)   |


