### PR TITLE
Add environments manifest

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,0 +1,14 @@
+# Deployed container versions
+# The versions here refer to the deployed versions of the respective containers in ECS. These versions are picked
+# up in the terragrunt.hcl files in the ECS module.
+#
+# These should correspond with the following files:
+# ./VERSION
+# ./wordpress/docker/apache/VERSION
+#
+production:
+  apache: 1.0.19
+  wordpress: 2.14.4
+staging:
+  apache: 1.0.19
+  wordpress: 2.15.1


### PR DESCRIPTION
# Summary | Résumé

In anticipation of a bigger change to how our deployments are handled, this adds a manifest file that tracks container versions in our ecs environments. Merging this will have no effect, it's just capturing the current versions.
