### PR TITLE
Bump production container to 2.14.1

### DIFF
--- a/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
@@ -69,7 +69,7 @@ inputs = {
 
   wordpress_repository_arn = dependency.ecr.outputs.wordpress_repository_arn
   wordpress_image          = dependency.ecr.outputs.wordpress_repository_url
-  wordpress_image_tag      = "v2.14.0"
+  wordpress_image_tag      = "v2.14.1"
 
   apache_repository_arn = dependency.ecr.outputs.apache_repository_arn
   apache_image          = dependency.ecr.outputs.apache_repository_url


### PR DESCRIPTION
# Summary | Résumé

This will bump the Production container to 2.14.1 in preparation for release
