### PR TITLE
Wordpress to version 5.8.3

### DIFF
--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.8.2-php8.0-fpm-alpine
+FROM wordpress:5.8.3-php8.0-fpm-alpine
 
 WORKDIR /usr/src/wordpress
 

--- a/wordpress/docker/production.Dockerfile
+++ b/wordpress/docker/production.Dockerfile
@@ -23,7 +23,7 @@ RUN npm --unsafe-perm install
 
 ## Release build
 
-FROM wordpress:5.8.2-php8.0-fpm-alpine
+FROM wordpress:5.8.3-php8.0-fpm-alpine
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \


### PR DESCRIPTION
# Summary | Résumé

Wordpress 5.8.3 was released January 6 and includes a few [security updates](https://wordpress.org/support/wordpress-version/version-5-8-3/#security-updates)

**Will need to hold this until the Docker image is available: https://hub.docker.com/_/wordpress**