### PR TITLE
Fix cache behaviour for subsite paths

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -105,6 +105,27 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
+    path_pattern     = "/*/wp-admin/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = aws_lb.wordpress.name
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Host", "Origin", "User-Agent"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
     path_pattern     = "/uploads/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
@@ -128,6 +149,27 @@ resource "aws_cloudfront_distribution" "wordpress" {
 
   ordered_cache_behavior {
     path_pattern     = "/wp-json/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = aws_lb.wordpress.name
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Host", "Origin", "User-Agent", "Authorization"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/*/wp-json/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -84,28 +84,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "/wp-admin/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = aws_lb.wordpress.name
-
-    forwarded_values {
-      query_string = true
-      headers      = ["Host", "Origin", "User-Agent"]
-      cookies {
-        forward = "all"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
-    path_pattern     = "/*/wp-admin/*"
+    path_pattern     = "wp-admin/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name
@@ -148,28 +127,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "/wp-json/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = aws_lb.wordpress.name
-
-    forwarded_values {
-      query_string = true
-      headers      = ["Host", "Origin", "User-Agent", "Authorization"]
-      cookies {
-        forward = "all"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
-    path_pattern     = "/*/wp-json/*"
+    path_pattern     = "wp-json/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -84,7 +84,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "wp-admin/*"
+    path_pattern     = "*wp-admin/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name
@@ -127,7 +127,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "wp-json/*"
+    path_pattern     = "*wp-json/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name


### PR DESCRIPTION
# Summary | Résumé

Previously cache rules for admin and api routes were just being applied to:

```
/wp-admin/*
/wp-json/*
```

However, this would not apply to corresponding subsite paths which would look like:

```
/[subsite]/wp-admin/*
/[subsite]/wp-json/*
```

We hadn't noticed any issues with the wp-admin routes, but the wp-json routes in subsites were not allowing the Authorization header through after our previous PR #463 
