### PR TITLE
Replace WPML en/fr flag icons

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - ./wordpress/docker/apache/httpd.conf:/usr/local/apache2/conf/httpd.conf
       - ./wordpress/docker/apache/conf.d/php-fpm.conf:/usr/local/apache2/conf.d/php-fpm.conf
       - ./wordpress/docker/apache/conf.d/default-site.conf:/usr/local/apache2/conf.d/default-site.conf
+      - ./assets/en.png:/usr/src/wordpress/wp-content/plugins/sitepress-multilingual-cms/res/flags/en.png
+      - ./assets/fr.png:/usr/src/wordpress/wp-content/plugins/sitepress-multilingual-cms/res/flags/fr.png
     networks:
       - app-network
 

--- a/wordpress/docker/production.Dockerfile
+++ b/wordpress/docker/production.Dockerfile
@@ -35,6 +35,10 @@ WORKDIR /usr/src/wordpress
 COPY --from=composer /app/wordpress/wp-content ./wp-content
 COPY --from=composer /app/wordpress/vendor ./vendor
 
+# Copy flags
+COPY ./assets/en.png /usr/src/wordpress/wp-content/plugins/sitepress-multilingual-cms/res/flags/en.png
+COPY ./assets/fr.png /usr/src/wordpress/wp-content/plugins/sitepress-multilingual-cms/res/flags/fr.png
+
 # Deny all web access to the vendor folder contents
 RUN echo "Deny from all" > ./vendor/.htaccess
 


### PR DESCRIPTION
# Summary | Résumé

By default WPML uses British and French flags for icons to represent EN/FR. We want the icons to be more agnostic. WPML provides a method to replace them but it is a manual process that must be done per site by uploading replacement flags through the ui. This PR replaces the source flag images at build time instead. 

In the local docker-compose environment, the flag images get mounted into the volume of the Apache container which is responsible for serving images. 

The Production build will copy the images directly into the filesystem of the WordPress container, which in turn is shared with the Apache container.

## To test

Locally:
- Check out this branch
- Restart your docker-compose environment
- Visit the Pages list view
- You may need to clear-cache or shift-reload
- Notice the flags have been replaced

Once this PR build is triggered, will pull down the resulting image and double-check that the files are there.
