### PR TITLE
feat: enable PR triggered a11y and weekly security scans

### DIFF
--- a/.github/workflows/build_push_container.yml
+++ b/.github/workflows/build_push_container.yml
@@ -66,3 +66,9 @@ jobs:
       - name: Logout of ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Run scan websites # Static scans
+        run: |
+          curl -s https://scan-websites.alpha.canada.ca > /dev/null
+          sleep 60
+          curl -X GET -H 'X-API-KEY: ${{ secrets.SCAN_WEBSITES_KEY }}' -H 'X-TEMPLATE-TOKEN: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}' https://scan-websites.alpha.canada.ca/scans/start

--- a/.github/workflows/weekly-dynamic-security-scan.yml
+++ b/.github/workflows/weekly-dynamic-security-scan.yml
@@ -1,0 +1,15 @@
+name: Scan for security vulnerabilities (Weekly on Sunday)
+
+on:
+  schedule:
+  - cron: "0 12 * * 0"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run scan websites # Dynamic scans
+        run: |
+          curl -s https://scan-websites.alpha.canada.ca > /dev/null
+          sleep 60
+          curl -X GET -H 'X-API-KEY: ${{ secrets.SCAN_WEBSITES_KEY }}' -H 'X-TEMPLATE-TOKEN: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}' 'https://scan-websites.alpha.canada.ca/scans/start?dynamic=true'


### PR DESCRIPTION
This PR adds a call to the Scan websites tool into the CI pipeline. After a new version of the application has been deployed it will make an API call to kick-off the default static (read-only traffic) API that request a spidering of the public facing pages and a a11y scan.

This also adds a weekly call to the Scan websites tool to run dynamic security testing every Sunday.