### PR TITLE
Add jjQuery accessible toggle for optional fields

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -82,6 +82,6 @@ header .gcweb-menu {
 }
 
 /* Aria toggle */
-form *[aria-hidden="true"] {
+form .displayNone {
   display: none;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -80,3 +80,8 @@ header .gcweb-menu {
 .hide-breadcrumbs #wb-bc {
   display: none;
 }
+
+/* Aria toggle */
+form *[aria-hidden="true"] {
+  display: none;
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/ContactForm.php
@@ -16,8 +16,11 @@ class ContactForm
         add_shortcode('contact-form', [$this, 'render']);
     }
 
-    public function checkBox($name, $id, $value): void
+    public function checkBox($name, $id, $value, $vals = [], $ariaControls = false): void
     {
+        // set to empty array if a non-array is passed in
+        $vals = is_array($vals) ? $vals : [];
+        $checked = in_array($value, $vals);
         ?>
         <div class="gc-input-checkbox">
             <input
@@ -26,6 +29,13 @@ class ContactForm
                 id="<?php echo sanitize_title($id); ?>"
                 type="checkbox"
                 value="<?php echo $id; ?>"
+                <?php if ($checked) {
+                    echo 'checked';
+                } ?>
+                <?php if ($ariaControls) {
+                    echo 'aria-controls="' . $ariaControls . '" ';
+                    echo 'aria-expanded="' . $checked . '" ';
+                } ?>
             />
             <label class="gc-checkbox-label" for="<?php echo sanitize_title($id); ?>">
             <span class="checkbox-label-text"><?php echo $value; ?></span>
@@ -172,19 +182,23 @@ class ContactForm
                         'usage[]',
                         'Something else.',
                         __('Something else.', 'cds-snc'),
+                        null, // we don't have previous values to pass in
+                        'optional-usage'
                     ); ?>
                     </div>
                     
-                    <label class="gc-label" for="usage-other" id="usage-other-label" class="hidden"">
-                        <?php _e('Other usage', 'cds-snc'); ?>
-                    </label>
-                    <input 
-                        type="text" 
-                        class="gc-input-text" 
-                        id="usage-other" 
-                        name="usage-other" 
-                        value=""
-                    />
+                    <div id="optional-usage" aria-hidden="false">
+                        <label class="gc-label" for="usage-other" id="usage-other-label" class="hidden"">
+                            <?php _e('Other usage', 'cds-snc'); ?>
+                        </label>
+                        <input
+                            type="text"
+                            class="gc-input-text"
+                            id="usage-other"
+                            name="usage-other"
+                            value=""
+                        />
+                    </div>
                 </div>
                 <!-- end usage -->
 
@@ -220,18 +234,22 @@ class ContactForm
                         'target[]',
                         'Other people.',
                         __('Other people.', 'cds-snc'),
+                        null, // we don't have previous values to pass in
+                        'optional-target'
                     ); ?>
                     </div>
-                    <label class="gc-label" for="target-other" id="target-other-label" class="hidden"">
-                        <?php _e('Other target audience', 'cds-snc'); ?>
-                    </label>
-                    <input 
-                        type="text" 
-                        class="gc-input-text" 
-                        id="target-other" 
-                        name="target-other" 
-                        value=""
-                    />
+                    <div id="optional-target" aria-hidden="false">
+                        <label class="gc-label" for="target-other" id="target-other-label" class="hidden"">
+                            <?php _e('Other target audience', 'cds-snc'); ?>
+                        </label>
+                        <input
+                            type="text"
+                            class="gc-input-text"
+                            id="target-other"
+                            name="target-other"
+                            value=""
+                        />
+                    </div>
                 </div>
                 <!-- target -->
                 <label data-testid="description" class="gc-label" id="message-label" for="message">

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/ContactForm.php
@@ -187,8 +187,8 @@ class ContactForm
                     ); ?>
                     </div>
                     
-                    <div id="optional-usage" aria-hidden="false">
-                        <label class="gc-label" for="usage-other" id="usage-other-label" class="hidden"">
+                    <div id="optional-usage">
+                        <label class="gc-label" for="usage-other" id="usage-other-label">
                             <?php _e('Other usage', 'cds-snc'); ?>
                         </label>
                         <input
@@ -238,8 +238,8 @@ class ContactForm
                         'optional-target'
                     ); ?>
                     </div>
-                    <div id="optional-target" aria-hidden="false">
-                        <label class="gc-label" for="target-other" id="target-other-label" class="hidden"">
+                    <div id="optional-target">
+                        <label class="gc-label" for="target-other" id="target-other-label">
                             <?php _e('Other target audience', 'cds-snc'); ?>
                         </label>
                         <input

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/src/handler.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/src/handler.js
@@ -1,29 +1,4 @@
 (function ($) {
-    function toggleOptional($el) {
-        $controlsElement = $('#' + $el.attr('aria-controls'));
-
-        // only change attributes if "aria-controls" element exists
-        if($controlsElement) {
-            if($el.is(':checked')) {
-                //show element
-                $el.attr('aria-expanded', true);
-                $controlsElement.attr('aria-hidden', false);
-            } else {
-                // hide element
-                $el.attr('aria-expanded', false);
-                $controlsElement.attr('aria-hidden', true);
-            }
-        }
-    }
-
-    $('input[aria-controls]').on("click", function (e) {
-        // add click handler
-        toggleOptional($(e.target));
-    }).each(function() {
-        // run it once on page load
-        toggleOptional($(this));
-    });
-
     $("body").on("submit", "#contact-form", function (e) {
         e.preventDefault();
         var form = $(this);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/src/handler.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Contact/src/handler.js
@@ -1,4 +1,29 @@
 (function ($) {
+    function toggleOptional($el) {
+        $controlsElement = $('#' + $el.attr('aria-controls'));
+
+        // only change attributes if "aria-controls" element exists
+        if($controlsElement) {
+            if($el.is(':checked')) {
+                //show element
+                $el.attr('aria-expanded', true);
+                $controlsElement.attr('aria-hidden', false);
+            } else {
+                // hide element
+                $el.attr('aria-expanded', false);
+                $controlsElement.attr('aria-hidden', true);
+            }
+        }
+    }
+
+    $('input[aria-controls]').on("click", function (e) {
+        // add click handler
+        toggleOptional($(e.target));
+    }).each(function() {
+        // run it once on page load
+        toggleOptional($(this));
+    });
+
     $("body").on("submit", "#contact-form", function (e) {
         e.preventDefault();
         var form = $(this);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
@@ -16,7 +16,7 @@ class RequestSite
         add_shortcode('request-site-form', [$this, 'render']);
     }
 
-    public function checkboxField($name, $id, $value, $vals = []): void
+    public function checkboxField($name, $id, $value, $vals = [], $ariaControls = false): void
     {
         // set to empty array if a non-array is passed in
         $vals = is_array($vals) ? $vals : [];
@@ -31,6 +31,10 @@ class RequestSite
                 value="<?php echo $id; ?>"
                 <?php if ($checked) {
                     echo 'checked';
+                } ?>
+                <?php if ($ariaControls) {
+                    echo 'aria-controls="' . $ariaControls . '" ';
+                    echo 'aria-expanded="' . $checked . '" ';
                 } ?>
             />
             <label class="gc-checkbox-label" for="<?php echo sanitize_title($id); ?>">
@@ -258,48 +262,52 @@ class RequestSite
                     <p><?php _e('We use this information to improve GC Articles.', 'cds-snc');?></p>
                     
                     <div class="focus-group" style="margin-bottom: 1.75rem">
-                    <?php $this->checkboxField(
-                        'usage[]',
-                        'Blog.',
-                        __('Blog.', 'cds-snc'),
-                        $all_values['usage']
-                    ); ?>
-                    <?php $this->checkboxField(
-                        'usage[]',
-                        'Newsletter archive with emailing to a subscriber list.',
-                        __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
-                        $all_values['usage']
-                    ); ?>
-                    <?php $this->checkboxField(
-                        'usage[]',
-                        'Website.',
-                        __('Website.', 'cds-snc'),
-                        $all_values['usage']
-                    ); ?>
-                    <?php $this->checkboxField(
-                        'usage[]',
-                        'Internal website.',
-                        __('Internal website.', 'cds-snc'),
-                        $all_values['usage']
-                    ); ?>
-                    <?php $this->checkboxField(
-                        'usage[]',
-                        'Something else.',
-                        __('Something else.', 'cds-snc'),
-                        $all_values['usage']
-                    ); ?>
+                        <?php $this->checkboxField(
+                            'usage[]',
+                            'Blog.',
+                            __('Blog.', 'cds-snc'),
+                            $all_values['usage']
+                        ); ?>
+                        <?php $this->checkboxField(
+                            'usage[]',
+                            'Newsletter archive with emailing to a subscriber list.',
+                            __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
+                            $all_values['usage']
+                        ); ?>
+                        <?php $this->checkboxField(
+                            'usage[]',
+                            'Website.',
+                            __('Website.', 'cds-snc'),
+                            $all_values['usage']
+                        ); ?>
+                        <?php $this->checkboxField(
+                            'usage[]',
+                            'Internal website.',
+                            __('Internal website.', 'cds-snc'),
+                            $all_values['usage'],
+                        ); ?>
+
+                        <?php $this->checkboxField(
+                            'usage[]',
+                            'Something else.',
+                            __('Something else.', 'cds-snc'),
+                            $all_values['usage'],
+                            "optional-usage"
+                        ); ?>
                     </div>
                     
-                    <label class="gc-label" for="usage-other" id="usage-other-label" class="hidden"">
-                        <?php _e('Other usage', 'cds-snc'); ?>
-                    </label>
-                    <input 
-                        type="text" 
-                        class="gc-input-text" 
-                        id="usage-other" 
-                        name="usage-other" 
-                        value="<?php echo $all_values['usage-other']; ?>"
-                    />
+                    <div id="optional-usage" aria-hidden="false">
+                        <label class="gc-label" for="usage-other" id="usage-other-label" class="hidden">
+                            <?php _e('Other usage', 'cds-snc'); ?>
+                        </label>
+                        <input
+                            type="text"
+                            class="gc-input-text"
+                            id="usage-other"
+                            name="usage-other"
+                            value="<?php echo $all_values['usage-other']; ?>"
+                        />
+                    </div>
                 </div>
                 <!-- end usage -->
 
@@ -339,19 +347,22 @@ class RequestSite
                         'target[]',
                         'Other people.',
                         __('Other people.', 'cds-snc'),
-                        $all_values['target']
+                        $all_values['target'],
+                        "optional-target"
                     ); ?>
                     </div>
-                    <label class="gc-label" for="target-other" id="target-other-label" class="hidden"">
-                        <?php _e('Other target audience', 'cds-snc'); ?>
-                    </label>
-                    <input 
-                        type="text" 
-                        class="gc-input-text" 
-                        id="target-other" 
-                        name="target-other" 
-                        value="<?php echo $all_values['target-other']; ?>"
-                    />
+                    <div id="optional-target" aria-hidden="false">
+                        <label class="gc-label" for="target-other" id="target-other-label" class="hidden">
+                            <?php _e('Other target audience', 'cds-snc'); ?>
+                        </label>
+                        <input
+                            type="text"
+                            class="gc-input-text"
+                            id="target-other"
+                            name="target-other"
+                            value="<?php echo $all_values['target-other']; ?>"
+                        />
+                    </div>
                 </div>
 
                 <!-- timeline -->

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
@@ -292,7 +292,7 @@ class RequestSite
                             'Something else.',
                             __('Something else.', 'cds-snc'),
                             $all_values['usage'],
-                            "optional-usage"
+                            'optional-usage'
                         ); ?>
                     </div>
                     
@@ -348,7 +348,7 @@ class RequestSite
                         'Other people.',
                         __('Other people.', 'cds-snc'),
                         $all_values['target'],
-                        "optional-target"
+                        'optional-target'
                     ); ?>
                     </div>
                     <div id="optional-target" aria-hidden="false">

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/src/handler.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/src/handler.js
@@ -1,4 +1,29 @@
 (function ($) {
+    function toggleOptional($el) {
+        $controlsElement = $('#' + $el.attr('aria-controls'));
+
+        // only change attributes if "aria-controls" element exists
+        if($controlsElement) {
+            if($el.is(':checked')) {
+                //show element
+                $el.attr('aria-expanded', true);
+                $controlsElement.attr('aria-hidden', false);
+            } else {
+                // hide element
+                $el.attr('aria-expanded', false);
+                $controlsElement.attr('aria-hidden', true);
+            }
+        }
+    }
+
+    $('input[aria-controls]').on("click", function (e) {
+        // add click handler
+        toggleOptional($(e.target));
+    }).each(function() {
+        // run it once on page load
+        toggleOptional($(this));
+    });
+
     $("body").on("submit", "#request-form", function (e) {
         e.preventDefault();
         var form = $(this);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/src/handler.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/src/handler.js
@@ -7,11 +7,11 @@
             if($el.is(':checked')) {
                 //show element
                 $el.attr('aria-expanded', true);
-                $controlsElement.attr('aria-hidden', false);
+                $controlsElement.removeClass('displayNone');
             } else {
                 // hide element
                 $el.attr('aria-expanded', false);
-                $controlsElement.attr('aria-hidden', true);
+                $controlsElement.addClass('displayNone').find('input').val('');
             }
         }
     }


### PR DESCRIPTION
# Summary | Résumé

This PR adds an accessible jQuery toggle for the optional fields on the first page of the Request a site form and on the Contact form.

The JS is duplicated, but that's actually a good thing because we can get rid of one copy in the (near) future.

## fun gif

![Screen Recording 2022-03-10 at 13 20 10](https://user-images.githubusercontent.com/2454380/157730335-c0f0ae07-00d5-4d68-9ede-5ea4405a99ea.gif)


## Description

I wasn't able to check my past work on this, but I am pretty confident. The idea is that the controlling element should have 2 aria attributes and the element being controlled should have 1.  There is an example on here that mostly confirms my approach: https://van11y.net/accessible-hide-show/

```html
<!-- expanded -->
<button aria-controls="toggle-area-1" aria-expanded="true">Toggle the stuff</button>
<div id="toggle-area-1" aria-hidden="false">
  <p>This stuff will be toggled 1</p>
</div>

<!-- hidden -->
<button aria-controls="toggle-area-2" aria-expanded="false">Toggle the stuff</button>
<div id="toggle-area-2" aria-hidden="true">
  <p>This stuff will be toggled 2</p>
</div>
```

The controlling element has an "aria-controls" attribute, with the id of the element that gets hidden. It also has an "aria-expanded" boolean attribute that is "true" when visible and "false" when hidden.

The element being toggled has an "id", obviously, and "aria-hidden" that says whether it's visible or not.

I'm not 100% sure that we need aria-hidden, as the example I linked to above doesn't use it. But it doesn't hurt anything.