### PR TITLE
Save list values from api

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/SaveListData.ts
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/SaveListData.ts
@@ -1,0 +1,26 @@
+export const sendListData = async (
+  endpoint: string | undefined,
+  rest_nonce: string | undefined,
+  data: {}
+) => {
+  if (!endpoint || !rest_nonce) return false;
+
+  const headers = new Headers({
+    'Content-Type': 'application/json;charset=UTF-8',
+  });
+
+  headers.append('X-WP-Nonce', rest_nonce);
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: headers,
+    mode: 'cors',
+    cache: 'default',
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    console.log(response.body);
+    console.log(response);
+  }
+};

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/UseListFetch.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/UseListFetch.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useFetch from 'use-http';
 import { useParams } from "react-router-dom";
 import { useList } from "../store/ListContext";
-
+import { sendListData } from "./SaveListData"
 
 export const useListFetch = () => {
     const { dispatch } = useList();
@@ -23,6 +23,15 @@ export const useListFetch = () => {
             } else {
                 setStatus("error")
             }
+
+            // sync list from List Manager API to local WP Option
+            const listData = await response.json();
+            const lists = listData.map((list: any) => {
+                return { id: list?.id, label: list?.name, type: "email" }
+            })
+            const REST_URL = window.CDS_VARS.rest_url;
+            const REST_NONCE = window.CDS_VARS.rest_nonce;
+            await sendListData(`${REST_URL}list-manager/list/save`, REST_NONCE, { "list_values": lists });
         }
 
         fetchData();


### PR DESCRIPTION
## PR

ref: https://github.com/cds-snc/gc-articles-issues/issues/281

This PR updates the code to "sync" / save the values when an API call is made to get current list data.

Once the list data is saved visiting `List Manager Settings` should populate the List Data with the saved information from the API call.

Once this PR is merged -- we can make a further update to use the the Notify service from here `options-general.php?page=notify-settings` as the sending service for lists.  Given the decision was made to use a single sending service we'll be able to remove the "List Manager Settings" settings after that - we can remove the sending service dropdown from bulk send and just used the defined service.

<img width="753" alt="Screen Shot 2022-03-15 at 2 33 21 PM" src="https://user-images.githubusercontent.com/62242/158447613-e658ac9f-e003-45be-9d6b-7b5cf19967bd.png">



### Currently list manager uses this interface to populate List available to send to 

<img width="500" alt="Screen Shot 2022-03-15 at 2 18 44 PM" src="https://user-images.githubusercontent.com/62242/158445369-c2975d29-08ad-4115-bd12-ce5a6112813f.png">

That in turn populates 

The Bulk send dropdown
<img width="622" alt="Screen Shot 2022-03-15 at 2 24 08 PM" src="https://user-images.githubusercontent.com/62242/158446145-f614a9f0-51bd-439e-aff7-5cab5406b026.png">

And the subscribe block dropdown

<img width="289" alt="Screen Shot 2022-03-15 at 2 25 34 PM" src="https://user-images.githubusercontent.com/62242/158446377-cc63a006-41c3-4b5e-a8ea-33f0587405f8.png">


