### PR TITLE
Add WPML Site Key to environment

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -39,6 +39,7 @@ env:
   TF_VAR_wordpress_logged_in_salt: ${{ secrets.PRODUCTION_WORDPRESS_LOGGED_IN_SALT }}
   TF_VAR_wordpress_nonce_salt: ${{ secrets.PRODUCTION_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.PRODUCTION_JWT_AUTH_SECRET_KEY }}
+  TF_VAR_wpml_site_key: ${{ secrets.PRODUCTION_WPML_SITE_KEY }}
 
 jobs:
   # Check the VERSION file to get the target version to deploy and previously deployed version.

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -42,6 +42,7 @@ env:
   TF_VAR_wordpress_logged_in_salt: ${{ secrets.STAGING_WORDPRESS_LOGGED_IN_SALT }}
   TF_VAR_wordpress_nonce_salt: ${{ secrets.STAGING_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.STAGING_JWT_AUTH_SECRET_KEY }}
+  TF_VAR_wpml_site_key: ${{ secrets.STAGING_WPML_SITE_KEY }}
 
 jobs:
   terragrunt-apply-staging:

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -39,6 +39,7 @@ env:
   TF_VAR_wordpress_logged_in_salt: ${{ secrets.PRODUCTION_WORDPRESS_LOGGED_IN_SALT }}
   TF_VAR_wordpress_nonce_salt: ${{ secrets.PRODUCTION_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.PRODUCTION_JWT_AUTH_SECRET_KEY }}
+  TF_VAR_wpml_site_key: ${{ secrets.PRODUCTION_WPML_SITE_KEY }}
 
 jobs:
   # Check the VERSION file to get the target version to deploy and previously deployed version.

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -40,6 +40,7 @@ env:
   TF_VAR_wordpress_logged_in_salt: ${{ secrets.STAGING_WORDPRESS_LOGGED_IN_SALT }}
   TF_VAR_wordpress_nonce_salt: ${{ secrets.STAGING_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.STAGING_JWT_AUTH_SECRET_KEY }}
+  TF_VAR_wpml_site_key: ${{ secrets.STAGING_WPML_SITE_KEY }}
 
 jobs:
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -33,6 +33,7 @@ The following Terraform variables are required:
 * `default_list_manager_api_key`: API key used for Platform ListManager request auth
 * `default_notify_api_key`: Default Notify API key used before a site has one configured
 * `slack_webhook_url`: Slack incoming webhook to post SNS notifications to
+* `wpml_site_key`: Site Key from WPML
 
 WordPress [generated secret keys](https://api.wordpress.org/secret-key/1.1/salt/):
 * `wordpress_auth_key`

--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -104,6 +104,10 @@
         "valueFrom": "${JWT_AUTH_SECRET_KEY}"
       },
       {
+        "name": "WPML_SITE_KEY",
+        "valueFrom": "${WPML_SITE_KEY}"
+      },
+      {
         "name": "WORDPRESS_DB_HOST",
         "valueFrom": "${WORDPRESS_DB_HOST}"
       },

--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -72,6 +72,7 @@ data "template_file" "wordpress_container_definition" {
     WORDPRESS_LOGGED_IN_SALT     = aws_secretsmanager_secret_version.wordpress_logged_in_salt.arn
     WORDPRESS_NONCE_SALT         = aws_secretsmanager_secret_version.wordpress_nonce_salt.arn
     JWT_AUTH_SECRET_KEY          = aws_secretsmanager_secret_version.jwt_auth_secret_key.arn
+    WPML_SITE_KEY                = aws_secretsmanager_secret_version.wpml_site_key.arn
 
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.wordpress_ecs_logs.name
     AWS_LOGS_REGION        = var.region

--- a/infrastructure/terragrunt/aws/ecs/iam.tf
+++ b/infrastructure/terragrunt/aws/ecs/iam.tf
@@ -95,6 +95,7 @@ data "aws_iam_policy_document" "wordpress_ecs_task_get_secret_value" {
       aws_secretsmanager_secret_version.wordpress_logged_in_salt.arn,
       aws_secretsmanager_secret_version.wordpress_nonce_salt.arn,
       aws_secretsmanager_secret_version.jwt_auth_secret_key.arn
+      aws_secretsmanager_secret_version.wpml_site_key.arn
     ]
   }
 }

--- a/infrastructure/terragrunt/aws/ecs/iam.tf
+++ b/infrastructure/terragrunt/aws/ecs/iam.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "wordpress_ecs_task_get_secret_value" {
       aws_secretsmanager_secret_version.wordpress_secure_auth_salt.arn,
       aws_secretsmanager_secret_version.wordpress_logged_in_salt.arn,
       aws_secretsmanager_secret_version.wordpress_nonce_salt.arn,
-      aws_secretsmanager_secret_version.jwt_auth_secret_key.arn
+      aws_secretsmanager_secret_version.jwt_auth_secret_key.arn,
       aws_secretsmanager_secret_version.wpml_site_key.arn
     ]
   }

--- a/infrastructure/terragrunt/aws/ecs/inputs.tf
+++ b/infrastructure/terragrunt/aws/ecs/inputs.tf
@@ -70,6 +70,12 @@ variable "encryption_key" {
   sensitive   = true
 }
 
+variable "wpml_site_key" {
+  description = "WPML Site Key"
+  type        = string
+  sensitive   = true
+}
+
 variable "s3_uploads_bucket" {
   description = "Bucket for user uploads"
   type        = string

--- a/infrastructure/terragrunt/aws/ecs/secrets.tf
+++ b/infrastructure/terragrunt/aws/ecs/secrets.tf
@@ -40,6 +40,15 @@ resource "aws_secretsmanager_secret_version" "encryption_key" {
   secret_string = var.encryption_key
 }
 
+resource "aws_secretsmanager_secret" "wpml_site_key" {
+  name = "wpml_site_key_${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "wpml_site_key" {
+  secret_id     = aws_secretsmanager_secret.wpml_site_key.id
+  secret_string = var.wpml_site_key
+}
+
 resource "aws_secretsmanager_secret" "s3_uploads_bucket" {
   name = "s3_uploads_bucket_${random_string.random.result}"
 }


### PR DESCRIPTION
# Summary | Résumé

Pretty sure this is what's been causing the error on creating a new site. When we added the WPML installer, there was an [environment variable/secret](https://github.com/cds-snc/gc-articles/blob/main/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Installer.php#L127) that needed to be added as well
