### PR TITLE
Messenger.php sends emails and creates tickets

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/Setup.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CDS\Modules\Contact;
 
 use CDS\Modules\Contact\Block;
+use CDS\Modules\Forms\Messenger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
@@ -103,23 +104,6 @@ class Setup
         }
     }
 
-    protected function sendEmail(string $email, string $message): array
-    {
-        try {
-            $notifyMailer = new NotifyClient();
-            $notifyTemplateId = '125002c5-cf95-4eec-a6c8-f97eda56550a';
-            $notifyMailer->sendMail($email, $notifyTemplateId, [
-                'email' => $email,
-                'message' => $message,
-            ]);
-
-            return ['success' => __('Thanks for the message', 'cds-snc')];
-        } catch (Exception $exception) {
-            error_log($exception->getMessage());
-            return ['error' => $exception->getMessage(), "error_message" => __('Error sending email', 'cds-snc')];
-        }
-    }
-
     public function confirmSend(): array
     {
         if (!isset($_POST['contact'])) {
@@ -196,10 +180,11 @@ class Setup
 
         # on hold
         # $response = $this->createTicket($goal, $fullname, $email, $message);
-        $this->sendEmail("platform-mvp@cds-snc.ca", $message);
+        $messenger = new Messenger();
+        $response = $messenger->sendMail("platform-mvp@cds-snc.ca", $message);
 
         if (isset($_POST['cc']) && $_POST['cc'] !== "") {
-            $this->sendEmail($email, $message);
+            $messenger->sendMail($email, $message);
         }
 
         return $response;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/Setup.php
@@ -90,7 +90,10 @@ class Setup
                     'email' => $email,
                     'comment' => ['body' => $message],
                     'requester' => ['name' => $fullname, 'email' => $email],
-                    'tags' => ['articles_api']
+                    'tags' => ['articles_api'],
+                    'is_public' => true,
+                    'recipient' => 'platform-mvp@cds-snc.ca',
+                    'type' => 'question'
                 ]
                 ],
             ]);
@@ -179,7 +182,7 @@ class Setup
         $message .= sanitize_text_field($_POST['message']);
 
         # on hold
-        # $response = $this->createTicket($goal, $fullname, $email, $message);
+        $response = $this->createTicket($goal, $fullname, $email, $message);
         $messenger = new Messenger();
         $response = $messenger->sendMail("platform-mvp@cds-snc.ca", $message);
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
@@ -201,6 +201,23 @@ class RequestSite
                     </li>
                 </ul>
 
+                <!-- send me a copy -->
+                <div>
+                    <div class="gc-input-checkbox">
+                        <input
+                            name="cc"
+                            class="gc-input-checkbox__input"
+                            id="send-a-copy-to-your-email"
+                            type="checkbox"
+                            value="<?php _e('Send a copy to your email.', 'cds-snc'); ?>"
+                        />
+                        <label class="gc-checkbox-label" for="send-a-copy-to-your-email">
+                            <span class="checkbox-label-text"><?php _e('Send a copy to your email.', 'cds-snc'); ?></span>
+                        </label>
+                    </div>
+                </div>
+                <!-- send me a copy -->
+
                 <div class="buttons" style="margin-top: 1.5rem;">
                     <button class="gc-button gc-button" type="submit" id="submit">
                         <?php _e('Request site', 'cds-snc'); ?>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
@@ -8,7 +8,6 @@ use CDS\Modules\FormRequestSite\Block;
 use CDS\Modules\Forms\Messenger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\RequestException;
 use CDS\Modules\Notify\NotifyClient;
 
 class Setup
@@ -45,7 +44,6 @@ class Setup
         return !isset($haystack[$needle]) || $haystack[$needle] === '';
     }
 
-    /* TODO */
     public function confirmSend(): array
     {
         if (!isset($_POST['request'])) {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
@@ -41,6 +41,12 @@ class Setup
         return !isset($haystack[$needle]) || $haystack[$needle] === '';
     }
 
+    protected function removeslashes($str)
+    {
+        $str = implode("", explode("\\", $str));
+        return stripslashes(trim($str));
+    }
+
     public function confirmSend(): array
     {
         if (!isset($_POST['request'])) {
@@ -80,16 +86,17 @@ class Setup
 
         $all_keys = array_merge($keys_page_1, $keys_page_2);
         $message = '';
+
         foreach ($all_keys as $_key) {
             $value = $_POST[$_key] ?? '';
             if ($value) {
                 $value = is_array($value) ? str_replace(".", "", implode(", ", $value)) : $value;
-                $message .= sanitize_text_field(ucfirst($_key)) . ': ' . sanitize_text_field($value) . "\n\n";
+                $message .= sanitize_text_field(ucfirst($_key)) . ': ' . $this->removeslashes(sanitize_text_field($value)) . "\n\n";
             }
         }
 
         $site = $_POST['site'] ?? __('No name specified', 'cds-snc');
-        $goal = __('Request a site:', 'cds-snc') . ' ' . $site;
+        $goal = __('Request a site:', 'cds-snc') . ' ' . $this->removeslashes($site);
         $fullname = $_POST['fullname'];
         $email = $_POST['email'];
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CDS\Modules\FormRequestSite;
 
 use CDS\Modules\FormRequestSite\Block;
+use CDS\Modules\Forms\Messenger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
@@ -37,23 +38,6 @@ class Setup
     public function enqueue()
     {
         wp_enqueue_script('cds-request-js', plugin_dir_url(__FILE__) . '/src/handler.js', ['jquery'], "1.0.0", true);
-    }
-
-    protected function sendEmail(string $message): array
-    {
-        try {
-            $notifyMailer = new NotifyClient();
-            $to = 'platform-mvp@cds-snc.ca';
-            $notifyTemplateId = "1c3c7d24-24f4-4466-a0ac-21dd687a7a4e";
-            $notifyMailer->sendMail($to, $notifyTemplateId, [
-                'message' => $message
-            ]);
-
-            return ["success" => __("Thanks for the message", "cds-snc")];
-        } catch (Exception $exception) {
-            error_log($exception->getMessage());
-            return ["error" => $exception->getMessage()];
-        }
     }
 
     public function isUnsetOrEmpty(string $needle, array $haystack): bool
@@ -109,7 +93,13 @@ class Setup
             }
         }
 
-        $response = $this->sendEmail($message);
+        $messenger = new Messenger();
+        $response = $messenger->sendMail("platform-mvp@cds-snc.ca", $message);
+
+        // # @TODO add a "CC" to the requet form
+        // if (isset($_POST['cc']) && $_POST['cc'] !== "") {
+        //     $messenger->sendMail($email, $message);
+        // }
 
         return $response;
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
@@ -6,9 +6,6 @@ namespace CDS\Modules\FormRequestSite;
 
 use CDS\Modules\FormRequestSite\Block;
 use CDS\Modules\Forms\Messenger;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use CDS\Modules\Notify\NotifyClient;
 
 class Setup
 {
@@ -91,8 +88,14 @@ class Setup
             }
         }
 
+        $site = $_POST['site'] ?? __('No name specified', 'cds-snc');
+        $goal = __('Request a site:', 'cds-snc') . ' ' . $site;
+        $fullname = $_POST['fullname'];
+        $email = $_POST['email'];
+
         $messenger = new Messenger();
-        $response = $messenger->sendMail("platform-mvp@cds-snc.ca", $message);
+        $response = $messenger->createTicket($goal, $fullname, $email, $message);
+        $messenger->sendMail($email, $message);
 
         // # @TODO add a "CC" to the requet form
         // if (isset($_POST['cc']) && $_POST['cc'] !== "") {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/Setup.php
@@ -95,12 +95,11 @@ class Setup
 
         $messenger = new Messenger();
         $response = $messenger->createTicket($goal, $fullname, $email, $message);
-        $messenger->sendMail($email, $message);
 
-        // # @TODO add a "CC" to the requet form
-        // if (isset($_POST['cc']) && $_POST['cc'] !== "") {
-        //     $messenger->sendMail($email, $message);
-        // }
+        $cc = $_POST['cc'] ?? '';
+        if ($cc) {
+            $messenger->sendMail($email, $message);
+        }
 
         return $response;
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Messenger.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Messenger.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace CDS\Modules\Forms;
 
 use CDS\Modules\Notify\NotifyClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
 
 class Messenger
 {
@@ -15,6 +18,11 @@ class Messenger
     public function getNotifyClient()
     {
         return new NotifyClient();
+    }
+
+    public function getGuzzleClient()
+    {
+        return new Client([]);
     }
 
     public function sendMail(string $email, string $message): array
@@ -30,6 +38,62 @@ class Messenger
         } catch (\Exception $exception) {
             error_log($exception->getMessage());
             return ['error' => $exception->getMessage(), "error_message" => __('Error sending email', 'cds-snc')];
+        }
+    }
+
+    protected function isJson($string): bool
+    {
+        json_decode($string);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    protected function handleException($e)
+    {
+        $exception = (string) $e->getResponse()->getBody();
+
+        error_log("ZENDESK - ClientException" . $exception);
+
+        if ($this->isJson($exception)) {
+            try {
+                return json_decode($exception);
+            } catch (\Exception $e) {
+                return __('ZenDesk client error', 'cds-snc');
+            }
+        }
+    }
+
+    public function createTicket(
+        string $goal,
+        string $fullname,
+        string $email,
+        string $message,
+    ): array {
+        try {
+            $client = $this->getGuzzleClient();
+
+            $response = $client->request('POST', getenv('ZENDESK_API_URL') . '/api/v2/requests', [
+                'json' =>  [
+                    'request' => [
+                        'subject' => $goal,
+                        'description' => '',
+                        'email' => $email,
+                        'comment' => ['body' => $message],
+                        'requester' => ['name' => $fullname, 'email' => $email],
+                        'tags' => ['articles_api'],
+                        'is_public' => true,
+                        'recipient' => 'platform-mvp@cds-snc.ca',
+                        'type' => 'question'
+                    ]
+                ],
+            ]);
+
+            return ['success' => __('Success', 'cds-snc')];
+        } catch (ClientException $exception) {
+            return ['error' => ["exceptions" => $this->handleException($exception)], "error_message" => __('Internal server error', 'cds-snc')];
+        } catch (\Exception $e) {
+            error_log("ZENDESK - Exception" . $exception->getMessage());
+            return ['error' => true, "error_message" => __('ZenDesk server error', 'cds-snc')];
         }
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Messenger.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Messenger.php
@@ -92,7 +92,7 @@ class Messenger
         } catch (ClientException $exception) {
             return ['error' => ["exceptions" => $this->handleException($exception)], "error_message" => __('Internal server error', 'cds-snc')];
         } catch (\Exception $e) {
-            error_log("ZENDESK - Exception" . $exception->getMessage());
+            error_log("ZENDESK - Exception" . $e->getMessage());
             return ['error' => true, "error_message" => __('ZenDesk server error', 'cds-snc')];
         }
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Messenger.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Messenger.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Forms;
+
+use CDS\Modules\Notify\NotifyClient;
+
+class Messenger
+{
+    public function __construct()
+    {
+    }
+
+    public function getNotifyClient()
+    {
+        return new NotifyClient();
+    }
+
+    public function sendMail(string $email, string $message): array
+    {
+        try {
+            $notifyTemplateId = '125002c5-cf95-4eec-a6c8-f97eda56550a';
+            $response = $this->getNotifyClient()->sendMail($email, $notifyTemplateId, [
+                'email' => $email,
+                'message' => $message,
+            ]);
+
+            return ['success' => __('Thanks for the message', 'cds-snc')];
+        } catch (\Exception $exception) {
+            error_log($exception->getMessage());
+            return ['error' => $exception->getMessage(), "error_message" => __('Error sending email', 'cds-snc')];
+        }
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/MessengerTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/MessengerTest.php
@@ -1,34 +1,62 @@
 <?php
 
 use CDS\Modules\Forms\Messenger;
+use GuzzleHttp\Exception\ClientException;
 
 
 test('asserts sendMail returns success message for a successful call', function () {
     /* Mocking a class within a class: https://docs.mockery.io/en/latest/cookbook/mocking_class_within_class.html */
     $clientMock = mock('NotifyClientMock')->expect(
-            sendMail: fn () => true,
+        sendMail: fn () => true,
     );
 
     $messenger = mock(Messenger::class)->makePartial();
     $messenger->shouldReceive("getNotifyClient")->andReturn($clientMock);
  
     expect($messenger->sendMail('paul.com', 'message'))->toMatchArray(
-            ['success' => 'Thanks for the message']
-        );
+        ['success' => 'Thanks for the message']
+    );
 });
 
 test('asserts sendMail returns error message if NotifyClient throws an exception', function () {
     /* Mocking a class within a class: https://docs.mockery.io/en/latest/cookbook/mocking_class_within_class.html */
     $clientMock = mock('NotifyClientMock');
-    $clientMock->shouldReceive('sendMail')->andThrow(new Exception('Bad template ID or something'));
+    $clientMock->shouldReceive('sendMail')->andThrow(new \Exception('Bad template ID or something'));
 
     $messenger = mock(Messenger::class)->makePartial();
     $messenger->shouldReceive("getNotifyClient")->andReturn($clientMock);
  
-    expect($messenger->sendMail('paul.com', 'message'))->toMatchArray(
+    expect($messenger->sendMail('paul@paul.ca', 'message'))->toMatchArray(
         [
             'error' => 'Bad template ID or something',
             'error_message' => 'Error sending email'
         ]
+    );
+});
+
+test('asserts createTicket returns success message for a successful call', function () {
+    $clientMock = mock('GuzzleClientMock')->expect(
+        request: fn () => true,
+    );
+
+    $messenger = mock(Messenger::class)->makePartial();
+    $messenger->shouldReceive("getGuzzleClient")->andReturn($clientMock);
+
+    expect($messenger->createTicket('Goal: Request a site', 'Paul Craig', 'paul@paul.ca', 'message'))->toMatchArray(
+        ['success' => 'Success']
+    );
+});
+
+test('asserts createTicket returns Zendesk server error generic exception', function () {
+    $clientMock = mock('GuzzleClientMock');
+    $clientMock->shouldReceive('request')->andThrow(new \Exception('Maybe we do need API auth after all'));
+
+    $messenger = mock(Messenger::class)->makePartial();
+    $messenger->shouldReceive("getGuzzleClient")->andReturn($clientMock);
+
+    expect($messenger->createTicket('Goal: Request a site', 'Paul Craig', 'paul@paul.ca', 'message'))->toMatchArray(
+        [
+            'error' => true,
+            'error_message' => 'ZenDesk server error']
     );
 });

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/MessengerTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/MessengerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use CDS\Modules\Forms\Messenger;
+
+
+test('asserts sendMail returns success message for a successful call', function () {
+    /* Mocking a class within a class: https://docs.mockery.io/en/latest/cookbook/mocking_class_within_class.html */
+    $clientMock = mock('NotifyClientMock')->expect(
+            sendMail: fn () => true,
+    );
+
+    $messenger = mock(Messenger::class)->makePartial();
+    $messenger->shouldReceive("getNotifyClient")->andReturn($clientMock);
+ 
+    expect($messenger->sendMail('paul.com', 'message'))->toMatchArray(
+            ['success' => 'Thanks for the message']
+        );
+});
+
+test('asserts sendMail returns error message if NotifyClient throws an exception', function () {
+    /* Mocking a class within a class: https://docs.mockery.io/en/latest/cookbook/mocking_class_within_class.html */
+    $clientMock = mock('NotifyClientMock');
+    $clientMock->shouldReceive('sendMail')->andThrow(new Exception('Bad template ID or something'));
+
+    $messenger = mock(Messenger::class)->makePartial();
+    $messenger->shouldReceive("getNotifyClient")->andReturn($clientMock);
+ 
+    expect($messenger->sendMail('paul.com', 'message'))->toMatchArray(
+        [
+            'error' => 'Bad template ID or something',
+            'error_message' => 'Error sending email'
+        ]
+    );
+});

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifyClient.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifyClient.php
@@ -41,7 +41,7 @@ class NotifyClient
             return false;
         }
 
-        $this->notifyClient->sendEmail(
+        return $this->notifyClient->sendEmail(
             $emailTo,
             $templateId,
             $data,


### PR DESCRIPTION
# Summary | Résumé

Added a new class to share code for sending messages between our request form and our contact form. It also adds a "CC" option to the Request a site form, duplicating the contact form behaviour.

Needs doing:
- [x] generalize sendMail method
- [x] add tests for sendMail
- [x] generalize the method to create Zendesk tickets
- [x] add tests for the Zendesk thing
- [x] CC on the request a site form

Notes:

- Mocking the NotifyClient wasn't possible when the `new` object was being created directly in the `sendEmail` function. [The Mockery docs](https://docs.mockery.io/en/latest/cookbook/mocking_class_within_class.html) recommend creating a second function that returns the new object, which is why it's like that.
- Should I make these static calls? Or maybe we want to pass in the template ID later or something
- I put the Messenger class in a directory called `/Forms`, assuming that the others will make it in there eventually. I can rename this if we want to take more of a 'wait and see' approach