### PR TITLE
Enable production workflows

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -1,13 +1,11 @@
 name: "Terragrunt apply PRODUCTION"
 
-# on:
-#  push:
-#    branches:
-#      - main
-#    paths:
-#      - "infrastructure/VERSION"
-
-on: workflow_dispatch
+ on:
+  push:
+    branches:
+      - main
+    paths:
+      - "infrastructure/VERSION"
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -1,6 +1,6 @@
 name: "Terragrunt apply PRODUCTION"
 
- on:
+on:
   push:
     branches:
       - main

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -1,13 +1,11 @@
 name: "Terragrunt plan PRODUCTION"
 
-# on:
-#  pull_request:
-#    branches:
-#      - main
-#    paths:
-#      - "infrastructure/VERSION"
-
-on: workflow_dispatch
+ on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "infrastructure/VERSION"
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -1,6 +1,6 @@
 name: "Terragrunt plan PRODUCTION"
 
- on:
+on:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# Summary | Résumé

In the previous Workflows PR #419, had to disable the production workflows until some of the workflow files were in place - chicken/egg and all that. This just re-enables them.
