### PR TITLE
Add workflow to deploy Production wordpress container

### DIFF
--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -112,6 +112,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Testing
+        run: |
+          cat infrastructure/environments.yml
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
         with:

--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -63,8 +63,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ env.TARGET_VERSION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
@@ -111,10 +109,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Testing
-        run: |
-          cat infrastructure/environments.yml
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2

--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -1,0 +1,134 @@
+name: "Terragrunt deploy PRODUCTION container"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "infrastructure/environments.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "infrastructure/environments.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.0.10
+  TERRAGRUNT_VERSION: 0.35.6
+  TF_INPUT: false
+  TF_VAR_database_name: ${{ secrets.PRODUCTION_DATABASE_NAME }}
+  TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
+  TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
+  TF_VAR_cloudfront_custom_header_name: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_NAME }}
+  TF_VAR_cloudfront_custom_header_value: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
+  TF_VAR_list_manager_endpoint: ${{ secrets.PRODUCTION_LIST_MANAGER_ENDPOINT }}
+  TF_VAR_default_list_manager_api_key: ${{ secrets.PRODUCTION_DEFAULT_LIST_MANAGER_API_KEY }}
+  TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}
+  TF_VAR_encryption_key: ${{ secrets.PRODUCTION_ENCRYPTION_KEY }}
+  TF_VAR_s3_uploads_bucket: ${{ secrets.PRODUCTION_S3_UPLOADS_BUCKET }}
+  TF_VAR_s3_uploads_key: ${{ secrets.PRODUCTION_S3_UPLOADS_KEY }}
+  TF_VAR_s3_uploads_secret: ${{ secrets.PRODUCTION_S3_UPLOADS_SECRET }}
+  TF_VAR_c3_aws_access_key_id: ${{ secrets.PRODUCTION_C3_AWS_ACCESS_KEY_ID }}
+  TF_VAR_c3_aws_secret_access_key: ${{ secrets.PRODUCTION_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_slack_webhook_url: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_URL }}
+  TF_VAR_wordpress_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_AUTH_KEY }}
+  TF_VAR_wordpress_secure_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_SECURE_AUTH_KEY }}
+  TF_VAR_wordpress_logged_in_key: ${{ secrets.PRODUCTION_WORDPRESS_LOGGED_IN_KEY }}
+  TF_VAR_wordpress_nonce_key: ${{ secrets.PRODUCTION_WORDPRESS_NONCE_KEY }}
+  TF_VAR_wordpress_auth_salt: ${{ secrets.PRODUCTION_WORDPRESS_AUTH_SALT }}
+  TF_VAR_wordpress_secure_auth_salt: ${{ secrets.PRODUCTION_WORDPRESS_SECURE_AUTH_SALT }}
+  TF_VAR_wordpress_logged_in_salt: ${{ secrets.PRODUCTION_WORDPRESS_LOGGED_IN_SALT }}
+  TF_VAR_wordpress_nonce_salt: ${{ secrets.PRODUCTION_WORDPRESS_NONCE_SALT }}
+  TF_VAR_jwt_auth_secret_key: ${{ secrets.PRODUCTION_JWT_AUTH_SECRET_KEY }}
+  TF_VAR_wpml_site_key: ${{ secrets.PRODUCTION_WPML_SITE_KEY }}
+
+jobs:
+  environments-manifest:
+    uses: cds-snc/gc-articles/.github/workflows/environments-manifest.yml@main
+
+  terragrunt-plan-production:
+    needs: environments-manifest
+    runs-on: ubuntu-latest
+
+    if: github.ref != 'refs/heads/main' && github.event_name == 'pull_request'
+
+    env:
+      TARGET_VERSION: ${{ needs.environments-manifest.outputs.PROD_WORDPRESS }}
+      PREVIOUS_VERSION: ${{ needs.environments-manifest.outputs.PREV_PROD_WORDPRESS }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_VERSION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Terragrunt
+        run: |
+          mkdir bin
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/*
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Install Conftest
+        run: |
+          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
+          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
+          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
+          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
+          && mv conftest /usr/local/bin \
+          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
+
+      # Load-balancer & database dependency
+      - name: Terragrunt plan ecs
+        if: ${{ needs.environments-manifest.outputs.CONTAINER_DEPLOYMENT == 'production' }}
+        uses: cds-snc/terraform-plan@v1
+        with:
+          directory: "infrastructure/terragrunt/env/prod/ecs"
+          comment-delete: "true"
+          comment-title: "Production: ecs"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+  terragrunt-apply-production:
+    needs: environments-manifest
+    runs-on: ubuntu-latest
+
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    env:
+      TARGET_VERSION: ${{ needs.environments-manifest.outputs.PROD_WORDPRESS }}
+      PREVIOUS_VERSION: ${{ needs.environments-manifest.outputs.PREV_PROD_WORDPRESS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_VERSION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Terragrunt
+        run: |
+          mkdir bin
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/*
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      # Load-balancer & database dependency
+      - name: Terragrunt apply ecs
+        if: ${{ needs.environments-manifest.outputs.CONTAINER_DEPLOYMENT == 'production' }}
+        working-directory: infrastructure/terragrunt/env/prod/ecs
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -111,8 +111,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ env.TARGET_VERSION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2

--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.0.19
-  wordpress: 2.14.4
+  wordpress: 2.16.1
 staging:
   apache: 1.0.19
   wordpress: 2.16.1

--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.0.19
-  wordpress: 2.16.1
+  wordpress: 2.14.4
 staging:
   apache: 1.0.19
   wordpress: 2.16.1


### PR DESCRIPTION
# Summary | Résumé

Adds a github actions workflow to deploy a WordPress container to Production using the new environments.yml versions manifest. 

Note that this workflow contains both `terragrunt plan` and `terragrunt apply` actions. 
- Plan runs on PRs to main 
- Apply runs on merge to main.

Once this is merged, steps to deploy a container to production will be:
- Update `infrastructure/environments.yml` with the new Production container version
- Create a PR
- Merge PR
