### PR TITLE
Patch/handle ajax requests

### DIFF
--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -16,5 +16,11 @@ if (isset($_GET['page_id']) && isset($_GET['preview'])) :
     $pageName = sprintf('/preview?id=%s&lang=%s', intval($_GET['page_id']), $lang);
 endif;
 
-$redirectUrl = Utils::addHttp($redirectHost) . $pageName;
-header("Location: ${redirectUrl}");
+
+if(!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) != 'xmlhttprequest'){
+    $redirectUrl = Utils::addHttp($redirectHost) . $pageName;
+    header("Location: ${redirectUrl}");
+}
+
+
+

--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -16,11 +16,8 @@ if (isset($_GET['page_id']) && isset($_GET['preview'])) :
     $pageName = sprintf('/preview?id=%s&lang=%s', intval($_GET['page_id']), $lang);
 endif;
 
-
+// don't redirect for ajax requests
 if(!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) != 'xmlhttprequest'){
     $redirectUrl = Utils::addHttp($redirectHost) . $pageName;
     header("Location: ${redirectUrl}");
 }
-
-
-


### PR DESCRIPTION
Found a bug when using the Redirect theme + http

<img width="587" alt="Screen Shot 2022-01-25 at 10 29 58 AM" src="https://user-images.githubusercontent.com/62242/151006947-1deae1e2-5586-4d62-8ebe-aa1667e0ecfa.png">


<img width="1029" alt="Screen Shot 2022-01-25 at 10 29 37 AM" src="https://user-images.githubusercontent.com/62242/151006977-af8b476d-b130-453a-a410-cd91cdf2a17d.png">

This patch should ignore ajax page request ... skip the redirect

