### PR TITLE
Remove backslashes from returned values (unless they are intentional)

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/FormRequestSite/RequestSite.php
@@ -74,7 +74,7 @@ class RequestSite
 
             // create array of keys and values
             foreach ($all_keys as $_key) {
-                $all_values[$_key] = $_POST[$_key] ?? '';
+                $all_values[$_key] = stripslashes($_POST[$_key] ?? '');
             }
 
             // find all empty values


### PR DESCRIPTION
# Summary | Résumé

Very tiny PR, solves the bug that when you would submit a site name like `Paul's Blog`, but then not enter a "target", you could get something back like `Paul\'s Blog`. If you enter literal backslashes for some reason, they will still be there.
