### PR TITLE
Fix admin language switcher

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -111,7 +111,7 @@ class AdminBar
             check_admin_referer('change_lang', 'cds_change_lang_nonce')
         ) {
             // sanitize the input
-            $lang = sanitize_key($_POST['locale']);
+            $lang = sanitize_text_field($_POST['locale']);
             $user_id = get_current_user_id();
             wp_update_user(['ID' => $user_id, 'locale' => $lang]);
             wp_redirect(esc_url_raw($_POST['_wp_http_referer']));

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -113,7 +113,17 @@ class AdminBar
             // sanitize the input
             $lang = sanitize_text_field($_POST['locale']);
             $user_id = get_current_user_id();
+
             wp_update_user(['ID' => $user_id, 'locale' => $lang]);
+
+            // change default lang for sitepress if WPML is installed
+            global $sitepress;
+            if ($sitepress) {
+                // grab "en" or "fr"
+                $base_lang =  substr($lang, 0, 2);
+                $sitepress->set_default_language($base_lang);
+            }
+
             wp_redirect(esc_url_raw($_POST['_wp_http_referer']));
             die();
         } else {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -116,13 +116,9 @@ class AdminBar
 
             wp_update_user(['ID' => $user_id, 'locale' => $lang]);
 
-            // change default lang for sitepress if WPML is installed
-            global $sitepress;
-            if ($sitepress) {
-                // grab "en" or "fr"
-                $base_lang =  substr($lang, 0, 2);
-                $sitepress->set_default_language($base_lang);
-            }
+            // get "en" or "fr"
+            $base_lang =  substr($lang, 0, 2);
+            update_user_meta($user_id, 'icl_admin_language', $base_lang);
 
             wp_redirect(esc_url_raw($_POST['_wp_http_referer']));
             die();

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -16,6 +16,23 @@ class AdminBar
 
         add_action('admin_bar_menu', [$this, 'addLanguageSwitcher'], 21);
         add_action('admin_post_cds_change_lang', [$this, 'handleLanguageSwitcherResponse']);
+
+        add_action('admin_menu', [$this, 'redirectNewPostToLocale']);
+    }
+
+    public function redirectNewPostToLocale(): void
+    {
+        global $pagenow;
+        $current_lang = sanitize_text_field($_GET['lang'] ?? null);
+
+        if ($pagenow === 'post-new.php' && is_null($current_lang)) {
+            $lang = get_user_locale();
+            $base_lang =  substr($lang, 0, 2);
+            $url = add_query_arg('lang', $base_lang);
+
+            wp_redirect($url);
+            exit;
+        }
     }
 
     public function addAdminToggle($wp_admin_bar): void


### PR DESCRIPTION
# Summary | Résumé

This PR (I think 🤞) allows editors to change the WP backend between (Canadian) English and (Canadian) French.

It turns out it's not straightforward at all. It's not a large PR but it took me like 2 days to get this far.

What I settled on was flipping the user locale to en_CA and fr_CA (previously these values would be lowercased), and changing a DB value called `icl_admin_language` between `en` and `fr`, so that at least WPML knows what language the backend is supposed to be in.

I also added a hook so that when new pages or new posts are created, they are opened in the user's current language.

## Settings -> General in both languages

| en_CA | fr_CA |
|-------|-------|
|  <img width="1457" alt="Screen Shot 2022-02-09 at 14 02 43" src="https://user-images.githubusercontent.com/2454380/153272066-03f26698-afa7-48a8-9f18-dcf312c13b74.png">   | <img width="1457" alt="Screen Shot 2022-02-09 at 14 02 48" src="https://user-images.githubusercontent.com/2454380/153272072-02e118b1-9c6e-42c1-ae11-3d9d0a40d88f.png">   | 



## Notes

There are lots of different language settings, but here are the 4 main ones:
1. `WPLANG`, which is the "site language" in general. Once WPML is installed, this value seems to not be referenced anymore.
2. `Profile -> Language`. This is a per-user language setting. It uses the full language string (`en_CA` or `fr_CA`), or it can be "default", which makes it an empty string. However, if we set this to an empty string, WPML defaults us to `en_US` and `fr_FR`.
3. `WPML -> Languages -> Site Languages`. This is a per-site setting, and it overrides `WPLANG`. I thought this had something to do with translating the admin interface, but it will only do it _if_ the user's `locale` is empty. If there is an explicit locale set, it no longer applies. It also breaks all the URLs, so we don't actually want to switch this.
4. "English/French" on the public-facing site. This isn't a language setting per sé, it just toggles between pages. However, if we change the WPML Default Language, we can break the whole site. 

### WPML Site Languages (default language)

I spent a bunch of time trying to get this to change programatically (see [commit #2](https://github.com/cds-snc/gc-articles/commit/3799d45e3725a0a03e9fff4d6aea90c94a916df3)), but this is something we don't want, actually. Changing the default language in the backend doesn't appear to do much, but it changes all the URLs for the public site.

For example, for "English (default)", our URLs look like this: 
- (EN homepage) `articles.ca/home`
- (FR homepage) `articles.ca/fr/home`

If we change this setting to "French (default)", then the URLs change:
- (EN homepage) `articles.ca/en/home`
- (FR homepage) `artciles.ca/home`

So, long story short, changing this every time an admin changes their language in the backend is a terrible idea.

### `en_CA`/`en_US` vs `fr_CA`/`fr_FR` as the locale setting

Locally, both the English and French Canadian settings work the same to translate the backend interface. However, the major difference between them is that _none_ of the WPML stuff translates itself when the locale is set to `fr_CA`. If we set the user's locale option to `fr_FR`, then WPML respects that, or if we clear the locale value (set it to an empty string), WPML respects that too, but if you then ask WP what your locale is, it returns `fr_FR`. 

Essentially, if we are not explicit with Canadian French/English, WordPress will default to France French and US English, which is what WPML expects to see. However, we have git included all the `en_CA` and `fr_CA` language files already, so we are in too deep to change now.

All to say, `fr_CA` changes most of the WP backend interface to French, but all the WPML stuff stays in English. This should be fine for us, since we don't allow GC Editors or Admins to see any WPML controlled settings. 

#### User profile in both languages

| en_CA | fr_CA |
|-------|-------|
|  <img width="1457" alt="Screen Shot 2022-02-09 at 13 33 07" src="https://user-images.githubusercontent.com/2454380/153272225-ed896e5b-0804-4197-8e58-ec9b342eb3cd.png">   |  <img width="1457" alt="Screen Shot 2022-02-09 at 13 33 03" src="https://user-images.githubusercontent.com/2454380/153272219-7842bccb-2166-4d6d-b60c-8136e69c5929.png">   |

#### WPML -> Languages in both languages

| en_CA | fr_CA |
|-------|-------|
| <img width="1457" alt="Screen Shot 2022-02-09 at 14 00 05" src="https://user-images.githubusercontent.com/2454380/153272232-81b21b2a-dc43-4790-b0b3-aea564831a16.png">   |    <img width="1457" alt="Screen Shot 2022-02-09 at 14 00 00" src="https://user-images.githubusercontent.com/2454380/153272229-fdfa3544-6dfd-422d-a3a9-c025633dff43.png"> |


### Redirect on new posts/pages

I thought that the WPML 'Default Language' was controlling whether new pages defaulted to english or french. It turns out that this is set via a query parameter, and they are not really consistently applied. 

I created a hook that looks for a `lang` query param when a new page or post is being created, and, if missing, sets it to the current locale. That solves our use case like 95% of the time.



