### PR TITLE
Fix link in the welcome email

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
@@ -182,7 +182,7 @@ class Users
             $unique = get_password_reset_key($userInfo);
 
             $uniqueUrl = network_site_url(
-                sprintf("wp-login.php?action=rp&key=%s&login=", $unique, rawurlencode($userInfo->user_login)),
+                sprintf("wp-login.php?action=rp&key=%s&login=%s", $unique, rawurlencode($userInfo->user_login)),
                 'login'
             );
         }


### PR DESCRIPTION
The link in the welcome email wasn't including the user's email address because the `%s` was being left out of the format string.