### PR TITLE
Fix alert elements

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor-and-public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor-and-public.css
@@ -87,3 +87,28 @@ body:not(.wp-admin) table tbody tr td,
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt {
   margin: 10px 0 20px 0;
 }
+
+/* Details */
+/* Remove bottom margin on open details elements and open alerts */
+section[class^="wp-block"] details[open],
+details[class^="wp-block"][open] {
+  padding-bottom: 0;
+}
+
+/* Alerts */
+.wp-block-cds-snc-alert details.alert {
+  /* Fix weird border glitch on closed alerts */
+  border-image: none;
+  margin-left: 0;
+}
+
+/* Align the alert icon with the title */
+.wp-block-cds-snc-alert details.alert:before,
+.wp-block-cds-snc-alert details.alert[open]:before {
+  padding: 0;
+  margin: 0;
+  padding-top: 15px;
+  margin-left: -1.3em;
+  top: unset;
+  line-height: unset;
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -35,3 +35,21 @@ header .gcweb-menu {
   background-color: #bbbfc5;
   border-color: #989da6;
 }
+
+/* Alerts */
+.wp-block-cds-snc-alert details.alert {
+  /* Fix weird border glitch on closed alerts */
+  border-image: none;
+  margin-left: 0;
+}
+
+/* Align the alert icon with the title */
+.wp-block-cds-snc-alert details.alert:before,
+.wp-block-cds-snc-alert details.alert[open]:before {
+  padding: 0;
+  margin: 0;
+  padding-top: 15px;
+  margin-left: -1.3em;
+  top: unset;
+  line-height: unset;
+}


### PR DESCRIPTION
# Summary | Résumé

Made some CSS interventions to fix the weird layouts we were seeing:

- Fixed the left border glitch when alerts were collapsed
- Make sure the icon is aligned with the alert title
- Left align alerts with other content
- Remove too-large bottom margin for open alerts

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/210

## Screenshot

| before | after |
|--------|-------|
|   <img width="1209" alt="Screen Shot 2022-02-18 at 09 36 43" src="https://user-images.githubusercontent.com/2454380/154703026-5eea5ca0-6c8f-4ac6-abf9-8e281262e212.png">   |    <img width="1209" alt="Screen Shot 2022-02-18 at 09 36 37" src="https://user-images.githubusercontent.com/2454380/154703017-61b9a372-31a6-4535-9199-439a2dbba434.png">  |

