### PR TITLE
Configure c3 to clear json routes

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -60,6 +60,10 @@
     {
       "type": "path",
       "url": "wp-content/themes/cds-default"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/amimoto-ami/c3-cloudfront-clear-cache"
     }
   ],
   "require": {
@@ -77,7 +81,7 @@
     "cds-snc/cds-default": "dev-main",
     "yoast/wordpress-seo-premium": "^17.7",
     "wpackagist-plugin/wp-rest-api-v2-menus":"0.10",
-    "wpackagist-plugin/c3-cloudfront-clear-cache": "^6.1"
+    "digitalcube/c3-cloudfront-clear-cache": "dev-master"
   },
   "require-dev": {
     "pestphp/pest": "^1.16",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fcd81abbb72f56852c606985d6a7a08",
+    "content-hash": "226da1fedc2ca1f7b85e824665329c21",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -115,16 +115,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.208.10",
+            "version": "3.209.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a7802ac9289e0c4de2c76cfe0ea0f11f72955754"
+                "reference": "34afa064da0bf2816640b91b7e376ee781cded42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a7802ac9289e0c4de2c76cfe0ea0f11f72955754",
-                "reference": "a7802ac9289e0c4de2c76cfe0ea0f11f72955754",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/34afa064da0bf2816640b91b7e376ee781cded42",
+                "reference": "34afa064da0bf2816640b91b7e376ee781cded42",
                 "shasum": ""
             },
             "require": {
@@ -200,9 +200,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.208.10"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.209.0"
             },
-            "time": "2022-01-05T19:19:54+00:00"
+            "time": "2022-01-06T19:13:57+00:00"
         },
         {
             "name": "brick/math",
@@ -608,6 +608,60 @@
                 }
             ],
             "time": "2021-09-13T08:19:44+00:00"
+        },
+        {
+            "name": "digitalcube/c3-cloudfront-clear-cache",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amimoto-ami/c3-cloudfront-clear-cache.git",
+                "reference": "6ef006eac0cd28d3a6b6f97973701832750ba3bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amimoto-ami/c3-cloudfront-clear-cache/zipball/6ef006eac0cd28d3a6b6f97973701832750ba3bd",
+                "reference": "6ef006eac0cd28d3a6b6f97973701832750ba3bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "phpcompatibility/phpcompatibility-wp": "*",
+                "phpunit/phpunit": "7.5.20",
+                "squizlabs/php_codesniffer": "*",
+                "wp-coding-standards/wpcs": "*",
+                "wp-phpunit/wp-phpunit": "5.7.2"
+            },
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "C3_CloudFront_Cache_Controller\\": "classes/",
+                    "C3_CloudFront_Cache_Controller\\WP\\": "classes/WP/",
+                    "C3_CloudFront_Cache_Controller\\Test\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "format": [
+                    "phpcbf --standard=./.phpcs.xml.dist --report-summary --report-source"
+                ],
+                "lint": [
+                    "phpcs --standard=./.phpcs.xml.dist"
+                ],
+                "phpcs": [
+                    "phpcs --standard=./.phpcs.xml.dist"
+                ]
+            },
+            "support": {
+                "source": "https://github.com/amimoto-ami/c3-cloudfront-clear-cache/tree/master",
+                "issues": "https://github.com/amimoto-ami/c3-cloudfront-clear-cache/issues"
+            },
+            "time": "2021-11-02T01:11:10+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -3716,24 +3770,6 @@
             "time": "2019-11-22T09:50:29+00:00"
         },
         {
-            "name": "wpackagist-plugin/c3-cloudfront-clear-cache",
-            "version": "6.1.2",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/c3-cloudfront-clear-cache/",
-                "reference": "trunk"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/c3-cloudfront-clear-cache.zip?timestamp=1625553267"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/c3-cloudfront-clear-cache/"
-        },
-        {
             "name": "wpackagist-plugin/disable-user-login",
             "version": "1.3.2",
             "source": {
@@ -4371,16 +4407,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.14.4",
+            "version": "2.14.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "f056f1fe935d9ed86e698905a957334029899895"
+                "reference": "a63e5e8f26ebbebf8ed3c5c691637325512eb0dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/f056f1fe935d9ed86e698905a957334029899895",
-                "reference": "f056f1fe935d9ed86e698905a957334029899895",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a63e5e8f26ebbebf8ed3c5c691637325512eb0dc",
+                "reference": "a63e5e8f26ebbebf8ed3c5c691637325512eb0dc",
                 "shasum": ""
             },
             "require": {
@@ -4430,7 +4466,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.14.4"
+                "source": "https://github.com/filp/whoops/tree/2.14.5"
             },
             "funding": [
                 {
@@ -4438,7 +4474,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-03T12:00:00+00:00"
+            "time": "2022-01-07T12:00:00+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -7390,7 +7426,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "cds-snc/cds-base": 20,
-        "cds-snc/cds-default": 20
+        "cds-snc/cds-default": 20,
+        "digitalcube/c3-cloudfront-clear-cache": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -10,9 +10,9 @@ class Cache
     {
         $instance = new self();
 
-        add_filter( 'c3_invalidation_items', function($items, $post) {
+        add_filter('c3_invalidation_items', function ($items, $post) {
             global $blog_id;
-            $site = get_blog_details( array( 'blog_id' => $blog_id ) );
+            $site = get_blog_details(array( 'blog_id' => $blog_id ));
             $sitePrefix = $site->path;
 
             return array_merge($items, [

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -6,16 +6,40 @@ namespace CDS\Modules\Cache;
 
 class Cache
 {
+    const locale_fr = 'fr_FR';
+
     public static function register()
+    {
+        $instance = new self();
+
+        $instance->registerInvalidationPaths();
+    }
+
+    protected function registerInvalidationPaths()
     {
         add_filter('c3_invalidation_items', function ($items, $post) {
             global $blog_id;
-            $site = get_blog_details(array( 'blog_id' => $blog_id ));
+            $site       = get_blog_details(array('blog_id' => $blog_id));
             $sitePrefix = $site->path;
 
+            $localePrefix = $this->getLocalePrefixForPost($post);
+
             return array_merge($items, [
-                "{$sitePrefix}wp-json/wp/v2/{$post->post_type}s/?slug={$post->post_name}",
+                "{$sitePrefix}{$localePrefix}wp-json/wp/v2/{$post->post_type}s/?slug={$post->post_name}",
             ]);
         }, 10, 2);
+    }
+
+    protected function getLocalePrefixForPost($post): string
+    {
+        if($language_information = apply_filters('wpml_post_language_details', null, $post->ID)) {
+            $locale = $language_information['locale'];
+
+            if ($locale === self::locale_fr) {
+                return 'fr/';
+            }
+        }
+
+        return '';
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -11,8 +11,12 @@ class Cache
         $instance = new self();
 
         add_filter( 'c3_invalidation_items', function($items, $post) {
+            global $blog_id;
+            $site = get_blog_details( array( 'blog_id' => $blog_id ) );
+            $sitePrefix = $site->path;
+
             return array_merge($items, [
-                "/site-name/wp-json/wp/v2/" . $post->post_name
+                "{$sitePrefix}wp-json/wp/v2/{$post->post_type}s/?slug={$post->post_name}",
             ]);
         }, 10, 2);
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Cache;
+
+class Cache
+{
+    public static function register()
+    {
+        $instance = new self();
+
+        add_filter( 'c3_invalidation_items', function($items, $post) {
+            return array_merge($items, [
+                "/site-name/wp-json/wp-v2/" . $post->post_name
+            ]);
+        }, 10, 2);
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -8,8 +8,6 @@ class Cache
 {
     public static function register()
     {
-        $instance = new self();
-
         add_filter('c3_invalidation_items', function ($items, $post) {
             global $blog_id;
             $site = get_blog_details(array( 'blog_id' => $blog_id ));

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -6,7 +6,7 @@ namespace CDS\Modules\Cache;
 
 class Cache
 {
-    const locale_fr = 'fr_FR';
+    const LOCALE_FR = 'fr_FR';
 
     public static function register()
     {
@@ -38,10 +38,10 @@ class Cache
 
     protected function getLocalePrefixForPost($post): string
     {
-        if($language_information = apply_filters('wpml_post_language_details', null, $post->ID)) {
+        if ($language_information = apply_filters('wpml_post_language_details', null, $post->ID)) {
             $locale = $language_information['locale'];
 
-            if ($locale === self::locale_fr) {
+            if ($locale === self::LOCALE_FR) {
                 return 'fr/';
             }
         }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -12,7 +12,7 @@ class Cache
 
         add_filter( 'c3_invalidation_items', function($items, $post) {
             return array_merge($items, [
-                "/site-name/wp-json/wp-v2/" . $post->post_name
+                "/site-name/wp-json/wp/v2/" . $post->post_name
             ]);
         }, 10, 2);
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -18,16 +18,22 @@ class Cache
     protected function registerInvalidationPaths()
     {
         add_filter('c3_invalidation_items', function ($items, $post) {
-            global $blog_id;
-            $site       = get_blog_details(array('blog_id' => $blog_id));
-            $sitePrefix = $site->path;
 
+            $sitePrefix = $this->getSitePrefixForPost();
             $localePrefix = $this->getLocalePrefixForPost($post);
 
             return array_merge($items, [
                 "{$sitePrefix}{$localePrefix}wp-json/wp/v2/{$post->post_type}s/?slug={$post->post_name}",
             ]);
         }, 10, 2);
+    }
+
+    protected function getSitePrefixForPost(): string
+    {
+        global $blog_id;
+        $site = get_blog_details(array('blog_id' => $blog_id));
+
+        return $site->path;
     }
 
     protected function getLocalePrefixForPost($post): string

--- a/wordpress/wp-content/plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Setup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CDS;
 
+use CDS\Modules\Cache\Cache;
 use CDS\Modules\Cleanup\Wpml;
 use CDS\Modules\EncryptedOption\EncryptedOption;
 use CDS\Modules\Blocks\Blocks;
@@ -60,6 +61,7 @@ class Setup
         DBInsights::register();
         Releases::register();
         SiteSettings::register();
+        Cache::register();
 
         new SubscriptionForm();
         new ContactForm();


### PR DESCRIPTION
# Summary | Résumé

Adds configuration for C3 Cloudfront Cache Controller plugin to invalidate cached API routes in addition to the default routes.

The option to customize invalidation paths has not been released yet, so this PR also pulls in the plugin from dev-master. This is not ideal, but hopefully they'll release an updated version soon.

For pages, the invalidation looks like:

```
/[site-prefix]/wp-json/wp/v2/pages/?slug=[page-slug]
/[site-prefix]/
/[site-prefix]/[page-slug]/*
```
or
```
/[site-prefix]/fr/[page-slug]/*
/[site-prefix]/fr/wp-json/wp/v2/pages/?slug=[page-slug]
/[site-prefix]/fr/
```
For posts, the invalidation looks like:

```
/[site-prefix]/
/[site-prefix]/category/uncategorized/*
/[site-prefix]/wp-json/wp/v2/posts/?slug=[page-slug]
/[site-prefix]/2021/12/22/[page-slug]/*
```
or
```
/[site-prefix]/fr/2021/12/22/[page-slug]/*
/[site-prefix]/fr/
/[site-prefix]/fr/category/non-classifiee/*
/[site-prefix]/fr/wp-json/wp/v2/posts/?[page-slug]
```

If there is no site-prefix (ie, for the base site), it's just left off.