### PR TITLE
Add language switcher to Admin

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -73,7 +73,7 @@ class AdminBar
         }
 
         $user_locale = get_user_locale();
-        $translation_locale = str_contains($user_locale, "en") ? "fr_FR" : "en_US";
+        $translation_locale = str_contains($user_locale, "en") ? "fr_CA" : "en_CA";
         // Not using i18n function for these because we don't want to translate them
         $translation_locale_name = str_contains($user_locale, "en") ? "Français" : "English";
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -40,8 +40,19 @@ class AdminBar
             )
         );
 
+        // Add an option to visit the site's "settings" page for superadmins
+        if (is_multisite() && current_user_can('manage_sites')) {
+            $wp_admin_bar->add_node(
+                array(
+                    'parent' => $menu_id,
+                    'id'     => $menu_id . '-edit-site',
+                    'title'  => __('Edit Site'),
+                    'href'   => network_admin_url('site-info.php?id=' . get_current_blog_id()),
+                )
+            );
+        }
 
-        // Add an option to visit the site.
+        // Add an option to visit the dashboard.
         $wp_admin_bar->add_node(
             array(
                 'parent' => $menu_id,
@@ -131,6 +142,7 @@ class AdminBar
     public function removeFromAdminBar($wp_admin_bar): void
     {
         $wp_admin_bar->remove_node('new-content');
+        $wp_admin_bar->remove_node('site-name');
 
         if (is_super_admin()) {
             return;
@@ -139,7 +151,6 @@ class AdminBar
         $wp_admin_bar->remove_node('updates');
         $wp_admin_bar->remove_node('comments');
         $wp_admin_bar->remove_node('wp-logo');
-        $wp_admin_bar->remove_node('site-name');
         $wp_admin_bar->remove_node('customize');
 
         /* plugins */

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -27,9 +27,9 @@ class AdminBar
         $wp_admin_bar->add_node([
             'id'    => $menu_id,
             'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
-                'GC Articles:',
+                'GC Articles',
                 'cds-snc'
-            ) . ' ' . get_bloginfo('name') . '</div>',
+            ) . ' › ' . get_bloginfo('name') . '</div>',
             'href'  => $home_url,
         ]);
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -12,6 +12,44 @@ class AdminBar
         add_action('wp_before_admin_bar_render', [$this, 'removeFromAdminBarBefore'], 99);
 
         add_action('admin_bar_menu', [$this, 'addCollections'], 21);
+        add_action('admin_bar_menu', [$this, 'addAdminToggle'], 21);
+    }
+
+    public function addAdminToggle($wp_admin_bar): void
+    {
+        $menu_id = 'cds-home';
+        // "is_admin" checks if viewing an admin page, it's not a role check
+        $home_url = is_admin() ? home_url('/') : admin_url();
+
+        $wp_admin_bar->add_node([
+            'id'    => $menu_id,
+            'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
+                'GC Articles:',
+                'cds-snc'
+            ) . ' ' . get_bloginfo('name') . '</div>',
+            'href'  => $home_url,
+        ]);
+
+        // Add an option to visit the site.
+        $wp_admin_bar->add_node(
+            array(
+                'parent' => $menu_id,
+                'id'     => $menu_id . '-view-site',
+                'title'  => __('Visit Site'),
+                'href'   => home_url('/'),
+            )
+        );
+
+
+        // Add an option to visit the site.
+        $wp_admin_bar->add_node(
+            array(
+                'parent' => $menu_id,
+                'id'     => $menu_id . '-admin-dashboard',
+                'title'  => __('Admin dashboard'),
+                'href'   => admin_url(),
+            )
+        );
     }
 
     public function addCollections($wp_admin_bar): void
@@ -114,15 +152,6 @@ class AdminBar
         $wp_admin_bar->add_node([
             'id'    => 'my-account',
             'title' => $newtext,
-        ]);
-
-        $wp_admin_bar->add_node([
-            'id'    => 'cds-home',
-            'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
-                'GC Articles',
-                'cds-snc'
-            ) . '</div>',
-            'href'  => admin_url(),
         ]);
 
         $wp_admin_bar->remove_menu('my-sites');

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -68,6 +68,10 @@ class AdminBar
 
     public function addLanguageSwitcher($wp_admin_bar): void
     {
+        if (!is_admin()) {
+            return;
+        }
+
         $user_locale = get_user_locale();
         $translation_locale = str_contains($user_locale, "en") ? "fr_FR" : "en_US";
         // Not using i18n function for these because we don't want to translate them

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css
@@ -188,13 +188,21 @@ details ul li, details ol li {
   color: #1d2327;
 }
 
-.wp-core-ui .button-primary, .wrap .page-title-action, .components-button.is-primary {
+.wp-core-ui .button-primary,
+.wrap .page-title-action,
+.components-button.is-primary,
+#wpadminbar input[type=submit] {
   background: #26374a;
   border-color: #26374a;
   color: #fff;
 }
 
-.wp-core-ui .button-primary:hover, .wp-core-ui .button-primary:focus, .wrap .page-title-action:hover, .wrap .page-title-action:focus {
+.wp-core-ui .button-primary:hover,
+.wp-core-ui .button-primary:focus,
+.wrap .page-title-action:hover,
+.wrap .page-title-action:focus,
+#wpadminbar input[type=submit]:hover,
+#wpadminbar input[type=submit]:focus {
   color: #fff;
   background-color: #1c578a;
   border-color: #091c2d;
@@ -208,7 +216,8 @@ details ul li, details ol li {
 
 .wp-core-ui .button-primary:active,
 .wp-core-ui .button-primary.active, .wp-core-ui .button-primary.active:focus, .wp-core-ui .button-primary.active:hover,
-.wrap .page-title-action:active {
+.wrap .page-title-action:active,
+#wpadminbar input[type=submit]:active {
   color: #fff;
   background-color: #16446c;
   border-color: #000;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -295,3 +295,19 @@ th.column-disable_user_login {
 .term-parent-wrap p{
   display: none;
 }
+
+/* Change language button in WP Admin bar */
+#wpadminbar #wp-admin-bar-change-lang > div {
+  padding: 0;
+  margin-right: 8px;
+}
+
+#wpadminbar #wp-admin-bar-change-lang input[type=submit] {
+  padding: 0 8px;
+  cursor: pointer;
+}
+
+#wpadminbar #wp-admin-bar-change-lang input[type=submit]:focus-visible {
+  outline: 2px solid #fd0;
+  outline-offset: -1px;
+}


### PR DESCRIPTION
# Summary | Résumé

This PR includes a language-switcher for the admin interface it changes the header toggle between both sites.

### Header toggle

See here for a description: https://github.com/cds-snc/gc-articles/pull/510

### Language switcher 

Built a little change-language form and got it working in the WP Admin Bar. Unlike the language switcher on the public facing site, which toggles between english and french pages, this one changes the backend interface between English and French. 

Note that the languages themselves are hardcoded.

I used the [Simple Admin Change Language](https://en-ca.wordpress.org/plugins/simple-admin-language-change/) for inspiration, although I ended up going a significantly different direction. The two major differences in my approach were:
1. Hardcode the two languages. The plugin loops through all 'installed' languages and displays them in a drop-down
2. Use a form to do a server-side language call. The plugin uses an Ajax call, requiring an extra script to be enqueued.

## Screenshot

<img width="1410" alt="Screen Shot 2022-01-31 at 10 54 50" src="https://user-images.githubusercontent.com/2454380/152176493-357d5711-f33d-4ad7-af94-3fed03e0f579.png">


## gif 

Form button looks the same as all the others, whether clicking it or tabbing over it.

![Screen Recording 2022-01-31 at 10 54 25](https://user-images.githubusercontent.com/2454380/152176556-161495b8-cbb6-46cd-9e7a-29b3860e5362.gif)

