### PR TITLE
Hide wpml lang in footer

### DIFF
--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -490,3 +490,7 @@ nav.nav--about li a:focus {
 .pager .previous a::before{
     content: "" !important;
 }
+
+.wpml-ls-statics-footer{
+    display:none;
+}


### PR DESCRIPTION
Adding this a patch until we dig into looking into defaulting the language setting to off -- cc @dsamojlenko 

This will hide the footer even if it's set to on.

https://github.com/cds-snc/gc-articles-issues/issues/19

<img width="1141" alt="Screen Shot 2022-01-27 at 9 09 37 AM" src="https://user-images.githubusercontent.com/62242/151375285-79a6b1e3-21a5-4603-87ce-ecad40e3570e.png">
