### PR TITLE
chore: increase 5xx alarm threshold to > 5

### DIFF
--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -61,7 +61,7 @@ inputs = {
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
-  alb_target_5xx_maximum                   = 0
+  alb_target_5xx_maximum                   = 5
   alb_target_4xx_maximum                   = 100
 
   canary_healthcheck_url_eng = "https://articles.alpha.canada.ca/"

--- a/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -61,7 +61,7 @@ inputs = {
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
-  alb_target_5xx_maximum                   = 0
+  alb_target_5xx_maximum                   = 5
   alb_target_4xx_maximum                   = 100
 
   canary_healthcheck_url_eng = "https://articles.cdssandbox.xyz/"


### PR DESCRIPTION
# Summary
The current threshold is too low and just causing noise in the ops channels.