### PR TITLE
Update wordpress container version to 2.14.4

### DIFF
--- a/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/ecs/terragrunt.hcl
@@ -69,7 +69,7 @@ inputs = {
 
   wordpress_repository_arn = dependency.ecr.outputs.wordpress_repository_arn
   wordpress_image          = dependency.ecr.outputs.wordpress_repository_url
-  wordpress_image_tag      = "v2.14.2"
+  wordpress_image_tag      = "v2.14.4"
 
   apache_repository_arn = dependency.ecr.outputs.apache_repository_arn
   apache_image          = dependency.ecr.outputs.apache_repository_url


### PR DESCRIPTION
# Summary | Résumé

Update wordpress container version to 2.14.4


