### PR TITLE
Add environments manifest workflow

### DIFF
--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -1,0 +1,76 @@
+name: "Environments version manifest"
+
+# Gets the following content from the `environments.yml` manifest:
+# 1. [ENV]_WORDPRESS: the target version for the Terraform plan and apply on Staging.
+# 2. PREV_[ENV]_WORDPRESS: the previously deployed Terraform version.
+
+on:
+  workflow_call:
+    outputs:
+      STAG_WORDPRESS:
+        description: "The current version of the Staging Wordpress container"
+        value: ${{ jobs.environments-manifest.outputs.STAG_WORDPRESS }}
+      PREV_STAG_WORDPRESS:
+        description: "The previous version of the Staging Wordpress container"
+        value: ${{ jobs.environments-manifest.outputs.PREV_STAG_WORDPRESS }}
+      PROD_WORDPRESS:
+        description: "The current version of the Production Wordpress container"
+        value: ${{ jobs.environments-manifest.outputs.PROD_WORDPRESS }}
+      PREV_PROD_WORDPRESS:
+        description: "The previous version of the Production Wordpress container"
+        value: ${{ jobs.environments-manifest.outputs.PREV_PROD_WORDPRESS }}
+      PROD_DEPLOYMENT:
+        description: "Boolean flag to indicate if we're dealing with a Prod deployment"
+        value: ${{ jobs.environments-manifest.outputs.PROD_DEPLOYMENT }}
+
+jobs:
+  environments-manifest:
+    runs-on: ubuntu-latest
+    outputs:
+      PROD_WORDPRESS: ${{ steps.versions.outputs.PROD_WORDPRESS }}
+      STAG_WORDPRESS: ${{ steps.versions.outputs.STAG_WORDPRESS }}
+      PREV_PROD_WORDPRESS: ${{ steps.previous.outputs.PROD_WORDPRESS }}
+      PREV_STAG_WORDPRESS: ${{ steps.previous.outputs.STAG_WORDPRESS }}
+      PROD_DEPLOYMENT: ${{ steps.environment.outputs.PROD_DEPLOYMENT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Versions
+        id: versions
+        run: |
+          PROD_WORDPRESS=$(yq '.production.wordpress' < ./infrastructure/environments.yml)
+          STAG_WORDPRESS=$(yq '.production.apache' < ./infrastructure/environments.yml)
+          echo "$(cat ./infrastructure/environments.yml)"
+          echo "::set-output name=PROD_WORDPRESS::${PROD_WORDPRESS}"
+          echo "::set-output name=STAG_WORDPRESS::${STAG_WORDPRESS}"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Previous versions
+        id: previous
+        run: |
+          git branch
+          PREV_ENVIRONMENTS_YML="$(git show main:infrastructure/environments.yml)"
+          echo "$PREV_ENVIRONMENTS_YML"
+          PROD_WORDPRESS=$(echo "$PREV_ENVIRONMENTS_YML" | yq '.production.wordpress' -)
+          STAG_WORDPRESS=$(echo "$PREV_ENVIRONMENTS_YML" | yq '.staging.wordpress' -)
+          echo "::set-output name=PROD_WORDPRESS::${PROD_WORDPRESS}"
+          echo "::set-output name=STAG_WORDPRESS::${STAG_WORDPRESS}"
+
+      - name: Deploy environment
+        id: environment
+        run: |
+          if [ ${{ steps.previous.outputs.PROD_WORDPRESS }} != ${{ steps.versions.outputs.PROD_WORDPRESS }} ]; then
+            echo "PROD_DEPLOYMENT=true"
+            echo "::set-output name=PROD_DEPLOYMENT::true"
+          else
+            echo "PROD_DEPLOYMENT=false"
+            echo "::set-output name=PROD_DEPLOYMENT::false"
+          fi


### PR DESCRIPTION
# Summary | Résumé

In anticipation of a coming update (#535) to deployment workflows. Adds an environments-manifest workflow that parses the new (#534) `environments.yml` manifest file and creates some outputs for use in related workflows.

The following outputs are generated:

STAG_WORDPRESS: The current version of the Staging Wordpress container
PREV_STAG_WORDPRESS: The previous version of the Staging Wordpress container
PROD_WORDPRESS: The current version of the Production Wordpress container
PREV_PROD_WORDPRESS: The previous version of the Production Wordpress container
PROD_DEPLOYMENT: Boolean flag to indicate if we're dealing with a Prod deployment