### PR TITLE
Improve forms CSS

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -82,6 +82,46 @@ header .gcweb-menu {
 }
 
 /* Forms */
+form * {
+  font-size: 20px;
+  line-height: 1.65em;
+}
+
+.gc-form-wrapper form .gc-description,
+.gc-form-wrapper form .gc-description ul li {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.gc-form-wrapper form .gc-description ul li {
+  margin-top: 5px;
+}
+
+.gc-form-wrapper form .gc-textarea {
+  margin-top: .75em;
+}
+
+form .focus-group {
+  margin-bottom: 1em;
+}
+
+form div[role="group"] .focus-group {
+  margin-bottom: 1.5em;
+}
+
+form .focus-group:first-of-type {
+  margin-top: 1em;
+}
+
+form div[id^="optional"] {
+  margin-top: -1em;
+  margin-bottom: 1.5em;
+}
+
+form .buttons {
+  margin: 1em 0;
+}
+
 form .displayNone {
   display: none;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -119,9 +119,11 @@ class ContactForm
                     <label class="gc-label" for="goal" id="goal_types">
                         <?php _e('Goal of your message', 'cds-snc'); ?>
                     </label>
-                    <p><?php _e('Your answer helps us make sure your message gets to the right people.', 'cds-snc');?></p>
+                    <div id="usage-desc" class="gc-description" data-testid="description">
+                        <?php _e('Your answer helps us make sure your message gets to the right people.', 'cds-snc');?>
+                    </div>
 
-                    <div class="focus-group" style="margin-bottom: 1.75rem">
+                    <div class="focus-group">
                     <?php $this->radioField(
                         'goal',
                         'Ask a question.',
@@ -155,9 +157,11 @@ class ContactForm
                     <label class="gc-label" for="usage" id="usage_types">
                         <?php _e('What are you thinking about using GC Articles for? (optional)', 'cds-snc'); ?>
                     </label>
-                    <p><?php _e('We use this information to improve GC Articles.', 'cds-snc');?></p>
-                    
-                    <div class="focus-group" style="margin-bottom: 1.75rem">
+                    <div id="usage-desc" class="gc-description" data-testid="description">
+                        <?php _e('We use this information to improve GC Articles.', 'cds-snc');?>
+                    </div>
+
+                    <div class="focus-group">
                     <?php $this->checkBox(
                         'usage[]',
                         'Blog.',
@@ -207,9 +211,11 @@ class ContactForm
                     <label class="gc-label" for="target" id="target_types">
                         <?php _e('Who are the target audiences you’re thinking about? (optional)', 'cds-snc'); ?>
                     </label>
-                    <p><?php _e('We use this information to improve GC Articles.', 'cds-snc');?></p>
+                    <div id="usage-desc" class="gc-description" data-testid="description">
+                        <?php _e('We use this information to improve GC Articles.', 'cds-snc');?>
+                    </div>
                     
-                    <div class="focus-group" style="margin-bottom: 1.75rem">
+                    <div class="focus-group">
                     <?php $this->checkBox(
                         'target[]',
                         'People who use your programs and services.',
@@ -275,7 +281,7 @@ class ContactForm
                 </div>
                 <!-- send me a copy -->
 
-                <div class="buttons" style="margin-top: 1.5rem;">
+                <div class="buttons">
                     <button class="gc-button gc-button" type="submit" id="submit">
                         <?php _e('Submit', 'cds-snc'); ?>
                     </button>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -196,14 +196,16 @@ class RequestSiteForm
                 </div>
                 <!-- end department -->
 
-                <ul>
-                    <li>
-                        <?php _e('Reminder: Only use GC Articles for information that is not sensitive and can be shared publicly.', 'cds-snc'); ?>
-                    </li>
-                    <li>
-                        <?php _e('Make sure you’re allowed to publsh this information on behalf of the Government of Canada.', 'cds-snc'); ?>
-                    </li>
-                </ul>
+                <div class="focus-group">
+                    <ul>
+                        <li>
+                            <?php _e('Reminder: Only use GC Articles for information that is not sensitive and can be shared publicly.', 'cds-snc'); ?>
+                        </li>
+                        <li>
+                            <?php _e('Make sure you’re allowed to publsh this information on behalf of the Government of Canada.', 'cds-snc'); ?>
+                        </li>
+                    </ul>
+                </div>
 
                 <!-- send me a copy -->
                 <div>
@@ -222,7 +224,7 @@ class RequestSiteForm
                 </div>
                 <!-- send me a copy -->
 
-                <div class="buttons" style="margin-top: 1.5rem;">
+                <div class="buttons">
                     <button class="gc-button gc-button" type="submit" id="submit">
                         <?php _e('Request site', 'cds-snc'); ?>
                     </button>
@@ -276,9 +278,11 @@ class RequestSiteForm
                     <label class="gc-label" for="usage" id="usage_types">
                         <?php _e('What will you use your site for?', 'cds-snc'); ?>
                     </label>
-                    <p><?php _e('We use this information to improve GC Articles.', 'cds-snc');?></p>
+                    <div id="usage-desc" class="gc-description" data-testid="description">
+                        <?php _e('We use this information to improve GC Articles.', 'cds-snc');?>
+                    </div>
                     
-                    <div class="focus-group" style="margin-bottom: 1.75rem">
+                    <div class="focus-group">
                         <?php $this->checkboxField(
                             'usage[]',
                             'Blog.',
@@ -333,9 +337,11 @@ class RequestSiteForm
                     <label class="gc-label" for="target" id="target_types">
                         <?php _e('Who are the target audiences for your site?', 'cds-snc'); ?>
                     </label>
-                    <p><?php _e('We use this information to improve GC Articles.', 'cds-snc');?></p>
+                    <div id="target-desc" class="gc-description" data-testid="description">
+                        <?php _e('We use this information to improve GC Articles.', 'cds-snc');?>
+                    </div>
                     
-                    <div class="focus-group" style="margin-bottom: 1.75rem">
+                    <div class="focus-group">
                     <?php $this->checkboxField(
                         'target[]',
                         'People who use your programs and services.',
@@ -383,22 +389,24 @@ class RequestSiteForm
                 </div>
 
                 <!-- timeline -->
-                <label data-testid="description" class="gc-label" id="timeline-label" for="timeline">
-                    <?php _e('When do you plan to make your site public?', 'cds-snc'); ?>
-                </label>
-                <div id="timeline-desc" class="gc-description" data-testid="description">
-                    <?php _e('We look for sites that will launch in the next 2 months. Sites that linger for longer than 2 months without being made public reduce our ranking in search engines.', 'cds-snc'); ?>
+                <div class="focus-group">
+                    <label data-testid="description" class="gc-label" id="timeline-label" for="timeline">
+                        <?php _e('When do you plan to make your site public?', 'cds-snc'); ?>
+                    </label>
+                    <div id="timeline-desc" class="gc-description" data-testid="description">
+                        <?php _e('We look for sites that will launch in the next 2 months. Sites that linger for longer than 2 months without being made public reduce our ranking in search engines.', 'cds-snc'); ?>
+                    </div>
+                    <textarea
+                        data-testid="textarea"
+                        class="gc-textarea"
+                        id="timeline"
+                        required
+                        placeholder=""
+                        name="timeline"
+                    ><?php echo $all_values['timeline']; ?></textarea>
                 </div>
-                <textarea
-                    data-testid="textarea"
-                    class="gc-textarea"
-                    id="timeline"
-                    required
-                    placeholder=""
-                    name="timeline"
-                ><?php echo $all_values['timeline']; ?></textarea>
 
-                <div class="buttons" style="margin-top: 1.5rem;">
+                <div class="buttons">
                     <button class="gc-button gc-button" type="submit" id="submit">
                         <?php _e('Next', 'cds-snc'); ?>
                     </button>


### PR DESCRIPTION
Removed inline styles, and added some CSS to make the forms generally present better on the page.

- Hint text is a bit bigger
- More space between fields
- Consistent hint text
- Regular text is 20px

# Screenshots

The main thing you'll see is more spacing between form fields and the hint text is more readable.

| before | after |
|--------|-------|
|   ![localhost_request-a-site-please_ (1)](https://user-images.githubusercontent.com/2454380/158226520-fabdc784-4331-4975-9f52-e0bbeb03cb23.png)    | ![localhost_request-a-site-please_](https://user-images.githubusercontent.com/2454380/158226348-c77db242-490e-49c6-b75a-3d256fbc72aa.png)  |
|   ![localhost_request-a-site-please (1)](https://user-images.githubusercontent.com/2454380/158226334-bd3aa1b9-8af6-423a-b32a-18695b36a8a6.png)   |  ![localhost_request-a-site-please](https://user-images.githubusercontent.com/2454380/158226508-6a18c68e-f7a3-46e9-99ac-a924d586389d.png)   |

Didn't show the contact form, but all the same changes apply. 


