### PR TITLE
Add cache buster IAM user and policy

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -150,3 +150,31 @@ resource "aws_cloudfront_distribution" "wordpress" {
     (var.billing_tag_key) = var.billing_tag_value
   }
 }
+
+resource "aws_iam_user" "cache_buster" {
+  name = "cache_buster"
+}
+
+resource "aws_iam_user_policy" "cache_buster" {
+  name = "cache_buster"
+  user = aws_iam_user.cache_buster.name
+
+  #checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "cloudfront:GetDistribution",
+          "cloudfront:ListInvalidations",
+          "cloudfront:GetStreamingDistribution",
+          "cloudfront:GetDistributionConfig",
+          "cloudfront:GetInvalidation",
+          "cloudfront:CreateInvalidation"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "${aws_cloudfront_distribution.wordpress.arn}"
+      }
+    ]
+  })
+}

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -172,7 +172,8 @@ data "aws_iam_policy_document" "cache_buster" {
 }
 
 resource "aws_iam_policy" "cache_buster" {
-  name   = "cache_buster"
+  name = "cache_buster"
+  #checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
   policy = data.aws_iam_policy_document.cache_buster.json
 }
 

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -176,8 +176,8 @@ resource "aws_iam_policy" "cache_buster" {
   policy = data.aws_iam_policy_document.cache_buster.json
 }
 
-#checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
 resource "aws_iam_user_policy_attachment" "cache_buster" {
+  #checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
   user       = aws_iam_user.cache_buster.name
   policy_arn = aws_iam_policy.cache_buster.arn
 }

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -155,25 +155,28 @@ resource "aws_iam_user" "cache_buster" {
   name = "cache_buster"
 }
 
-resource "aws_iam_user_policy" "cache_buster" {
-  name = "cache_buster"
-  user = aws_iam_user.cache_buster.name
-
-  #checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Action" : [
-          "cloudfront:GetDistribution",
-          "cloudfront:ListInvalidations",
-          "cloudfront:GetDistributionConfig",
-          "cloudfront:GetInvalidation",
-          "cloudfront:CreateInvalidation"
-        ],
-        "Effect" : "Allow",
-        "Resource" : "${aws_cloudfront_distribution.wordpress.arn}"
-      }
+data "aws_iam_policy_document" "cache_buster" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudfront:GetDistribution",
+      "cloudfront:ListInvalidations",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:GetInvalidation",
+      "cloudfront:CreateInvalidation"
     ]
-  })
+    resources = [
+      aws_cloudfront_distribution.wordpress.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cache_buster" {
+  name   = "cache_buster"
+  policy = data.aws_iam_policy_document.cache_buster.json
+}
+
+resource "aws_iam_user_policy_attachment" "cache_buster" {
+  user       = aws_iam_user.cache_buster.name
+  policy_arn = aws_iam_policy.cache_buster.arn
 }

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -172,11 +172,11 @@ data "aws_iam_policy_document" "cache_buster" {
 }
 
 resource "aws_iam_policy" "cache_buster" {
-  name = "cache_buster"
-  #checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
+  name   = "cache_buster"
   policy = data.aws_iam_policy_document.cache_buster.json
 }
 
+#checkov:skip=CKV_AWS_40:This is a one-off user for cache-busting plugin
 resource "aws_iam_user_policy_attachment" "cache_buster" {
   user       = aws_iam_user.cache_buster.name
   policy_arn = aws_iam_policy.cache_buster.arn

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -167,7 +167,6 @@ resource "aws_iam_user_policy" "cache_buster" {
         "Action" : [
           "cloudfront:GetDistribution",
           "cloudfront:ListInvalidations",
-          "cloudfront:GetStreamingDistribution",
           "cloudfront:GetDistributionConfig",
           "cloudfront:GetInvalidation",
           "cloudfront:CreateInvalidation"


### PR DESCRIPTION
# Summary | Résumé

Adds the necessary infra changes (IAM user and policy) to support the cache invalidation plugin to be added in #436.