### PR TITLE
Bugfix - fix typo in enable jwt

### DIFF
--- a/cypress/test-setup/setup-ci.sh
+++ b/cypress/test-setup/setup-ci.sh
@@ -16,7 +16,7 @@ wp-env run tests-cli wp theme activate cds-default
 wp-env run tests-cli wp plugin activate sitepress-multilingual-cms cds-base two-factor;
 wp-env run tests-cli wp plugin activate s3-uploads wps-hide-login disable-user-login;
 wp-env run tests-cli wp plugin activate wordpress-seo wordpress-seo-premium wp-rest-api-v2-menus;
-wp-env run tests-cli wp plugin activate jwt-authentications-for-wp-rest-api;
+wp-env run tests-cli wp plugin activate jwt-authentication-for-wp-rest-api;
 
 wp-env run tests-cli wp option update permalink_structure "/%postname%/";
 wp-env run tests-cli "wp option add LIST_MANAGER_NOTIFY_SERVICES 'Les Articles GC Articles~gc-articles-fb26a6b5-57aa-4cc2-85fe-3053ed344fe8-30569ea9-362b-41c4-a811-842ccf3db3dc'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       wp plugin activate sitepress-multilingual-cms cds-base two-factor login-lockdown --network;
       wp plugin activate s3-uploads wps-hide-login disable-user-login gutenberg --network;
       wp plugin activate wordpress-seo wordpress-seo-premium wpml-string-translation wp-seo-multilingual --network;
-      wp plugin activate jwt-authentications-for-wp-rest-api --network;
+      wp plugin activate jwt-authentication-for-wp-rest-api --network;
       '
     volumes:
       - wordpress:/usr/src/wordpress

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -154,6 +154,8 @@ define('OTGS_DISABLE_AUTO_UPDATES', true);
 define('WP_AUTO_UPDATE_CORE', false);
 
 define('JWT_AUTH_SECRET_KEY', getenv_docker('JWT_AUTH_SECRET_KEY', 'tQ;XnD#UmY2A*O,LIm(:NL|4c=R|3t~QD/3p{7CBKRz^eepfib9q-PHr7ZMZG$uz'));
+
+define( 'WP_MEMORY_LIMIT', '256M' );
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -155,7 +155,7 @@ define('WP_AUTO_UPDATE_CORE', false);
 
 define('JWT_AUTH_SECRET_KEY', getenv_docker('JWT_AUTH_SECRET_KEY', 'tQ;XnD#UmY2A*O,LIm(:NL|4c=R|3t~QD/3p{7CBKRz^eepfib9q-PHr7ZMZG$uz'));
 
-define( 'WP_MEMORY_LIMIT', '256M' );
+define('WP_MEMORY_LIMIT', '256M');
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
# Summary | Résumé

Two minor fixes here:
- typo in jwt package name when enabling for cypress and local dev
- increase wordpress memory limit (wpml requirement)