### PR TITLE
Fix Subscribe form endpoint

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/FormHelpers.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/FormHelpers.php
@@ -11,7 +11,7 @@ class FormHelpers
 {
     public static function render($data)
     {
-        $action = get_home_url() . '/wp-json/wp-notify/v1/bulk'; ?>
+        $action = site_url() . '/wp-json/wp-notify/v1/bulk'; ?>
       <div class="wrap">
         <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
         <form id="notify_template_sender_form" name="notify_template_sender_form" method="post" action="<?php echo $action; ?>">

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Subscribe/SubscriptionForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Subscribe/SubscriptionForm.php
@@ -39,10 +39,12 @@ class SubscriptionForm
             $subscribeLabel = $attributes['subscribeLabel'];
         endif;
 
+        $apiEndpoint = site_url() . '/wp-json/subscribe/v1/process';
+
         ob_start();
         ?>
         <div class="gc-form-wrapper">
-           <form id="subscribe-form" method="POST" action="/wp-json/subscribe/v1/process">
+           <form id="subscribe-form" method="POST" action="<?php echo $apiEndpoint; ?>">
                 <input type="hidden" name="list_id" value="<?php echo $listId; ?>"/>
                 <?php wp_nonce_field('list_manager_nonce_action', 'list_manager'); ?>
                 <div class="focus-group">


### PR DESCRIPTION
# Summary | Résumé

The Subscribe form action url was previously hardcoded to `/wp-json/subscribe/v1/process` which meant all subscriptions were sent to the base site.

This adds the appropriate site prefix to that action url
