### PR TITLE
Hide desc and xfn text fields for menu items

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -343,8 +343,10 @@ th.column-disable_user_login {
   display:none;
 }
 
-
-
 .yoast-settings{
+  display:none;
+}
+
+.field-xfn, .field-description{
   display:none;
 }

--- a/wordpress/wp-content/themes/cds-redirector/admin-css.php
+++ b/wordpress/wp-content/themes/cds-redirector/admin-css.php
@@ -1,0 +1,6 @@
+<?php
+function load_admin_style() {
+    wp_enqueue_style( 'redirector_admin_css', get_template_directory_uri() . '/redirector-admin.css', false, '1.0.0' );
+}
+
+add_action( 'admin_enqueue_scripts', 'load_admin_style' );

--- a/wordpress/wp-content/themes/cds-redirector/functions.php
+++ b/wordpress/wp-content/themes/cds-redirector/functions.php
@@ -13,6 +13,7 @@ if (!defined('ABSPATH')) {
 }
 
 require_once __DIR__ . '/filter-core-buttons.php';
+require_once __DIR__ . '/admin-css.php';
 
 use CDS\Utils;
 

--- a/wordpress/wp-content/themes/cds-redirector/redirector-admin.css
+++ b/wordpress/wp-content/themes/cds-redirector/redirector-admin.css
@@ -1,0 +1,8 @@
+body{
+  font-size: 3em;
+}
+
+/* turn field description on for this theme */
+.field-description{
+  display:block !important;
+}


### PR DESCRIPTION
- Updates `admin.css` to hide `description` and `xfn` text fields by default.  
- Adds `admin css` to the Redirector theme to turn `description` back on for that theme.

Closes https://github.com/cds-snc/gc-articles-issues/issues/239