### PR TITLE
Use named parameters for form field functions

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -49,31 +49,33 @@ class ContactForm
                     </div>
 
                     <div class="focus-group">
-                    <?php echo Utils::radioField(
-                        'goal',
-                        'Ask a question.',
-                        __('Ask a question.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::radioField(
-                        'goal',
-                        'Get technical support.',
-                        __('Get technical support.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::radioField(
-                        'goal',
-                        'Give feedback.',
-                        __('Give feedback.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::radioField(
-                        'goal',
-                        'Schedule a demo to learn more about GC Articles.',
-                        __('Schedule a demo to learn more about GC Articles.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::radioField(
-                        'goal',
-                        'Other',
-                        __('Other', 'cds-snc'),
-                    ); ?>
+                    <?php
+                        Utils::radioField(
+                            'goal',
+                            'Ask a question.',
+                            __('Ask a question.', 'cds-snc'),
+                        );
+                        Utils::radioField(
+                            'goal',
+                            'Get technical support.',
+                            __('Get technical support.', 'cds-snc'),
+                        );
+                        Utils::radioField(
+                            'goal',
+                            'Give feedback.',
+                            __('Give feedback.', 'cds-snc'),
+                        );
+                        Utils::radioField(
+                            'goal',
+                            'Schedule a demo to learn more about GC Articles.',
+                            __('Schedule a demo to learn more about GC Articles.', 'cds-snc'),
+                        );
+                        Utils::radioField(
+                            'goal',
+                            'Other',
+                            __('Other', 'cds-snc'),
+                        );
+                    ?>
                 </div>
                 <!-- end goal of your message -->
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -89,37 +89,38 @@ class ContactForm
                     </div>
 
                     <div class="focus-group">
-                    <?php echo Utils::checkboxField(
-                        'usage[]',
-                        'Blog.',
-                        __('Blog.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'usage[]',
-                        'Newsletter archive with emailing to a subscriber list.',
-                        __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'usage[]',
-                        'Website.',
-                        __('Website.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'usage[]',
-                        'Internal website.',
-                        __('Internal website.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'usage[]',
-                        'Something else.',
-                        __('Something else.', 'cds-snc'),
-                        null, // we don't have previous values to pass in
-                        'optional-usage'
-                    ); ?>
+                    <?php
+                        Utils::checkboxField(
+                            name: 'usage[]',
+                            id: 'Blog.',
+                            label: __('Blog.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'usage[]',
+                            id: 'Newsletter archive with emailing to a subscriber list.',
+                            label: __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'usage[]',
+                            id: 'Website.',
+                            label: __('Website.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'usage[]',
+                            id: 'Internal website.',
+                            label: __('Internal website.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'usage[]',
+                            id: 'Something else.',
+                            label: __('Something else.', 'cds-snc'),
+                            ariaControls: 'optional-usage'
+                        );
+                    ?>
                     </div>
                     
                     <div id="optional-usage">
-                        <?php echo Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- end usage -->
@@ -134,36 +135,37 @@ class ContactForm
                     </div>
                     
                     <div class="focus-group">
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'People who use your programs and services.',
-                        __('People who use your programs and services.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'General public.',
-                        __('General public.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'Subscribers.',
-                        __('Subscribers.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'Internal employees and/or community volunteers.',
-                        __('Internal employees and/or community volunteers.', 'cds-snc'),
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'Other people.',
-                        __('Other people.', 'cds-snc'),
-                        null, // we don't have previous values to pass in
-                        'optional-target'
-                    ); ?>
+                    <?php
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'People who use your programs and services.',
+                            value: __('People who use your programs and services.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'General public.',
+                            value: __('General public.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'Subscribers.',
+                            value: __('Subscribers.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'Internal employees and/or community volunteers.',
+                            value: __('Internal employees and/or community volunteers.', 'cds-snc'),
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'Other people.',
+                            value: __('Other people.', 'cds-snc'),
+                            ariaControls: 'optional-target'
+                        );
+                    ?>
                     </div>
                     <div id="optional-target">
-                        <?php echo Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- target -->
@@ -182,7 +184,7 @@ class ContactForm
 
                 <!-- send me a copy -->
                 <div>
-                    <?php echo Utils::checkboxField(
+                    <?php Utils::checkboxField(
                         'cc',
                         'Send a copy to your email.',
                         __('Send a copy to your email.', 'cds-snc'),

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -93,27 +93,27 @@ class ContactForm
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Blog.',
-                            label: __('Blog.', 'cds-snc'),
+                            value: __('Blog.', 'cds-snc'),
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Newsletter archive with emailing to a subscriber list.',
-                            label: __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
+                            value: __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Website.',
-                            label: __('Website.', 'cds-snc'),
+                            value: __('Website.', 'cds-snc'),
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Internal website.',
-                            label: __('Internal website.', 'cds-snc'),
+                            value: __('Internal website.', 'cds-snc'),
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Something else.',
-                            label: __('Something else.', 'cds-snc'),
+                            value: __('Something else.', 'cds-snc'),
                             ariaControls: 'optional-usage'
                         );
                     ?>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -192,7 +192,7 @@ class ContactForm
                 </div>
                 <!-- send me a copy -->
 
-                <?php echo Utils::submitButton(__('Submit', 'cds-snc')); ?>
+                <?php Utils::submitButton(__('Submit', 'cds-snc')); ?>
             </form>
         </div>
         <?php

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -29,14 +29,15 @@ class ContactForm
         <div class="gc-form-wrapper">
             <form id="cds-form" method="POST" action="/wp-json/contact/v1/process">
                 
-                <?php wp_nonce_field(
-                    'cds_form_nonce_action',
-                    'cds-form-nonce',
-                ); ?>
-            
-                <?php echo Utils::textField('fullname', __('Full name', 'cds-snc')); ?>
-                
-                <?php echo Utils::textField('email', __('Email', 'cds-snc')); ?>
+                <?php
+                    wp_nonce_field(
+                        'cds_form_nonce_action',
+                        'cds-form-nonce',
+                    );
+
+                    Utils::textField(id: 'fullname', label: __('Full name', 'cds-snc'));
+                    Utils::textField(id: 'email', label: __('Email', 'cds-snc'));
+                ?>
             
                 <!-- goal of your message -->
                 <div role="group" aria-labelledby="goal_types">
@@ -116,7 +117,7 @@ class ContactForm
                     </div>
                     
                     <div id="optional-usage">
-                        <?php echo Utils::textField('usage-optional', __('Other usage', 'cds-snc')); ?>
+                        <?php echo Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- end usage -->
@@ -160,7 +161,7 @@ class ContactForm
                     ); ?>
                     </div>
                     <div id="optional-target">
-                        <?php echo Utils::textField('target-optional', __('Other target audience', 'cds-snc')); ?>
+                        <?php echo Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- target -->

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
@@ -75,11 +75,11 @@ class Setup
             }
         }
 
-        if (isset($_POST['usage-other']) && $_POST['usage-other'] !== '') {
+        if (isset($_POST['usage-optional']) && $_POST['usage-optional'] !== '') {
             $message .=
                 "\n" .
                 '(Other) ' .
-                sanitize_text_field($_POST['usage-other']) .
+                sanitize_text_field($_POST['usage-optional']) .
                 "\n";
         }
 
@@ -93,11 +93,11 @@ class Setup
             }
         }
 
-        if (isset($_POST['target-other']) && $_POST['target-other'] !== '') {
+        if (isset($_POST['target-optional']) && $_POST['target-optional'] !== '') {
             $message .=
                 "\n" .
                 '(Other) ' .
-                sanitize_text_field($_POST['target-other']) .
+                sanitize_text_field($_POST['target-optional']) .
                 "\n";
         }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -74,12 +74,13 @@ class RequestSiteForm
                     ?>
                 </p>
 
-                <?php wp_nonce_field(
-                    'cds_form_nonce_action',
-                    'cds-form-nonce',
-                );
+                <?php
+                    wp_nonce_field(
+                        'cds_form_nonce_action',
+                        'cds-form-nonce',
+                    );
 
-                // add hidden fields for previous answers
+                    // add hidden fields for previous answers
                 foreach ($all_values as $_key => $_value) {
                     // if is array, iterate through each array value
                     if (is_array($_value)) {
@@ -91,22 +92,19 @@ class RequestSiteForm
                     }
                 }
 
+                    Utils::textField(id: 'fullname', label: __('Full name', 'cds-snc'));
+                    Utils::textField(
+                        id: 'email',
+                        label: __('Email', 'cds-snc'),
+                        description: __('Must be a Government of Canada email address. <br />Currently, we accept email addresses ending in gc.ca, canada.ca, or cds-snc.ca.'),
+                    );
+                    Utils::textField(id: 'role', label: __('Job title or role', 'cds-snc'));
+                    Utils::textField(
+                        id: 'department',
+                        label: __('Department or agency', 'cds-snc'),
+                        description: __('GC Articles is only for government employees.', 'cds-snc')
+                    );
                 ?>
-
-                <?php echo Utils::textField('fullname', __('Full name', 'cds-snc')); ?>
-
-                <!-- start email -->
-                <?php echo Utils::textField(
-                    'email',
-                    __('Email', 'cds-snc'),
-                    __('Must be a Government of Canada email address. <br />Currently, we accept email addresses ending in gc.ca, canada.ca, or cds-snc.ca.'),
-                );
-                ?>
-                <!-- end email -->
-
-                <?php echo Utils::textField('role', __('Job title or role', 'cds-snc')); ?>
-
-                <?php echo Utils::textField('department', __('Department or agency', 'cds-snc'), __('GC Articles is only for government employees.', 'cds-snc')); ?>
 
                 <div class="focus-group">
                     <ul>
@@ -155,11 +153,11 @@ class RequestSiteForm
                 ); ?>
             
                 <!-- start site -->
-                <?php echo Utils::textField(
-                    'site',
-                    __('English title of your site', 'cds-snc'),
-                    __('This title will appear at the top of your site. You can change this later.', 'cds-snc'),
-                    $all_values['site']
+                <?php Utils::textField(
+                    id: 'site',
+                    label: __('English title of your site', 'cds-snc'),
+                    description: __('This title will appear at the top of your site. You can change this later.', 'cds-snc'),
+                    value: $all_values['site']
                 ); ?>
                 <!-- end site -->
 
@@ -207,7 +205,7 @@ class RequestSiteForm
                         ); ?>
                     </div>
                     <div id="optional-usage" aria-hidden="false">
-                        <?php echo Utils::textField('usage-optional', __('Other usage', 'cds-snc')); ?>
+                        <?php echo Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- end usage -->
@@ -255,7 +253,7 @@ class RequestSiteForm
                     ); ?>
                     </div>
                     <div id="optional-target" aria-hidden="false">
-                        <?php echo Utils::textField('target-optional', __('Other target audience', 'cds-snc')); ?>
+                        <?php echo Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
                     </div>
                 </div>
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -119,7 +119,7 @@ class RequestSiteForm
 
                 <!-- send me a copy -->
                 <div>
-                    <?php echo Utils::checkboxField(
+                    <?php Utils::checkboxField(
                         'cc',
                         'Send a copy to your email.',
                         __('Send a copy to your email.', 'cds-snc'),
@@ -171,38 +171,39 @@ class RequestSiteForm
                     </div>
                     
                     <div class="focus-group">
-                        <?php echo Utils::checkboxField(
-                            'usage[]',
-                            'Blog.',
-                            __('Blog.', 'cds-snc'),
-                            $all_values['usage']
-                        ); ?>
-                        <?php echo Utils::checkboxField(
-                            'usage[]',
-                            'Newsletter archive with emailing to a subscriber list.',
-                            __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
-                            $all_values['usage']
-                        ); ?>
-                        <?php echo Utils::checkboxField(
-                            'usage[]',
-                            'Website.',
-                            __('Website.', 'cds-snc'),
-                            $all_values['usage']
-                        ); ?>
-                        <?php echo Utils::checkboxField(
-                            'usage[]',
-                            'Internal website.',
-                            __('Internal website.', 'cds-snc'),
-                            $all_values['usage'],
-                        ); ?>
-
-                        <?php echo Utils::checkboxField(
-                            'usage[]',
-                            'Something else.',
-                            __('Something else.', 'cds-snc'),
-                            $all_values['usage'],
-                            'optional-usage'
-                        ); ?>
+                        <?php
+                            Utils::checkboxField(
+                                name: 'usage[]',
+                                id: 'Blog.',
+                                value: __('Blog.', 'cds-snc'),
+                                vals: $all_values['usage']
+                            );
+                            Utils::checkboxField(
+                                name: 'usage[]',
+                                id: 'Newsletter archive with emailing to a subscriber list.',
+                                value: __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
+                                vals: $all_values['usage']
+                            );
+                            Utils::checkboxField(
+                                name: 'usage[]',
+                                id: 'Website.',
+                                value: __('Website.', 'cds-snc'),
+                                vals: $all_values['usage']
+                            );
+                            Utils::checkboxField(
+                                name: 'usage[]',
+                                id: 'Internal website.',
+                                value: __('Internal website.', 'cds-snc'),
+                                vals: $all_values['usage']
+                            );
+                            Utils::checkboxField(
+                                name: 'usage[]',
+                                id: 'Something else.',
+                                value: __('Something else.', 'cds-snc'),
+                                vals: $all_values['usage'],
+                                ariaControls: 'optional-usage'
+                            );
+                        ?>
                     </div>
                     <div id="optional-usage" aria-hidden="false">
                         <?php echo Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
@@ -220,37 +221,39 @@ class RequestSiteForm
                     </div>
                     
                     <div class="focus-group">
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'People who use your programs and services.',
-                        __('People who use your programs and services.', 'cds-snc'),
-                        $all_values['target']
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'General public.',
-                        __('General public.', 'cds-snc'),
-                        $all_values['target']
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'Subscribers.',
-                        __('Subscribers.', 'cds-snc'),
-                        $all_values['target']
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'Internal employees and/or community volunteers.',
-                        __('Internal employees and/or community volunteers.', 'cds-snc'),
-                        $all_values['target']
-                    ); ?>
-                    <?php echo Utils::checkboxField(
-                        'target[]',
-                        'Other people.',
-                        __('Other people.', 'cds-snc'),
-                        $all_values['target'],
-                        'optional-target'
-                    ); ?>
+                    <?php
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'People who use your programs and services.',
+                            value: __('People who use your programs and services.', 'cds-snc'),
+                            vals: $all_values['target']
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'General public.',
+                            value: __('General public.', 'cds-snc'),
+                            vals: $all_values['target']
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'Subscribers.',
+                            value: __('Subscribers.', 'cds-snc'),
+                            vals: $all_values['target']
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'Internal employees and/or community volunteers.',
+                            value: __('Internal employees and/or community volunteers.', 'cds-snc'),
+                            vals: $all_values['target']
+                        );
+                        Utils::checkboxField(
+                            name: 'target[]',
+                            id: 'Other people.',
+                            value: __('Other people.', 'cds-snc'),
+                            vals: $all_values['target'],
+                            ariaControls: 'optional-target'
+                        );
+                    ?>
                     </div>
                     <div id="optional-target" aria-hidden="false">
                         <?php echo Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -41,7 +41,7 @@ class RequestSiteForm
             <?php
 
             $required_keys = ['site', 'usage', 'target', 'timeline'];
-            $all_keys = array_merge($required_keys, ['usage-other', 'target-other']);
+            $all_keys = array_merge($required_keys, ['usage-optional', 'target-optional']);
             $all_values = [];
             $empty_values = [];
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -127,7 +127,7 @@ class RequestSiteForm
                 </div>
                 <!-- send me a copy -->
 
-                <?php echo Utils::submitButton(__('Request site', 'cds-snc')); ?>
+                <?php Utils::submitButton(__('Request site', 'cds-snc')); ?>
             </form>
 
 
@@ -206,7 +206,7 @@ class RequestSiteForm
                         ?>
                     </div>
                     <div id="optional-usage" aria-hidden="false">
-                        <?php echo Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- end usage -->
@@ -256,7 +256,7 @@ class RequestSiteForm
                     ?>
                     </div>
                     <div id="optional-target" aria-hidden="false">
-                        <?php echo Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
                     </div>
                 </div>
 
@@ -278,7 +278,7 @@ class RequestSiteForm
                     ><?php echo $all_values['timeline']; ?></textarea>
                 </div>
 
-                <?php echo Utils::submitButton(__('Next', 'cds-snc')); ?>
+                <?php Utils::submitButton(__('Next', 'cds-snc')); ?>
             </form>
             <?php }  // end of the big if ?>
         </div>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
@@ -41,7 +41,7 @@ class Setup
             return ['error' => true, "error_message" => $nonceErrorMessage];
         }
 
-        $keys_page_1 = ['site', 'usage', 'usage-other', 'target', 'target-other', 'timeline'];
+        $keys_page_1 = ['site', 'usage', 'usage-optional', 'target', 'target-optional', 'timeline'];
         $keys_page_2 = ['fullname', 'email', 'role', 'department'];
         $empty_keys = [];
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/SubscriptionForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/SubscriptionForm.php
@@ -49,14 +49,15 @@ class SubscriptionForm
            <form id="cds-form" method="POST" action="<?php echo $apiEndpoint; ?>">
                 <input type="hidden" name="list_id" value="<?php echo $listId; ?>"/>
 
-                <?php wp_nonce_field(
+            <?php
+                wp_nonce_field(
                     'cds_form_nonce_action',
                     'cds-form-nonce',
-                ); ?>
+                );
 
-                <?php echo Utils::textField('email', $emailLabel, null, null, $placeholder); ?>
-
-                <?php echo Utils::submitButton($subscribeLabel); ?>
+                Utils::textField(id: 'email', label: $emailLabel, placeholder: $placeholder);
+                echo Utils::submitButton($subscribeLabel);
+            ?>
             </form>
         </div>
         <?php

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/SubscriptionForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/SubscriptionForm.php
@@ -56,7 +56,7 @@ class SubscriptionForm
                 );
 
                 Utils::textField(id: 'email', label: $emailLabel, placeholder: $placeholder);
-                echo Utils::submitButton($subscribeLabel);
+                Utils::submitButton($subscribeLabel);
             ?>
             </form>
         </div>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
@@ -92,7 +92,7 @@ class Utils
         echo $field;
     }
 
-    public static function checkboxField(string $name, string $id, string $value, array|string $vals = null, string $ariaControls = null): string
+    public static function checkboxField(string $name, string $id, string $value, array|string $vals = null, string $ariaControls = null, ?bool $echo = true)
     {
         // set to empty array if a non-array is passed in
         $vals = is_array($vals) ? $vals : [];
@@ -124,7 +124,11 @@ class Utils
 
         $field = ob_get_contents();
         ob_end_clean();
-        return $field;
+
+        if (!$echo) {
+            return $field;
+        }
+        echo $field;
     }
 
     public static function submitButton(string $label): string

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
@@ -63,7 +63,7 @@ class Utils
         echo $field;
     }
 
-    public static function radioField(string $name, string $id, string $value): string
+    public static function radioField(string $name, string $id, string $value, ?bool $echo = true)
     {
         ob_start();
         ?>
@@ -85,7 +85,11 @@ class Utils
 
         $field = ob_get_contents();
         ob_end_clean();
-        return $field;
+
+        if (!$echo) {
+            return $field;
+        }
+        echo $field;
     }
 
     public static function checkboxField(string $name, string $id, string $value, array|string $vals = null, string $ariaControls = null): string

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
@@ -131,7 +131,7 @@ class Utils
         echo $field;
     }
 
-    public static function submitButton(string $label): string
+    public static function submitButton(string $label, ?bool $echo = true)
     {
         ob_start();
         ?>
@@ -142,6 +142,10 @@ class Utils
 
         $field = ob_get_contents();
         ob_end_clean();
-        return $field;
+
+        if (!$echo) {
+            return $field;
+        }
+        echo $field;
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
@@ -23,7 +23,7 @@ class Utils
         return '';
     }
 
-    public static function textField(string $id, string $label, ?string $description = null, ?string $value = '', ?string $placeholder = null): string
+    public static function textField(string $id, string $label, ?string $description = null, ?string $value = '', ?string $placeholder = null, ?bool $echo = true)
     {
         $isEmail = $id === 'email';
         $isRequired = !str_ends_with($id, "optional");
@@ -56,7 +56,11 @@ class Utils
 
         $field = ob_get_contents();
         ob_end_clean();
-        return $field;
+
+        if (!$echo) {
+            return $field;
+        }
+        echo $field;
     }
 
     public static function radioField(string $name, string $id, string $value): string

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
@@ -15,7 +15,7 @@ afterAll(function () {
 });
 
 test('asserts textField returns a text input with expected values', function () {
-    $field = Utils::textField('myId', 'Enter your name');
+    $field = Utils::textField('myId', 'Enter your name', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('<label class="gc-label" for="myId" id="myId-label">Enter your name</label>');
@@ -23,7 +23,7 @@ test('asserts textField returns a text input with expected values', function () 
 });
 
 test('asserts textField returns a text input that is not required when id ends with "optional"', function () {
-    $field = Utils::textField('myId-optional', 'Enter your middle name');
+    $field = Utils::textField('myId-optional', 'Enter your middle name', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('<label class="gc-label" for="myId-optional" id="myId-optional-label">Enter your middle name</label>');
@@ -31,7 +31,7 @@ test('asserts textField returns a text input that is not required when id ends w
 });
 
 test('asserts textField returns an email input when id is "email"', function () {
-    $field = Utils::textField('email', 'Enter your email');
+    $field = Utils::textField('email', 'Enter your email', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('<label class="gc-label" for="email" id="email-label">Enter your email</label>');
@@ -39,24 +39,24 @@ test('asserts textField returns an email input when id is "email"', function () 
 });
 
 test('asserts textField returns a text input with a description', function () {
-    $field = Utils::textField('myId', 'Enter your name', 'Your name is that thing people call you');
+    $field = Utils::textField('myId', 'Enter your name', 'Your name is that thing people call you', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('<div id="myId-desc" class="gc-description" data-testid="description">Your name is that thing people call you</div>');
 });
 
 test('asserts textField returns a text input with a filled-in value', function () {
-    $field = Utils::textField('myId', 'Enter your name', null, 'Gino');
+    $field = Utils::textField('myId', 'Enter your name', value: 'Gino', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('<input type="text" id="myId" name="myId" value="Gino" required class="gc-input-text" />');
 });
 
 test('asserts textField returns a text input with a placeholder', function () {
-    $field = Utils::textField('myId', 'Enter your name', null, null, 'John Doe');
+    $field = Utils::textField('myId', 'Enter your name', placeholder: 'Your name here', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
-    expect($field)->toContain('<input type="text" id="myId" name="myId" value="" placeholder="John Doe" required class="gc-input-text" />');
+    expect($field)->toContain('<input type="text" id="myId" name="myId" value="" placeholder="Your name here" required class="gc-input-text" />');
 });
 
 test('asserts radioField returns a radio input with expected values', function () {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
@@ -101,7 +101,7 @@ test('asserts checkboxField returns an "aria-controls" and "expanded" checkbox i
 });
 
 test('asserts submitButton returns a button with the label we want', function () {
-    $field = Utils::submitButton('Press the button');
+    $field = Utils::submitButton('Press the button', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('<button class="gc-button" type="submit" id="submit">Press the button</button>');

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
@@ -60,7 +60,7 @@ test('asserts textField returns a text input with a placeholder', function () {
 });
 
 test('asserts radioField returns a radio input with expected values', function () {
-    $field = Utils::radioField('myName', 'myId', 'myValue');
+    $field = Utils::radioField('myName', 'myId', 'myValue', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     // note that "id" arg is used for value (because we don't want to be translated)

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
@@ -70,7 +70,7 @@ test('asserts radioField returns a radio input with expected values', function (
 });
 
 test('asserts checkboxField returns a checkbox input with expected values', function () {
-    $field = Utils::checkboxField('myName', 'myId', 'myValue');
+    $field = Utils::checkboxField('myName', 'myId', 'myValue', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     // note that "id" arg is used for value (because we don't want to be translated)
@@ -80,21 +80,21 @@ test('asserts checkboxField returns a checkbox input with expected values', func
 });
 
 test('asserts checkboxField returns a "checked" checkbox input if "values" array contains value', function () {
-    $field = Utils::checkboxField('myName', 'myId', 'myValue', ['myValue']);
+    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myValue'], echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('checked');
 });
 
 test('asserts checkboxField returns a not "checked" checkbox input if "values" array does not contain value', function () {
-    $field = Utils::checkboxField('myName', 'myId', 'myValue', ['myOtherValue']);
+    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myOtherValue'], echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->not->toContain('checked');
 });
 
 test('asserts checkboxField returns an "aria-controls" and "expanded" checkbox input', function () {
-    $field = Utils::checkboxField('myName', 'myId', 'myValue', ['myValue'], 'aria-controls');
+    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myValue'], ariaControls: 'aria-controls', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('aria-controls="aria-controls" aria-expanded="1"');


### PR DESCRIPTION
# Summary | Résumé

This PR is an update to #626,

In this PR:
- all the form field functions now `echo` by default
- use named params instead of `null`s as positional arguments
- remove some of the superfluous "<?php" tags now that our forms are using more PHP in general
- fix a bug introduced by the past PR, where optional fields weren't being included in the email message

