### PR TITLE
Add options to side search bar and breadcrumbs

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -66,3 +66,12 @@ header .gcweb-menu {
 .hide-search-bar #wb-srch {
   display: none;
 }
+
+/* Hide breadcrumbs */
+.hide-breadcrumbs header {
+  margin-bottom: 25px;
+}
+
+.hide-breadcrumbs #wb-bc {
+  display: none;
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -57,3 +57,12 @@ header .gcweb-menu {
 .wp-block-image img {
   height: auto;
 }
+
+/* Hide search bar */
+.hide-search-bar header .brand {
+  margin-bottom: 20px;
+}
+
+.hide-search-bar #wb-srch {
+  display: none;
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -24,7 +24,7 @@ class NotifySettings
     {
         $instance = new self($encryptedOption);
 
-        add_action('admin_menu', [$instance, 'notifyApiSettingsAddPluginPage']);
+        add_action('admin_menu', [$instance, 'notifyApiSettingsAddPluginPage'], 100);
         add_action('admin_init', [$instance, 'notifyApiSettingsPageInit']);
         add_action('admin_head', [$instance, 'addStyles']);
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Site;
+
+class SettingsFunctions
+{
+    public function __construct()
+    {
+    }
+
+    public static function register()
+    {
+        $instance = new self();
+        $instance->addActions();
+    }
+
+    public function addActions()
+    {
+        add_filter('body_class', [$this, 'addBodyClasses']);
+    }
+
+    public function addBodyClasses($classes)
+    {
+        $showSearch = get_option('show_search');
+
+        if ($showSearch === 'off') {
+            $classes[] = 'hide-search-bar';
+        }
+
+        $showBreadcrumbs = get_option('show_breadcrumbs');
+
+        if ($showBreadcrumbs === 'off') {
+            $classes[] = 'hide-breadcrumbs';
+        }
+
+        return $classes;
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -90,6 +90,11 @@ class SiteSettings
 
         register_setting(
             'site_settings_group', // option_group
+            'show_search',
+        );
+
+        register_setting(
+            'site_settings_group', // option_group
             'blogname',
         );
 
@@ -107,6 +112,17 @@ class SiteSettings
             'collection_settings_section', // section
             [
                 'label_for' => 'collection_mode'
+            ]
+        );
+
+        add_settings_field(
+            'show_search', // id
+            __('Show Search', 'cds-snc'), // title
+            array( $this, 'showSearchCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section', // section
+            [
+                'label_for' => 'show_search'
             ]
         );
 
@@ -172,6 +188,14 @@ class SiteSettings
 
         printf('<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />', checked('maintenance', $collection_mode, false), __("Maintenance", "cds-snc"));
         printf('<input type="radio" name="collection_mode" id="collection_live" value="live" %s /> <label for="collection_live">%s</label><br />', checked('live', $collection_mode, false), __("Live", "cds-snc"));
+    }
+
+    public function showSearchCallback()
+    {
+        $show_search = get_option('show_search');
+
+        printf('<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />', checked('on', $show_search, false), __("Yes", "cds-snc"));
+        printf('<input type="radio" name="show_search" id="show_search_off" value="off" %s /> <label for="show_search_off">%s</label><br />', checked('off', $show_search, false), __("No", "cds-snc"));
     }
 
     public function collectionMaintenancePageCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -64,7 +64,7 @@ class SiteSettings
         // add section MAINTENANCE MODE
         add_settings_section(
             'collection_settings_section_maintenance', // id
-            __("Maintenance mode"), // title
+            __("Maintenance mode", 'cds-snc'), // title
             array( $this, 'maintenanceDescriptionCallback'), // callback
             'collection-settings-admin' // page
         );
@@ -72,7 +72,7 @@ class SiteSettings
         // add section SITE CONFIGURATION
         add_settings_section(
             'collection_settings_section_config', // id
-            __("Site configuration"), // title
+            __("Site configuration", 'cds-snc'), // title
             null, // callback
             'collection-settings-admin' // page
         );
@@ -225,24 +225,24 @@ class SiteSettings
     {
         $collection_mode = get_option('collection_mode');
 
-        printf('<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />', checked('maintenance', $collection_mode, false), __("Turn on", "cds-snc"));
-        printf('<input type="radio" name="collection_mode" id="collection_live" value="live" %s /> <label for="collection_live">%s</label><br />', checked('live', $collection_mode, false), __("Turn off", "cds-snc"));
+        printf('<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />', checked('maintenance', $collection_mode, false), __('Turn on', "cds-snc"));
+        printf('<input type="radio" name="collection_mode" id="collection_live" value="live" %s /> <label for="collection_live">%s</label><br />', checked('live', $collection_mode, false), __('Turn off', "cds-snc"));
     }
 
     public function showSearchCallback()
     {
         $show_search = get_option('show_search');
 
-        printf('<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />', checked('on', $show_search, false), __("Show the search bar", "cds-snc"));
-        printf('<input type="radio" name="show_search" id="show_search_off" value="off" %s /> <label for="show_search_off">%s</label><br />', checked('off', $show_search, false), __("Hide the search bar", "cds-snc"));
+        printf('<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />', checked('on', $show_search, false), __('Show the search bar', "cds-snc"));
+        printf('<input type="radio" name="show_search" id="show_search_off" value="off" %s /> <label for="show_search_off">%s</label><br />', checked('off', $show_search, false), __('Hide the search bar', "cds-snc"));
     }
 
     public function breadcrumbsCallback()
     {
         $show_breadcrumbs = get_option('show_breadcrumbs');
 
-        printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_on" value="on" %s /> <label for="show_breadcrumbs_on">%s</label><br />', checked("on", $show_breadcrumbs, false), __("Show breadcrumbs", "cds-snc"));
-        printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_off" value="off" %s /> <label for="show_breadcrumbs_off">%s</label><br />', checked("off", $show_breadcrumbs, false), __("Hide breadcrumbs", "cds-snc"));
+        printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_on" value="on" %s /> <label for="show_breadcrumbs_on">%s</label><br />', checked("on", $show_breadcrumbs, false), __('Show breadcrumbs', "cds-snc"));
+        printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_off" value="off" %s /> <label for="show_breadcrumbs_off">%s</label><br />', checked("off", $show_breadcrumbs, false), __('Hide breadcrumbs', "cds-snc"));
     }
 
     public function collectionMaintenancePageCallback()
@@ -299,8 +299,8 @@ class SiteSettings
 
     public function maintenanceDescriptionCallback()
     {
-        echo __('In maintenance mode, pages and articles you publish will <strong>not</strong> be publicly visible.');
+        echo __('In maintenance mode, pages and articles you publish will <strong>not</strong> be publicly visible.', 'cds-snc');
         echo '<br />';
-        echo __('Logged-in users will be able to create and view content, but all other visitors will be redirected to the maintenance page.');
+        echo __('Logged-in users will be able to create and view content, but all other visitors will be redirected to the maintenance page.', 'cds-snc');
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -14,7 +14,7 @@ class SiteSettings
     {
         $instance = new self();
 
-        add_action('admin_menu', [$instance, 'collectionSettingsAddPluginPage']);
+        add_action('admin_menu', [$instance, 'collectionSettingsAddPluginPage'], 99);
         add_action('admin_init', [$instance, 'collectionSettingsPageInit']);
 
         add_filter('collection_settings_option_group', function ($capability) {
@@ -40,7 +40,6 @@ class SiteSettings
 
         <div class="wrap">
             <h1><?php _e('Site Settings', 'cds-snc') ?></h1>
-            <?php settings_errors(); ?>
 
             <form method="post" action="options.php" id="collection_settings_form" class="gc-form-wrapper">
                 <?php
@@ -54,10 +53,26 @@ class SiteSettings
 
     public function collectionSettingsPageInit()
     {
-        // add section
+        // add section GENERAL
         add_settings_section(
-            'collection_settings_section', // id
-            get_bloginfo("name"), // title
+            'collection_settings_section_general', // id
+            __("General"), // title
+            null, // callback
+            'collection-settings-admin' // page
+        );
+
+        // add section MAINTENANCE MODE
+        add_settings_section(
+            'collection_settings_section_maintenance', // id
+            __("Maintenance mode"), // title
+            array( $this, 'maintenanceDescriptionCallback'), // callback
+            'collection-settings-admin' // page
+        );
+
+        // add section SITE CONFIGURATION
+        add_settings_section(
+            'collection_settings_section_config', // id
+            __("Site configuration"), // title
             null, // callback
             'collection-settings-admin' // page
         );
@@ -103,57 +118,13 @@ class SiteSettings
             'blogdescription',
         );
 
-        // add fields
-        add_settings_field(
-            'collection_mode', // id
-            __('Mode', 'cds-snc'), // title
-            array( $this, 'collectionModeCallback'), // callback
-            'collection-settings-admin', // page
-            'collection_settings_section', // section
-            [
-                'label_for' => 'collection_mode'
-            ]
-        );
-
-        add_settings_field(
-            'show_search', // id
-            __('Show Search', 'cds-snc'), // title
-            array( $this, 'showSearchCallback'), // callback
-            'collection-settings-admin', // page
-            'collection_settings_section', // section
-            [
-                'label_for' => 'show_search'
-            ]
-        );
-
-        add_settings_field(
-            'collection_mode_maintenance_page', // id
-            __('Maintenance Page', 'cds-snc'), // title
-            array( $this, 'collectionMaintenancePageCallback'), // callback
-            'collection-settings-admin', // page
-            'collection_settings_section', // section
-            [
-                'label_for' => 'collection_mode_maintenance_page'
-            ]
-        );
-
-        add_settings_field(
-            'page_on_front', // id
-            __('Home Page', 'cds-snc'), // title
-            array( $this, 'readingSettingsCallback'), // callback
-            'collection-settings-admin', // page
-            'collection_settings_section', // section
-            [
-                'label_for' => 'page_on_front'
-            ]
-        );
-
+        // add fields GENERAL
         add_settings_field(
             'blogname', // id
             __('Site Name', 'cds-snc'), // title
             array( $this, 'blogNameCallback'), // callback
             'collection-settings-admin', // page
-            'collection_settings_section', // section
+            'collection_settings_section_general', // section
             [
                 'label_for' => 'blogname'
             ]
@@ -164,9 +135,43 @@ class SiteSettings
             __('Site Description', 'cds-snc'), // title
             array( $this, 'blogDescriptionCallback'), // callback
             'collection-settings-admin', // page
-            'collection_settings_section', // section
+            'collection_settings_section_general', // section
             [
                 'label_for' => 'blogdescription'
+            ]
+        );
+
+        add_settings_field(
+            'page_on_front', // id
+            __('Home Page', 'cds-snc'), // title
+            array( $this, 'readingSettingsCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_general', // section
+            [
+                'label_for' => 'page_on_front'
+            ]
+        );
+
+        // add fields MAINTENANCE
+        add_settings_field(
+            'collection_mode', // id
+            __('Activate maintenance mode', 'cds-snc'), // title
+            array( $this, 'collectionModeCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_maintenance', // section
+            [
+                'label_for' => 'collection_mode'
+            ]
+        );
+
+        add_settings_field(
+            'collection_mode_maintenance_page', // id
+            __('Maintenance Page', 'cds-snc'), // title
+            array( $this, 'collectionMaintenancePageCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_maintenance', // section
+            [
+                'label_for' => 'collection_mode_maintenance_page'
             ]
         );
 
@@ -175,9 +180,21 @@ class SiteSettings
             __('Search engine visibility', 'cds-snc'), // title
             array( $this, 'indexSiteCallback'), // callback
             'collection-settings-admin', // page
-            'collection_settings_section', // section
+            'collection_settings_section_general', // section
             [
                 'label_for' => 'blog_public'
+            ]
+        );
+
+        // add fields MAINTENANCE
+        add_settings_field(
+            'show_search', // id
+            __('Search bar', 'cds-snc'), // title
+            array( $this, 'showSearchCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_config', // section
+            [
+                'label_for' => 'show_search'
             ]
         );
     }
@@ -186,16 +203,16 @@ class SiteSettings
     {
         $collection_mode = get_option('collection_mode');
 
-        printf('<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />', checked('maintenance', $collection_mode, false), __("Maintenance", "cds-snc"));
-        printf('<input type="radio" name="collection_mode" id="collection_live" value="live" %s /> <label for="collection_live">%s</label><br />', checked('live', $collection_mode, false), __("Live", "cds-snc"));
+        printf('<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />', checked('maintenance', $collection_mode, false), __("Turn on", "cds-snc"));
+        printf('<input type="radio" name="collection_mode" id="collection_live" value="live" %s /> <label for="collection_live">%s</label><br />', checked('live', $collection_mode, false), __("Turn off", "cds-snc"));
     }
 
     public function showSearchCallback()
     {
         $show_search = get_option('show_search');
 
-        printf('<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />', checked('on', $show_search, false), __("Yes", "cds-snc"));
-        printf('<input type="radio" name="show_search" id="show_search_off" value="off" %s /> <label for="show_search_off">%s</label><br />', checked('off', $show_search, false), __("No", "cds-snc"));
+        printf('<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />', checked('on', $show_search, false), __("Show the search bar", "cds-snc"));
+        printf('<input type="radio" name="show_search" id="show_search_off" value="off" %s /> <label for="show_search_off">%s</label><br />', checked('off', $show_search, false), __("Hide the search bar", "cds-snc"));
     }
 
     public function collectionMaintenancePageCallback()
@@ -248,5 +265,12 @@ class SiteSettings
         <?php _e('Discourage search engines from indexing this site'); ?>
         <p class="description"><?php _e('It is up to search engines to honor this request.'); ?></p>
         <?php
+    }
+
+    public function maintenanceDescriptionCallback()
+    {
+        echo __('In maintenance mode, pages and articles you publish will <strong>not</strong> be publicly visible.');
+        echo '<br />';
+        echo __('Logged-in users will be able to create and view content, but all other visitors will be redirected to the maintenance page.');
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -105,17 +105,22 @@ class SiteSettings
 
         register_setting(
             'site_settings_group', // option_group
-            'show_search',
-        );
-
-        register_setting(
-            'site_settings_group', // option_group
             'blogname',
         );
 
         register_setting(
             'site_settings_group', // option_group
             'blogdescription',
+        );
+
+        register_setting(
+            'site_settings_group', // option_group
+            'show_search',
+        );
+
+        register_setting(
+            'site_settings_group', // option_group
+            'show_breadcrumbs',
         );
 
         // add fields GENERAL
@@ -197,6 +202,23 @@ class SiteSettings
                 'label_for' => 'show_search'
             ]
         );
+
+        /**
+         * Note that there is also a Yoast (WPSEO) setting for this, but it's nested in an array.
+         * -> get_option('wpseo_titles')['breadcrumbs-enable']
+         *
+         * Since the settings API doesn't let me write to that field easily, I am creating a new setting.
+         */
+        add_settings_field(
+            'show_breadcrumbs', // id
+            __('Breadcrumbs', 'cds-snc'), // title
+            array( $this, 'breadcrumbsCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_config', // section
+            [
+                'label_for' => 'show_breadcrumbs'
+            ]
+        );
     }
 
     public function collectionModeCallback()
@@ -213,6 +235,14 @@ class SiteSettings
 
         printf('<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />', checked('on', $show_search, false), __("Show the search bar", "cds-snc"));
         printf('<input type="radio" name="show_search" id="show_search_off" value="off" %s /> <label for="show_search_off">%s</label><br />', checked('off', $show_search, false), __("Hide the search bar", "cds-snc"));
+    }
+
+    public function breadcrumbsCallback()
+    {
+        $show_breadcrumbs = get_option('show_breadcrumbs');
+
+        printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_on" value="on" %s /> <label for="show_breadcrumbs_on">%s</label><br />', checked("on", $show_breadcrumbs, false), __("Show breadcrumbs", "cds-snc"));
+        printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_off" value="off" %s /> <label for="show_breadcrumbs_off">%s</label><br />', checked("off", $show_breadcrumbs, false), __("Hide breadcrumbs", "cds-snc"));
     }
 
     public function collectionMaintenancePageCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Setup.php
@@ -34,6 +34,7 @@ use CDS\Modules\UserCollections\UserCollections;
 use CDS\Modules\DBInsights\DBInsights;
 use CDS\Modules\Releases\Releases;
 use CDS\Modules\Site\SiteSettings;
+use CDS\Modules\Site\SettingsFunctions;
 use CDS\Modules\Site\SiteSetup;
 use CDS\Modules\Wpml\Wpml;
 use CDS\Modules\Users\EmailDomains;
@@ -60,6 +61,7 @@ class Setup
         DBInsights::register();
         Releases::register();
         SiteSettings::register();
+        SettingsFunctions::register();
         SiteSetup::register();
         Cache::register();
         Wpml::register();

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -151,7 +151,8 @@ function cds_breadcrumb($sep = ''): string
         return $breadcrumb;
     }
 
-    if (!function_exists('yoast_breadcrumb')) {
+    // if breadcrumbs are disabled, yoast_breadcrumb returns null
+    if (!function_exists('yoast_breadcrumb') || is_null(yoast_breadcrumb('', '', null))) {
         return '';
     }
 


### PR DESCRIPTION
# Summary

This PR restructures the settings page, and adds 2 new settings: 1 to hide the breadcrumbs, and 1 to hide the search bar.

## 1. Restructure the settings page

It was getting a bit cluttered, so I started grouping the various options under headings.

| before | after |
|--------|-------|
|   ![Screen Shot 2022-03-02 at 12 13 59](https://user-images.githubusercontent.com/2454380/156417654-3d951845-a439-4276-914c-14421195ee6d.png)    |   ![Screen Shot 2022-03-02 at 12 13 27](https://user-images.githubusercontent.com/2454380/156417470-42c37904-2d4c-4d2e-a5a1-24b98f939c12.png)  |

Changes:
- I created 3 sub-sections — we can change them if we want — but there you go
- Added a couple of sentences to explain what maintenance mode is
- Removed the double "settings saved" flash message
- Added the 2 new settings at the bottom
- Moves the "Site settings" and "Notify API Settings" options to the bottom of the Settings panel 

## 2. Add 2 new settings

### Hide the search bar

Hide the search bar if not needed. Adds a CSS class to the body which adds `display: none` to the search bar.

### Hide the breadcrumbs

Hide the breadcrumbs if not needed. Adds a CSS class to the body which adds `display: none` to the search bar.

I spent a while looking into the Yoast setting that Enables or Disables the breadcrumbs. The yoast breadcrumb setting is stored in a nested option that you can't update with a normal implementation of the settings API.

You have to call `get_option('wpseo_titles')['breadcrumbs-enable']` to get the Yoast setting. Since I wasn't able to figure it out, I created a new setting `show_breadcrumbs`, which will add a CSS class to the body, same as the search bar setting.

### Screenshots

Desktop

| with search bar and breadcrumbs |  hidden search bar and breadcrumbs  |
|--------|-------|
|  <img width="1396" alt="Screen Shot 2022-03-02 at 12 33 38" src="https://user-images.githubusercontent.com/2454380/156418187-66ad65f1-cc8e-4e79-9006-9e333d47ddde.png">  |  <img width="1396" alt="Screen Shot 2022-03-02 at 12 34 24" src="https://user-images.githubusercontent.com/2454380/156418243-bb58fa4c-13eb-407e-a266-845184cf3c5f.png">  |

Mobile

| with search bar and breadcrumbs |  hidden search bar and breadcrumbs  |
|--------|-------|
|   <img width="612" alt="Screen Shot 2022-03-02 at 12 34 49" src="https://user-images.githubusercontent.com/2454380/156418391-0587b39b-8f09-4716-898f-9f79f2021519.png">   |   <img width="612" alt="Screen Shot 2022-03-02 at 12 34 47" src="https://user-images.githubusercontent.com/2454380/156418370-1b9ea691-278f-4a41-b5cb-4d2cc7482516.png">  |








