### PR TITLE
Renamed apache container workflow

### DIFF
--- a/.github/workflows/build_push_apache_container.yml
+++ b/.github/workflows/build_push_apache_container.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/deploy_apache_container.yml"
+      - ".github/workflows/build_push_apache_container.yml"
       - "wordpress/docker/apache/**"
 
 env:


### PR DESCRIPTION
# Summary | Résumé

In a previous PR #552 the workflow file for build/push apache container was renamed, but forgot to update the workflow trigger
