### PR TITLE
Augment the GC Articles top menu link

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -40,8 +40,19 @@ class AdminBar
             )
         );
 
+        // Add an option to visit the site's "settings" page for superadmins
+        if (is_multisite() && current_user_can('manage_sites')) {
+            $wp_admin_bar->add_node(
+                array(
+                    'parent' => $menu_id,
+                    'id'     => $menu_id . '-edit-site',
+                    'title'  => __('Edit Site'),
+                    'href'   => network_admin_url('site-info.php?id=' . get_current_blog_id()),
+                )
+            );
+        }
 
-        // Add an option to visit the site.
+        // Add an option to visit the dashboard.
         $wp_admin_bar->add_node(
             array(
                 'parent' => $menu_id,
@@ -131,6 +142,7 @@ class AdminBar
     public function removeFromAdminBar($wp_admin_bar): void
     {
         $wp_admin_bar->remove_node('new-content');
+        $wp_admin_bar->remove_node('site-name');
 
         if (is_super_admin()) {
             return;
@@ -139,7 +151,6 @@ class AdminBar
         $wp_admin_bar->remove_node('updates');
         $wp_admin_bar->remove_node('comments');
         $wp_admin_bar->remove_node('wp-logo');
-        $wp_admin_bar->remove_node('site-name');
         $wp_admin_bar->remove_node('customize');
 
         /* plugins */

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -12,6 +12,44 @@ class AdminBar
         add_action('wp_before_admin_bar_render', [$this, 'removeFromAdminBarBefore'], 99);
 
         add_action('admin_bar_menu', [$this, 'addCollections'], 21);
+        add_action('admin_bar_menu', [$this, 'addAdminToggle'], 21);
+    }
+
+    public function addAdminToggle($wp_admin_bar): void
+    {
+        $menu_id = 'cds-home';
+        // "is_admin" checks if viewing an admin page, it's not a role check
+        $home_url = is_admin() ? home_url('/') : admin_url();
+
+        $wp_admin_bar->add_node([
+            'id'    => $menu_id,
+            'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
+                'GC Articles:',
+                'cds-snc'
+            ) . ' ' . get_bloginfo('name') . '</div>',
+            'href'  => $home_url,
+        ]);
+
+        // Add an option to visit the site.
+        $wp_admin_bar->add_node(
+            array(
+                'parent' => $menu_id,
+                'id'     => $menu_id . '-view-site',
+                'title'  => __('Visit Site'),
+                'href'   => home_url('/'),
+            )
+        );
+
+
+        // Add an option to visit the site.
+        $wp_admin_bar->add_node(
+            array(
+                'parent' => $menu_id,
+                'id'     => $menu_id . '-admin-dashboard',
+                'title'  => __('Admin dashboard'),
+                'href'   => admin_url(),
+            )
+        );
     }
 
     public function addCollections($wp_admin_bar): void
@@ -114,15 +152,6 @@ class AdminBar
         $wp_admin_bar->add_node([
             'id'    => 'my-account',
             'title' => $newtext,
-        ]);
-
-        $wp_admin_bar->add_node([
-            'id'    => 'cds-home',
-            'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
-                'GC Articles',
-                'cds-snc'
-            ) . '</div>',
-            'href'  => admin_url(),
         ]);
 
         $wp_admin_bar->remove_menu('my-sites');


### PR DESCRIPTION
# Summary 

This is the first of my PRs about the admin header, this one is much easier to review + approve.

Previously, GC Admins didn't have an easy way to navigate to the public site, so I augmented the "GC Articles" header menu item. The "GC Articles" link now has the name of the site included, and toggles between the admin interface and the public interface.

It also has a drop-down with options to view the site or the dashboard, so all our bases are covered.

Super admins can also see an "Edit site" link (not pictured), which takes you to the network site settings. After adding this, it made sense to remove the other 'site name' top menu link entirely.

## Screenshots

| dashboard view | viewing the site |
|----------------|------------------|
|      <img width="1000" alt="Screen Shot 2022-01-28 at 13 34 21" src="https://user-images.githubusercontent.com/2454380/151806415-5406076e-59f3-435b-a3e0-0261d4de5e63.png">      |      <img width="1000" alt="Screen Shot 2022-01-28 at 13 34 27" src="https://user-images.githubusercontent.com/2454380/151806422-b3e28390-a84d-4a18-8111-11dea18b5972.png">       |

