### PR TITLE
"Collections" → "Sites"

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -11,7 +11,7 @@ class AdminBar
         add_action('admin_bar_menu', [$this, 'removeFromAdminBar'], 2147483647);
         add_action('wp_before_admin_bar_render', [$this, 'removeFromAdminBarBefore'], 99);
 
-        add_action('admin_bar_menu', [$this, 'addCollections'], 21);
+        add_action('admin_bar_menu', [$this, 'addSites'], 21);
         add_action('admin_bar_menu', [$this, 'addAdminToggle'], 21);
 
         add_action('admin_bar_menu', [$this, 'addLanguageSwitcher'], 21);
@@ -148,18 +148,18 @@ class AdminBar
         }
     }
 
-    public function addCollections($wp_admin_bar): void
+    public function addSites($wp_admin_bar): void
     {
-        // if less than 2 collections or a superadmin, skip this
+        // if less than 2 sites or a superadmin, skip this
         if (count($wp_admin_bar->user->blogs) < 2 || is_super_admin()) {
             return;
         }
 
-        $root_id = 'my-collections';
+        $root_id = 'cds-my-sites';
         $wp_admin_bar->add_node([
             'id'    =>  $root_id,
             'title' => '<div class="ab-item"><span class="ab-icon"></span>' . __(
-                'My Collections',
+                'My Sites',
                 'cds-snc'
             ) . '</div>'
         ]);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/CreateSites.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/CreateSites.php
@@ -4,30 +4,30 @@ declare(strict_types=1);
 
 namespace CDS\Modules\Cleanup;
 
-class SitesToCollections
+class CreateSites
 {
     public string $adminEmailMessage;
-    public string $collectionMessage;
+    public string $siteMessage;
 
     public function __construct()
     {
         $this->adminEmailMessage = __('Admin Email <strong>must be</strong> a current Super Admin', 'cds-snc');
-        $this->collectionMessage = __('or else a Collection won’t be created', 'cds-snc');
+        $this->siteMessage = __('or else a new Site won’t be created', 'cds-snc');
 
-        // add message to the Add New Collection Form
-        add_action('network_site_new_form', [$this, 'editNewCollectionForm']);
-        // throw an error if a new user is attepted to be created when adding a New Collection
+        // add message to the Add New Site Form
+        add_action('network_site_new_form', [$this, 'editNewSiteForm']);
+        // throw an error if a new user is attepted to be created when adding a new site
         add_action('pre_network_site_new_created_user', [$this, 'dieIfNewUser']);
     }
 
-    public function editNewCollectionForm(): void
+    public function editNewSiteForm(): void
     {
         // remove the existing message
         print "<style>.form-field:last-of-type {display: none;}</style>";
         printf(
             "<p>%s, %s.</p>",
             $this->adminEmailMessage,
-            $this->collectionMessage
+            $this->siteMessage
         );
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -27,7 +27,7 @@
   top: 3px;
 }
 
-#wpadminbar #wp-admin-bar-my-collections .ab-icon:before {
+#wpadminbar #wp-admin-bar-cds-my-sites .ab-icon:before {
   content: '\f541';
   top: 3px;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/DBInsights/src/DBInsights.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/DBInsights/src/DBInsights.tsx
@@ -33,7 +33,7 @@ const DBInsights = ({
     <div className="wp-list-table">
       <h4>
         <span style={{ color: "red" }} className="dashicons dashicons-warning"></span>
-        {__(' Tables exist from deleted collections', 'cds-snc')}
+        {__(' Tables exist from deleted sites', 'cds-snc')}
       </h4>
       <div className="faded-edge" style={{ paddingLeft: 30, height: 200, overflowY: "scroll" }}>
         {rows}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/UserCollections/UserCollections.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/UserCollections/UserCollections.php
@@ -50,7 +50,7 @@ class UserCollections
     {
         wp_add_dashboard_widget(
             'cds_collections_widget',
-            __('Your collections', 'cds'),
+            __('Your sites', 'cds'),
             [$this, 'userCollectionsPanelHandler'],
         );
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Setup.php
@@ -17,7 +17,7 @@ use CDS\Modules\Cleanup\PostsToArticles;
 use CDS\Modules\Cleanup\PrintStyles as CleanupPrintStyles;
 use CDS\Modules\Cleanup\Profile as CleanupProfile;
 use CDS\Modules\Cleanup\Roles as CleanupRoles;
-use CDS\Modules\Cleanup\SitesToCollections;
+use CDS\Modules\Cleanup\CreateSites;
 use CDS\Modules\Cleanup\Media;
 use CDS\Modules\Cli\GenerateEncryptionKey;
 use CDS\Modules\Contact\Setup as ContactForm;
@@ -111,7 +111,7 @@ class Setup
 
     public function cleanup()
     {
-        new SitesToCollections();
+        new CreateSites();
         new PostsToArticles();
         new CleanupRoles();
         new CleanupLogin();


### PR DESCRIPTION
# Summary | Résumé

"Collections" is a bad word — I don't know _who_ thought of it — and we don't permit that language in this house any longer, young man. 

Did a bit of a sweep through some of the UI changes we've made and found 3 places we were still calling them "Collections".
- in the wp-admin bar when you have multiple sites
- on the dashboard, we had a "your collections" widget
- when creating a new site, we would say you needed to assign a super admin to the new 'collection'

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/246

## WP Admin menu (for users with more than 1 site)

| before | after |
|--------|-------|
|   <img width="500" alt="Screen Shot 2022-02-17 at 11 30 56" src="https://user-images.githubusercontent.com/2454380/154528798-e5ce7aeb-00eb-4b33-8ac9-ad35326f6c76.png">  |  <img width="457" alt="Screen Shot 2022-02-17 at 11 28 31" src="https://user-images.githubusercontent.com/2454380/154528788-5d0ffb9d-d7a9-48bd-919a-092bd4448405.png">  |

## Dashboard widget

| before | after |
|--------|-------|
|  <img width="538" alt="Screen Shot 2022-02-17 at 11 30 15" src="https://user-images.githubusercontent.com/2454380/154528797-099ce899-123e-49f3-8727-ad7d3b2e313a.png">   |   <img width="547" alt="Screen Shot 2022-02-17 at 11 28 42" src="https://user-images.githubusercontent.com/2454380/154528795-b2829528-2f76-42e0-a436-67af9a38cbd6.png"> |

## Creating a new site screen

| before | after |
|--------|-------|
| <img width="735" alt="Screen Shot 2022-02-17 at 11 31 55" src="https://user-images.githubusercontent.com/2454380/154528800-53864ae5-6fa9-4bfd-a7a5-92ab7c84b740.png">    |  <img width="734" alt="Screen Shot 2022-02-17 at 11 33 32" src="https://user-images.githubusercontent.com/2454380/154528803-554e6114-9b26-4f52-8723-005d22ce6954.png">  |





