### PR TITLE
Handle when the Theme Option for redirect_url has not been set

### DIFF
--- a/wordpress/wp-content/themes/cds-redirector/functions.php
+++ b/wordpress/wp-content/themes/cds-redirector/functions.php
@@ -214,12 +214,12 @@ if (!class_exists('Redirector')) {
 Redirector::register();
 
 // Helper function to use in your theme to return a theme option value
-function cds_get_theme_option($id = '')
+function cds_get_theme_option($id = ''): ?string
 {
     return Redirector::getThemeOption($id);
 }
 
-function cds_get_active_language()
+function cds_get_active_language(): ?string
 {
     return Redirector::getActiveLanguage();
 }

--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -18,9 +18,10 @@ endif;
 
 $isSelf = false;
 
-if (str_contains($_SERVER['REQUEST_URI'], $redirectHost) || isset($_GET['action']) == "edit" || isset($_GET['_wp-find-template'])) :
+if ($redirectHost && str_contains($_SERVER['REQUEST_URI'],
+        $redirectHost) || isset($_GET['action']) == "edit" || isset($_GET['_wp-find-template'])) {
     $isSelf = true;
-endif;
+}
 
 $isAjaxRequest = false;
 

--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -11,10 +11,10 @@ $lang = cds_get_active_language();
 $redirectHost = cds_get_theme_option("redirect_url");
 $pageName = sprintf("/%s?lang=%s", $wp->request, $lang);
 
-if (isset($_GET['page_id']) && isset($_GET['preview'])) :
+if (isset($_GET['page_id']) && isset($_GET['preview'])) {
     // handles incoming "draft" links from wp table (list view)
     $pageName = sprintf('/preview?id=%s&lang=%s', intval($_GET['page_id']), $lang);
-endif;
+}
 
 $isSelf = false;
 
@@ -33,13 +33,13 @@ $isAjaxRequest = false;
 if (
     isset($_SERVER['HTTP_X_REQUESTED_WITH']) &&
     strcasecmp($_SERVER['HTTP_X_REQUESTED_WITH'], 'xmlhttprequest') == 0
-) :
+) {
     //Set our $isAjaxRequest to true.
     $isAjaxRequest = true;
-endif;
+}
 
 // don't redirect for ajax requests
-if (!$isAjaxRequest && !$isSelf) :
+if (!$isAjaxRequest && !$isSelf) {
     $redirectUrl = Utils::addHttp($redirectHost) . $pageName;
     header("Location: ${redirectUrl}");
-endif;
+}

--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -24,7 +24,7 @@ if (
         $redirectHost
     ) || isset($_GET['action']) == "edit" || isset($_GET['_wp-find-template'])
 ) {
-    $isSelf = true;
+    exit();
 }
 
 $isAjaxRequest = false;
@@ -35,11 +35,13 @@ if (
     strcasecmp($_SERVER['HTTP_X_REQUESTED_WITH'], 'xmlhttprequest') == 0
 ) {
     //Set our $isAjaxRequest to true.
-    $isAjaxRequest = true;
+    exit();
 }
 
-// don't redirect for ajax requests
-if (!$isAjaxRequest && !$isSelf) {
-    $redirectUrl = Utils::addHttp($redirectHost) . $pageName;
-    header("Location: ${redirectUrl}");
+if (!$redirectHost) {
+    $link = site_url() . "/wp-admin/admin.php?page=theme-settings";
+    wp_die("You have the Redirector theme enabled, but have not <a href='${link}'>configured a redirect.</a>");
 }
+
+$redirectUrl = Utils::addHttp($redirectHost) . $pageName;
+header("Location: ${redirectUrl}");

--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -18,8 +18,12 @@ endif;
 
 $isSelf = false;
 
-if ($redirectHost && str_contains($_SERVER['REQUEST_URI'],
-        $redirectHost) || isset($_GET['action']) == "edit" || isset($_GET['_wp-find-template'])) {
+if (
+    $redirectHost && str_contains(
+        $_SERVER['REQUEST_URI'],
+        $redirectHost
+    ) || isset($_GET['action']) == "edit" || isset($_GET['_wp-find-template'])
+) {
     $isSelf = true;
 }
 

--- a/wordpress/wp-content/themes/cds-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-redirector/index.php
@@ -16,8 +16,6 @@ if (isset($_GET['page_id']) && isset($_GET['preview'])) {
     $pageName = sprintf('/preview?id=%s&lang=%s', intval($_GET['page_id']), $lang);
 }
 
-$isSelf = false;
-
 if (
     $redirectHost && str_contains(
         $_SERVER['REQUEST_URI'],
@@ -26,8 +24,6 @@ if (
 ) {
     exit();
 }
-
-$isAjaxRequest = false;
 
 //IF HTTP_X_REQUESTED_WITH is equal to xmlhttprequest
 if (


### PR DESCRIPTION
# Summary | Résumé

When the option was not set for the redirect_url this bit of code was erroring on the console. This just adds a conditional to prevent the exception. 

Obviously you end up with a broken redirect if you don't fill in that field, so the redirect still doesn't work in the situation, but it's not throwing code exceptions anymore.

Also added some return types and changed the `if/endif`s to `if {}` for consistency