### PR TITLE
Use box-shadow instead of outline for focus styles on footer links

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -18,6 +18,22 @@ header .gcweb-menu {
   border-top-color: #26374a; /* originally #38414d */
 }
 
+/* Fix footer links safari bug */
+.wb-navcurr a {
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+}
+
+.wb-navcurr a:focus {
+  box-shadow:
+    0 0 0 2px hsl(0deg 0% 6%),
+    0 0 0 3px hsl(0deg 0% 100%);
+  outline: 0;
+  border-radius: 2px;
+  border-top: 0;
+  border-bottom: 0;
+}
+
 /* Link button (for blog pagination) */
 .pager .next > a,
 .pager .next > a:visited,


### PR DESCRIPTION
# Summary | Résumé

Fixes a weird CSS bug that happens where having an outline seems to break the column css in Safari.

@amazingphilippe pointed it out to us, basically tabbing through the footer links in safari moves the links between columns. Outlines are not supposed to affect the size of elements, so this is a bug to do with Safari.

## gif 

| before | after |
|--------|-------|
|  presently, focus styles have low contrast in safari and links jump around      |  afterwords, focus has higher contrast and footer links don't move     |
|   ![Screen Recording 2022-03-16 at 12 46 55](https://user-images.githubusercontent.com/2454380/158644005-f2cea8fa-98fa-47b1-a4c5-e4ef0171713b.gif)    |    ![Screen Recording 2022-03-16 at 12 45 06](https://user-images.githubusercontent.com/2454380/158643996-40e1d7e7-97f5-4d97-a341-9f507438899b.gif)  |

