### PR TITLE
Remove OTGS auto update flag due to constant error log messages

### DIFF
--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -147,9 +147,6 @@ define('AWS_ACCESS_KEY_ID', getenv_docker('C3_AWS_ACCESS_KEY_ID', ''));
 define('AWS_SECRET_ACCESS_KEY', getenv_docker('C3_AWS_SECRET_ACCESS_KEY', ''));
 define('C3_DISTRIBUTION_ID', getenv_docker('C3_DISTRIBUTION_ID', ''));
 
-/* This is for WPML auto updates */
-define('OTGS_DISABLE_AUTO_UPDATES', true);
-
 /* Disable core updates */
 define('WP_AUTO_UPDATE_CORE', false);
 


### PR DESCRIPTION
# Summary | Résumé

The OTGS_DISABLE_AUTO_UPDATES flag causes a ton of errors in the logs. Removing for now. The result will be that on Staging we'll start to see WPML errors on the Dashboard suggesting to add this flag. When they appear, we'll figure out how to hide them again another way.
