### PR TITLE
Fix cloudfront path issues

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -84,7 +84,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "*wp-admin/*"
+    path_pattern     = "*/wp-admin/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name
@@ -127,7 +127,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "*wp-json/*"
+    path_pattern     = "*/wp-json/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -42,7 +42,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host", "Options", "Referer"]
+      headers      = ["Host", "Options", "Referer", "Authorization"]
       cookies {
         forward = "whitelist"
         whitelisted_names = [
@@ -84,7 +84,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "*/wp-admin/*"
+    path_pattern     = "wp-admin/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name
@@ -127,7 +127,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "*/wp-json/*"
+    path_pattern     = "wp-json/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.wordpress.name


### PR DESCRIPTION
# Summary | Résumé

The previous wildcard prefixes were breaking WPML language linking for some reason.

Tried various iterations of these wildcard route, was not able to resolve.

This all started with trying to add the Authorization header to wp-json routes. The problem is that subsite urls are of the form: `/subsite/wp-json/...` but if we use something like `/*/wp-json` or `*/wp-json` or `*wp-json` it breaks WPML language linking for some reason.

In the end, enabling the Authorization header on the default behaviour and these rules fixed it.

This is not ideal. But it's enough already. We should be replacing these legacy Cache Behaviours with new Cache Policies sometime anyway. Maybe revisit then.
