### PR TITLE
Clear menu api routes cache

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -24,8 +24,7 @@ class Cache
 
             return array_merge($items, [
                 "{$sitePrefix}{$localePrefix}wp-json/wp/v2/{$post->post_type}s/?slug={$post->post_name}",
-                "{$sitePrefix}menus/v1/menus/notify-admin",
-                "{$sitePrefix}menus/v1/menus/notify-admin-fr"
+                "{$sitePrefix}menus/v1/menus/*",
             ]);
         }, 10, 2);
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cache/Cache.php
@@ -24,6 +24,8 @@ class Cache
 
             return array_merge($items, [
                 "{$sitePrefix}{$localePrefix}wp-json/wp/v2/{$post->post_type}s/?slug={$post->post_name}",
+                "{$sitePrefix}menus/v1/menus/notify-admin",
+                "{$sitePrefix}menus/v1/menus/notify-admin-fr"
             ]);
         }, 10, 2);
     }


### PR DESCRIPTION
# Summary | Résumé

This will clear cache for both en/fr menu api routes when updating a page or post.

This is not ideal - it would be preferable to fire these invalidations when Menus are updated, but the plugin does not appear to have any hooks to enable refreshing cache on content other than posts/pages.

Since there can be more than one menu per site, and we don't know the names of the menus, just using a wildcard for the path:

```
/[site-name]/menus/v1/menus/*
```
