### PR TITLE
Hide Yubikeys option in personal profile

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
@@ -109,15 +109,6 @@ class Profile
          *--------------------------------------------*/
         $crawler->filter('.user-sessions-wrap')->remove();
 
-        /*--------------------------------------------*
-         * Remove Yubikeys from the 2FA plugin
-         *--------------------------------------------*/
-        // Remove the last row of the 2FA table, which has the option to add Yubikeys
-        $crawler->filter('.two-factor-methods-table tbody tr:last-of-type')->remove();
-        // Remove the section about security keys
-        $crawler->filter('.security-keys')->remove();
-
-
         echo $crawler->save();
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
@@ -107,6 +107,15 @@ class Profile
          *--------------------------------------------*/
         $crawler->filter('.user-sessions-wrap')->remove();
 
+        /*--------------------------------------------*
+         * Remove Yubikeys from the 2FA plugin
+         *--------------------------------------------*/
+        // Remove the last row of the 2FA table, which has the option to add Yubikeys
+        $crawler->filter('.two-factor-methods-table tbody tr:last-of-type')->remove();
+        // Remove the section about security keys
+        $crawler->filter('.security-keys')->remove();
+
+
         echo $crawler->save();
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
@@ -95,8 +95,10 @@ class Profile
         /*--------------------------------------------*
          * Remove Yoast Settings
          *--------------------------------------------*/
-
         $crawler->filter('.yoast-settings')->remove();
+        $crawler->filter('#yoast-seo-schema ~ p')->remove();
+        $crawler->filter('#yoast-seo-schema')->remove();
+
         /*--------------------------------------------*
          * Remove Application Passwords Fields
          *--------------------------------------------*/

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TwoFactor/TwoFactor.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TwoFactor/TwoFactor.php
@@ -30,7 +30,6 @@ class TwoFactor
         return [
             'Two_Factor_Email' => TWO_FACTOR_DIR . 'providers/class-two-factor-email.php',
             'Two_Factor_Totp' => TWO_FACTOR_DIR . 'providers/class-two-factor-totp.php',
-            'Two_Factor_FIDO_U2F' => TWO_FACTOR_DIR . 'providers/class-two-factor-fido-u2f.php',
         ];
     }
 


### PR DESCRIPTION
# Summary | Résumé

This PR removes the "security keys" part of the two-factor plugin, and a bit of text about Yoast SEO which precedes it.

The Security Keys don't work in Chrome/Edge since Feb 2022, although there is a PR open on the repo to enable this. For now though, we should remove them as an option.

⚠️ Note that existing security keys can't be removed once this is released, let's remove them beforehand ⚠️ 

## Screenshots

| before | to remove | after |
|--------|-----------|-------|
|  ![Screen Shot 2022-02-08 at 09 26 42](https://user-images.githubusercontent.com/2454380/153008014-c62b8eb3-e5de-4466-b454-c55f52b30eff.png)   |    ![Screen Shot 2022-02-08 at 09 26 42 copy](https://user-images.githubusercontent.com/2454380/153008008-75691528-4d74-42e1-b342-ec2539fb2298.jpg)    |   ![Screen Shot 2022-02-08 at 09 27 03](https://user-images.githubusercontent.com/2454380/153008017-7c0ba63b-6d82-4124-9e2c-61fd8cd15006.png)   |

