### PR TITLE
Add IDs for translated pages to REST response

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Cleanup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Cleanup.php
@@ -59,7 +59,12 @@ class Cleanup
                 $settings['translation-management']['post_translation_editor_native'] = true;
                 update_option('icl_sitepress_settings', $settings);
             }
-            if (array_key_exists('post_translation_editor_native_for_post_type', $settings['translation-management'] ?? [])) {
+            if (
+                array_key_exists(
+                    'post_translation_editor_native_for_post_type',
+                    $settings['translation-management'] ?? []
+                )
+            ) {
                 unset($settings['translation-management']['post_translation_editor_native_for_post_type']);
                 update_option('icl_sitepress_settings', $settings);
             }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Wpml.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Wpml.php
@@ -10,5 +10,43 @@ class Wpml
     {
         Installer::register();
         Cleanup::register();
+
+        self::addTranslatedIDsToPages();
+    }
+
+    private static function addTranslatedIDsToPages()
+    {
+        add_action('rest_api_init', function () {
+
+            /**
+             * Add an 'id_en' field field to the REST response for a page
+             * Returns an integer id, or 'null' if no translation provided
+             */
+            register_rest_field('page', 'id_en', array(
+                'get_callback' => function ($post, $field_name, $request) {
+                    return apply_filters('wpml_object_id', $post['id'], 'post', false, 'en');
+                },
+                'update_callback' => null,
+                'schema' => array(
+                    'description' => __('ID for English page.', 'cds-snc'),
+                    'type'        => 'integer'
+                ),
+            ));
+
+            /**
+             * Add an 'id_fr' field to the REST response for a page
+             * Returns an integer id, or 'null' if no translation provided
+             */
+            register_rest_field('page', 'id_fr', array(
+                'get_callback' => function ($post, $field_name, $request) {
+                    return apply_filters('wpml_object_id', $post['id'], 'post', false, 'fr');
+                },
+                'update_callback' => null,
+                'schema' => array(
+                    'description' => __('ID for French page.', 'cds-snc'),
+                    'type'        => 'integer'
+                ),
+            ));
+        });
     }
 }


### PR DESCRIPTION
# Summary | Résumé

Returning pages from the API now includes 2 new keys:
- `id_en`
- `id_fr`

They return an integer ID, or 'null' if no translation has been provided.

The most helpful documentation for this was the WordPress docs themselves,
and the translation IDs come from a WPML filter.

Sources:
- https://developer.wordpress.org/rest-api/extending-the-rest-api/modifying-responses/#adding-custom-fields-to-api-responses
- https://wpml.org/wpml-hook/wpml_object_id/


