### PR TITLE
feat: add WAF ACL and VPC logs to CBS satellite bucket

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
-  name        = "aws-waf-logs-platform-ircc"
+  name        = "aws-waf-logs-platform-mvp"
   destination = "extended_s3"
 
   server_side_encryption {
@@ -30,7 +30,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
 resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_us_east" {
   provider = aws.us-east-1
 
-  name        = "aws-waf-logs-platform-ircc-us-east"
+  name        = "aws-waf-logs-platform-mvp-us-east"
   destination = "extended_s3"
 
   server_side_encryption {

--- a/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
-  name        = "aws-waf-logs-platform-mvp"
+  name        = "aws-waf-logs-platform-mvp-${var.region}"
   destination = "extended_s3"
 
   server_side_encryption {
@@ -30,7 +30,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
 resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_us_east" {
   provider = aws.us-east-1
 
-  name        = "aws-waf-logs-platform-mvp-us-east"
+  name        = "aws-waf-logs-platform-mvp-us-east-1"
   destination = "extended_s3"
 
   server_side_encryption {

--- a/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
@@ -1,21 +1,29 @@
 #
 # Kinesis Firehose
 #
+locals {
+  cbs_satellite_bucket_arn    = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+  cbs_satellite_bucket_prefix = "waf_acl_logs/AWSLogs/${var.account_id}/"
+}
+
 resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs" {
   name        = "aws-waf-logs-platform-ircc"
-  destination = "s3"
+  destination = "extended_s3"
 
   server_side_encryption {
     enabled = true
   }
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose_waf_logs.arn
-    bucket_arn = module.firehose_waf_log_bucket.s3_bucket_arn
+  extended_s3_configuration {
+    role_arn           = aws_iam_role.firehose_waf_logs.arn
+    prefix             = local.cbs_satellite_bucket_prefix
+    bucket_arn         = local.cbs_satellite_bucket_arn
+    compression_format = "GZIP"
   }
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
   }
 }
 
@@ -23,19 +31,22 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_us_east" {
   provider = aws.us-east-1
 
   name        = "aws-waf-logs-platform-ircc-us-east"
-  destination = "s3"
+  destination = "extended_s3"
 
   server_side_encryption {
     enabled = true
   }
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose_waf_logs.arn
-    bucket_arn = module.firehose_waf_log_bucket.s3_bucket_arn
+  extended_s3_configuration {
+    role_arn           = aws_iam_role.firehose_waf_logs.arn
+    prefix             = local.cbs_satellite_bucket_prefix
+    bucket_arn         = local.cbs_satellite_bucket_arn
+    compression_format = "GZIP"
   }
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
   }
 }
 
@@ -52,7 +63,7 @@ module "firehose_waf_log_bucket" {
       id      = "expire"
       enabled = true
       expiration = {
-        days = 90
+        days = 30
       }
     }
   ]
@@ -100,8 +111,8 @@ data "aws_iam_policy_document" "firehose_waf_logs" {
       "s3:PutObject"
     ]
     resources = [
-      module.firehose_waf_log_bucket.s3_bucket_arn,
-      "${module.firehose_waf_log_bucket.s3_bucket_arn}/*"
+      local.cbs_satellite_bucket_arn,
+      "${local.cbs_satellite_bucket_arn}/*"
     ]
   }
   statement {

--- a/infrastructure/terragrunt/aws/network/vpc.tf
+++ b/infrastructure/terragrunt/aws/network/vpc.tf
@@ -17,6 +17,19 @@ module "wordpress_vpc" {
   billing_tag_value = var.billing_tag_value
 }
 
+resource "aws_flow_log" "cloud_based_sensor" {
+  log_destination      = "arn:aws:s3:::${var.cbs_satellite_bucket_name}/vpc_flow_logs/"
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = module.wordpress_vpc.vpc_id
+  log_format           = "$${vpc-id} $${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${subnet-id} $${instance-id}"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
 resource "aws_vpc_endpoint" "ecr-dkr" {
   vpc_id              = module.wordpress_vpc.vpc_id
   vpc_endpoint_type   = "Interface"


### PR DESCRIPTION
# Summary
Updates the WAF ACLs and VPC to send logs to the
Cloud Based Sensor satellite bucket.

The existing WAF ACL log bucket will be kept for 30
days to preserve traceability.

# Related
* Closes cds-snc/cloud-based-sensor#93