### PR TITLE
Use ref_name for current branch check

### DIFF
--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Previous versions
         id: previous
         run: |
-          echo "Current branch: ${{ github.ref_name }}"
           if [ ${{ github.ref_name }} == 'main' ]; then
             PREV_SHA="$(git show -2 --pretty=format:"%h" --no-patch infrastructure/environments.yml | tail -n 1)"
             PREV_ENVIRONMENTS_YML="$(git show ${PREV_SHA}:infrastructure/environments.yml)"

--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Previous versions
         id: previous
         run: |
-          echo ${{ github.ref_name }}
+          echo "Current branch: ${{ github.ref_name }}"
           if [ ${{ github.ref_name }} == 'main' ]; then
             PREV_SHA="$(git show -2 --pretty=format:"%h" --no-patch infrastructure/environments.yml | tail -n 1)"
             PREV_ENVIRONMENTS_YML="$(git show ${PREV_SHA}:infrastructure/environments.yml)"

--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Previous versions
         id: previous
         run: |
-          if [ ${{ github.head_ref }} == 'main' ]; then
+          echo ${{ github.ref_name }}
+          if [ ${{ github.ref_name }} == 'main' ]; then
             PREV_SHA="$(git show -2 --pretty=format:"%h" --no-patch infrastructure/environments.yml | tail -n 1)"
             PREV_ENVIRONMENTS_YML="$(git show ${PREV_SHA}:infrastructure/environments.yml)"
           else

--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.0.19
-  wordpress: 2.14.4
+  wordpress: 2.16.1
 staging:
   apache: 1.0.19
   wordpress: 2.16.1

--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.0.19
-  wordpress: 2.16.1
+  wordpress: 2.14.4
 staging:
   apache: 1.0.19
   wordpress: 2.16.1


### PR DESCRIPTION
# Summary | Résumé

Deployment #565 failed because we tried using `github.head_ref` to determine current branch, but that only works on PRs. This replaces that with `github.ref_name` which always refers to the branch or tag that triggered the workflow run.
