### PR TITLE
Use a CONTAINER_DEPLOYMENT flag to determine whether to run ECS

### DIFF
--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -19,9 +19,9 @@ on:
       PREV_PROD_WORDPRESS:
         description: "The previous version of the Production Wordpress container"
         value: ${{ jobs.environments-manifest.outputs.PREV_PROD_WORDPRESS }}
-      PROD_DEPLOYMENT:
+      CONTAINER_DEPLOYMENT:
         description: "Boolean flag to indicate if we're dealing with a Prod deployment"
-        value: ${{ jobs.environments-manifest.outputs.PROD_DEPLOYMENT }}
+        value: ${{ jobs.environments-manifest.outputs.CONTAINER_DEPLOYMENT }}
 
 jobs:
   environments-manifest:
@@ -31,7 +31,7 @@ jobs:
       STAG_WORDPRESS: ${{ steps.versions.outputs.STAG_WORDPRESS }}
       PREV_PROD_WORDPRESS: ${{ steps.previous.outputs.PROD_WORDPRESS }}
       PREV_STAG_WORDPRESS: ${{ steps.previous.outputs.STAG_WORDPRESS }}
-      PROD_DEPLOYMENT: ${{ steps.environment.outputs.PROD_DEPLOYMENT }}
+      CONTAINER_DEPLOYMENT: ${{ steps.environment.outputs.CONTAINER_DEPLOYMENT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,9 +68,12 @@ jobs:
         id: environment
         run: |
           if [ ${{ steps.previous.outputs.PROD_WORDPRESS }} != ${{ steps.versions.outputs.PROD_WORDPRESS }} ]; then
-            echo "PROD_DEPLOYMENT=true"
-            echo "::set-output name=PROD_DEPLOYMENT::true"
+            echo "CONTAINER_DEPLOYMENT=production"
+            echo "::set-output name=CONTAINER_DEPLOYMENT::production"
+          elif [ ${{ steps.previous.outputs.STAG_WORDPRESS }} != ${{ steps.versions.outputs.STAG_WORDPRESS }} ]; then
+            echo "CONTAINER_DEPLOYMENT=staging"
+            echo "::set-output name=CONTAINER_DEPLOYMENT::staging"
           else
-            echo "PROD_DEPLOYMENT=false"
-            echo "::set-output name=PROD_DEPLOYMENT::false"
+            echo "CONTAINER_DEPLOYMENT=false"
+            echo "::set-output name=CONTAINER_DEPLOYMENT::false"
           fi

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -142,7 +142,7 @@ jobs:
 
       # Load-balancer & database dependency
       - name: Terragrunt apply ecs
-        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' }}
+        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' || needs.environments-manifest.outputs.CONTAINER_DEPLOYMENT == 'true' }}
         working-directory: infrastructure/terragrunt/env/prod/ecs
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -53,9 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: environments-manifest
 
-    if: |
-      github.ref == 'refs/heads/main' && github.event_name == 'push' &&
-      needs.environments-manifest.outputs.PROD_DEPLOYMENT == 'false'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -142,7 +140,7 @@ jobs:
 
       # Load-balancer & database dependency
       - name: Terragrunt apply ecs
-        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' }}
+        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' || needs.environments-manifest.outputs.CONTAINER_DEPLOYMENT == 'staging' }}
         working-directory: infrastructure/terragrunt/env/staging/ecs
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -55,7 +55,6 @@ jobs:
       PREVIOUS_VERSION: ${{ needs.version-manifest.outputs.previous }}
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -183,7 +182,7 @@ jobs:
 
       # Load-balancer & database dependency
       - name: Terragrunt plan ecs
-        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' }}
+        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' || needs.environments-manifest.outputs.CONTAINER_DEPLOYMENT == 'production' }}
         uses: cds-snc/terraform-plan@v1
         with:
           directory: "infrastructure/terragrunt/env/prod/ecs"

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -51,8 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: environments-manifest
 
-    if: needs.environments-manifest.outputs.PROD_DEPLOYMENT == 'false'
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -168,7 +166,7 @@ jobs:
 
       # Load-balancer & database dependency
       - name: Terragrunt plan ecs
-        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' }}
+        if: ${{ steps.filter.outputs.ecs == 'true' || steps.filter.outputs.common == 'true' || needs.environments-manifest.outputs.CONTAINER_DEPLOYMENT == 'staging' }}
         uses: cds-snc/terraform-plan@v1
         with:
           directory: "infrastructure/terragrunt/env/staging/ecs"


### PR DESCRIPTION
# Summary | Résumé

The previous updates to the deploy scripts had a bug: the ECS apply wasn't triggered because the path-filter only triggers when the ECS module files change. For container deploys, we no longer modify the module files directly, we just update the manifest.

This replaces the previous PROD_DEPLOYMENT boolean flag to a CONTAINER_DEPLOYMENT flag that specifies either production, staging, or false (no container deployment), which can then be used to determine whether to run the ECS plan/apply in the different environments.
