### PR TITLE
Environments Manifest: Use prev changed ref when on main

### DIFF
--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -56,8 +56,12 @@ jobs:
       - name: Previous versions
         id: previous
         run: |
-          git branch
-          PREV_ENVIRONMENTS_YML="$(git show main:infrastructure/environments.yml)"
+          if [ ${{ github.head_ref }} == 'main' ]; then
+            PREV_SHA="$(git show -2 --pretty=format:"%h" --no-patch infrastructure/environments.yml | tail -n 1)"
+            PREV_ENVIRONMENTS_YML="$(git show ${PREV_SHA}:infrastructure/environments.yml)"
+          else
+            PREV_ENVIRONMENTS_YML="$(git show main:infrastructure/environments.yml)"
+          fi
           echo "$PREV_ENVIRONMENTS_YML"
           PROD_WORDPRESS=v$(echo "$PREV_ENVIRONMENTS_YML" | yq '.production.wordpress' -)
           STAG_WORDPRESS=v$(echo "$PREV_ENVIRONMENTS_YML" | yq '.staging.wordpress' -)


### PR DESCRIPTION
# Summary | Résumé

Updates the environments manifest ref for previous versions. 

#560 failed because once the manifest file has merged to main, we were just comparing the file against itself and the workflow wouldn't run.

So the Previous Versions job has been updated so:
- If on a PR, use the manifest file in main as the ref
- If on main, use the last change to the manifest file as the ref

This works because:
- When on a PR, the manifest file in main will always be the last deployed versions.
- When on main, the last time the manifest file was updated will always be the last deployed versions.