### PR TITLE
Bugfix: Copy build files for new ListManager UI

### DIFF
--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -52,6 +52,7 @@ COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-base/build ./wp-conten
 COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/js ./wp-content/plugins/cds-base/classes/Modules/Contact/js
 COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-base/classes/Modules/Subscribe/js ./wp-content/plugins/cds-base/classes/Modules/Subscribe/js
 COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-base/classes/Modules/Styles/template/css ./wp-content/plugins/cds-base/classes/Modules/Styles/template/css
+COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/build ./wp-content/plugins/cds-base/classes/Modules/ListManager/app/build
 
 VOLUME /usr/src/wordpress
 


### PR DESCRIPTION
# Summary | Résumé

Bugfix: List Manager UI PR #598 added some build files that need to be copied into the final production container build