### PR TITLE
Consistent Admin menus for English and French language settings

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/AdminBar.php
@@ -242,9 +242,10 @@ class AdminBar
         $wp_admin_bar->remove_menu('wp-mail-smtp-menu');
         $wp_admin_bar->remove_menu('wpseo-menu');
 
-        /* remove "Howdy" from admin bar */
+        /* remove "Howdy" and "Salutations" from admin bar */
         $my_account = $wp_admin_bar->get_node('my-account');
-        $newtext    = str_replace('Howdy,', '', $my_account->title);
+        $newtext    = str_replace('Howdy, ', '', $my_account->title);
+        $newtext    = str_replace('Salutations, ', '', $newtext);
         $wp_admin_bar->add_node([
             'id'    => 'my-account',
             'title' => $newtext,

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -25,30 +25,45 @@ class Menus
             return;
         }
 
-        global $menu, $submenu;
+        global $menu;
 
         /* add items to keep here */
         $allowed = [
-            __('Pages'),
-            __('Posts'),
-            __('Articles', 'cds-snc'),
-            __('Bulk', 'cds-snc'),
-            __('Users'),
-            __('Settings'),
-            __('Media')
+            // English menu items
+            "Dashboard",
+            "Articles",
+            "Media",
+            "Pages", // same in FR
+            "Menus", // same in FR
+            "Users",
+            "Settings",
+            "Bulk Send",
+
+            // French menu items
+            "Tableau de bord",
+            "Les Articles",
+            "Média",
+            "Utilisateurs",
+            "Réglages",
+            "Envoyer en masse",
         ];
 
         //  __('Settings'), __('Appearance')
         // http://localhost/wp-admin/options-reading.php
         end($menu);
         while (prev($menu)) {
-            $value = explode(' ', $menu[key($menu)][0]);
-            if (! in_array($value[0] !== null ? $value[0] : '', $allowed)) {
+            $value = $menu[key($menu)] ?? [];
+            $label = $value[0] ?? '';
+            $isSeparator = ($value[4] ?? null)  === "wp-menu-separator";
+
+            // Unset menu items unless they are safelisted or separators
+            if (!in_array($label, $allowed) && !$isSeparator) {
                 unset($menu[key($menu)]);
             }
         }
 
         $this->hideWPMailSmtpMenus();
+        $this->removeDashboardSubmenu();
         $this->removeSettingsPages();
     }
 
@@ -108,6 +123,19 @@ class Menus
         remove_submenu_page('wp-mail-smtp', 'wp-mail-smtp-tools');
         //Hide "WP Mail SMTP → About Us".
         remove_submenu_page('wp-mail-smtp', 'wp-mail-smtp-about');
+    }
+
+    public function removeDashboardSubmenu()
+    {
+        global $submenu;
+
+        try {
+            if ($submenu && isset($submenu["index.php"])) :
+                $submenu["index.php"] = [];
+            endif;
+        } catch (Exception $e) {
+            // no-op
+        }
     }
 
     public function removeSettingsPages()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -332,10 +332,10 @@ th.column-disable_user_login {
   display:none;
 }
 
-/* 
+/*
    We didn't have a classname to hook to...
-   if your here --- this is likely what you need to edit
-*/ 
+   if you're here --- this is likely what you need to edit
+*/
 
 /* focus-keyword-input-metabox */
 


### PR DESCRIPTION
# Summary | Résumé

This PR does a few things: Standardizes admin menu items for EN and FR language settings, removes "Salutations" in the top admin bar header, and fixes a whitespace linting error in our admin css file.

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/247

## Standardizes our menu items

When you were logged in as an administrator, the left hand menu items would change as you switched between English and French. It would also remove all the separators from the menu, which, while it doesn't impact functionality, wasn't something we intended. 

New code standardizes the menu items between both languages, and keeps the separators in place. 

(green underlines added so the changes are clearer.)

| before | after |
|--------|-------|
|        |  added "Dashboard", "Les Articles", and "Envoyer en masse" . Also "salutations" is gone (top, right)    |
|   <img width="1176" alt="Screen Shot 2022-02-18 at 14 46 08" src="https://user-images.githubusercontent.com/2454380/154752525-8b74737c-34a3-4c01-8cf4-2c217d69054d.png">   |  <img width="1176" alt="Screen Shot 2022-02-18 at 14 45 29" src="https://user-images.githubusercontent.com/2454380/154752519-0f63ea20-eb39-47c4-80c9-423749583e37.png">  |


| before | after |
|--------|-------|
|        |  added "Dashboard", and menu items are spaced out more     |
|  <img width="1176" alt="Screen Shot 2022-02-18 at 14 46 02" src="https://user-images.githubusercontent.com/2454380/154752735-0f5820b3-92f8-4922-b699-75a674660f72.png">    |  <img width="1176" alt="Screen Shot 2022-02-18 at 14 45 34" src="https://user-images.githubusercontent.com/2454380/154752730-fc031749-3cd3-4ad7-baf3-f4200bbe9752.png">    |

## Removes "Salutations"

The wordpress profile link normally says "Howdy", but we removed that. Now that we have a French admin UI, it was saying "Salutations", and so we're removing that too. 

