### PR TITLE
Auto create fr content - finish site setup

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/js/index.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/js/index.js
@@ -39,9 +39,18 @@ API.createPage = ($, data) => {
    });
 }
 
-API.translatePage = async ($, data) => {
+API.translatePage = async ($, BASE_SITE, data) => {
+
+   $('.text-status').text(`Retrieving ${slug} page content`);
+   const postContent = await API.getContent($, `${BASE_SITE}/fr`, data.fr_slug);
+
+   data.translated_title = postContent.title;
+   data.translated_content = postContent.content;
 
    const endpoint = window.ADMIN_REST.ENDPOINT;
+
+
+   $('.text-status').text(`Creating page`);
 
    return new Promise(async (resolve, reject) => {
       const result = await $.ajax({
@@ -79,7 +88,7 @@ API.setOptions = async ($, data) => {
 }
 
 (function ($) {
-   
+
    const BASE_SITE = "/template-site" // this is the site to pull content from
 
    $('.text-status').hide().removeClass("hidden");
@@ -103,8 +112,8 @@ API.setOptions = async ($, data) => {
          await API.setOptions($, { homeId, maintenanceId });
 
          $('.text-status').delay(500).text("Creating page translations");
-         await API.translatePage($, { post_id: homeId });
-         await API.translatePage($, { post_id: maintenanceId });
+         await API.translatePage($, BASE_SITE, { post_id: homeId, fr_slug: "home-fr" });
+         await API.translatePage($, BASE_SITE, { post_id: maintenanceId, fr_slug: "maintenance-fr" });
 
          $('.loader-container').fadeOut();
          $('.text-status').html(`Finished. You can now <a href="users.php?page=users-add">add a user</a>.`);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/js/index.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/js/index.js
@@ -41,7 +41,7 @@ API.createPage = ($, data) => {
 
 API.translatePage = async ($, BASE_SITE, data) => {
 
-   $('.text-status').text(`Retrieving ${slug} page content`);
+   $('.text-status').text(`Retrieving page content`);
    const postContent = await API.getContent($, `${BASE_SITE}/fr`, data.fr_slug);
 
    data.translated_title = postContent.title;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Wpml.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Wpml.php
@@ -124,11 +124,19 @@ class Wpml
             // Include WPML API
             include_once(WP_PLUGIN_DIR . '/sitepress-multilingual-cms/inc/wpml-api.php');
 
-            // Define title of translated post
-            $post_translated_title = get_post($post_id)->post_title . '(fr)';
+            // Define title & content of translated post
+            $post_translated_title = sanitize_text_field($_POST['translated_title']);
+            $post_translated_content = sanitize_text_field($_POST['translated_content']);
 
             // Insert translated post
-            $post_translated_id = wp_insert_post(array( 'post_title' => $post_translated_title, 'post_type' => $post_type, "post_status" => "publish" ));
+            $post_translated_id = wp_insert_post(
+                array(
+                    'post_title' => $post_translated_title,
+                    'post_content' => $post_translated_content,
+                    'post_type' => $post_type,
+                    "post_status" => "publish"
+                )
+            );
             // Get trid of original post
             $trid = wpml_get_content_trid('post_' . $post_type, $post_id);
 


### PR DESCRIPTION
Adds code to pull and add FR content for pages

To test --- add 2 translated pages to "template-site"

Adds translated content for:

- home ... slug = home-fr
- maintenance = maintenance-fr


Previous setup

```
Make a site will pull content from called -> template-site
Under that site
make a "home page" with the slug -> home
make a "maintenance page" with the slug -> maintenance

Those sites will be the templates for the new site you create

```


