### PR TITLE
Add blog description to site setting 

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -123,6 +123,17 @@ class SiteSettings
         );
 
         add_settings_field(
+            'blogdescription', // id
+            _('Site Description', 'cds-snc'), // title
+            array( $this, 'blogDescriptionCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section', // section
+            [
+                'label_for' => 'blogdescription'
+            ]
+        );
+
+        add_settings_field(
             'blog_public', // id
             _('Search engine visibility', 'cds-snc'), // title
             array( $this, 'indexSiteCallback'), // callback
@@ -169,6 +180,13 @@ class SiteSettings
                     'selected' => get_option('page_on_front'),
                 )
             );
+    }
+
+    public function blogDescriptionCallback()
+    {
+        ?>
+        <input name="blogdescription" type="text" id="blogdescription" class="regular-text" value="<?php echo get_bloginfo("name");?>">
+        <?php
     }
 
     public function indexSiteCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -88,6 +88,10 @@ class SiteSettings
             'collection_mode',
         );
 
+        register_setting(
+            'site_settings_group', // option_group
+            'blogname',
+        );
 
         register_setting(
             'site_settings_group', // option_group
@@ -125,6 +129,17 @@ class SiteSettings
             'collection_settings_section', // section
             [
                 'label_for' => 'page_on_front'
+            ]
+        );
+
+        add_settings_field(
+            'blogname', // id
+            _('Site Name', 'cds-snc'), // title
+            array( $this, 'blogNameCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section', // section
+            [
+                'label_for' => 'blogname'
             ]
         );
 
@@ -186,6 +201,13 @@ class SiteSettings
                     'selected' => get_option('page_on_front'),
                 )
             );
+    }
+
+    public function blogNameCallback()
+    {
+        ?>
+        <input name="blogname" type="text" id="blogname" class="regular-text" value="<?php echo get_option("blogname");?>">
+        <?php
     }
 
     public function blogDescriptionCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -85,7 +85,13 @@ class SiteSettings
 
         register_setting(
             'site_settings_group', // option_group
-            'blog_public',
+            'collection_mode',
+        );
+
+
+        register_setting(
+            'site_settings_group', // option_group
+            'blogdescription',
         );
 
         // add fields
@@ -185,7 +191,7 @@ class SiteSettings
     public function blogDescriptionCallback()
     {
         ?>
-        <input name="blogdescription" type="text" id="blogdescription" class="regular-text" value="<?php echo get_bloginfo("name");?>">
+        <input name="blogdescription" type="text" id="blogdescription" class="regular-text" value="<?php echo get_option("blogdescription");?>">
         <?php
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSetup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSetup.php
@@ -67,6 +67,8 @@ class SiteSetup
             update_option("collection_mode", "maintenance");
             update_option("blog_public", 0);
             update_option("options_set", 1);
+            update_option("options_set", 1);
+            update_option("blogdescription", get_bloginfo("name"));
 
             if (isset($_POST['homeId'])) {
                 $homeId = intval($_POST['homeId']);


### PR DESCRIPTION
Adds blog name and blog description to site setting 

The finish site setup for super admins will set the blog description to the site name ... as a default vs "Just another WP site"