### PR TITLE
Revert prodution container version

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.0.19
-  wordpress: 2.16.1
+  wordpress: 2.14.4
 staging:
   apache: 1.0.19
   wordpress: 2.16.1


### PR DESCRIPTION
# Summary | Résumé

Reverting the production container version again as #565 failed again. This time due to a github ref error, to be fixed in #566 
