### PR TITLE
Add URL preview component

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -104,13 +104,9 @@ form * {
 }
 
 .gc-form-wrapper form .gc-description,
-.gc-form-wrapper form .gc-description ul li {
+.gc-form-wrapper form .gc-description * {
   font-size: 18px;
   line-height: 24px;
-}
-
-.gc-form-wrapper form .gc-description ul li {
-  margin-top: 5px;
 }
 
 .gc-form-wrapper form .gc-textarea {
@@ -146,3 +142,9 @@ form button.gc-button[disabled] {
   opacity: .7;
   cursor: progress;
 }
+
+/* URL Typer */
+.gc-form-wrapper div.url-typer {
+  margin-top: -.5em;
+  margin-bottom: 1.5em;
+} 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -153,12 +153,27 @@ class RequestSiteForm
                 ); ?>
             
                 <!-- start site -->
-                <?php Utils::textField(
-                    id: 'site',
-                    label: __('English title of your site', 'cds-snc'),
-                    description: __('This title will appear at the top of your site. You can change this later.', 'cds-snc'),
-                    value: $all_values['site']
-                ); ?>
+                <div class="focus-group">
+                    <label class="gc-label" for="site" id="site-label">
+                        <?php _e('English title of your site', 'cds-snc'); ?>
+                    </label>
+                    <div id="site-desc" class="gc-description" data-testid="description">
+                        <?php _e('This title will appear at the top of your site. You can change this later.', 'cds-snc'); ?>
+                    </div>
+                    <input 
+                        type="text" 
+                        class="gc-input-text" 
+                        id="site" 
+                        name="site" 
+                        value="<?php echo $all_values['site']; ?>"
+                        aria-describedby="url-typer"
+                        required
+                    />
+                    <div id="url-typer" class="url-typer gc-description" aria-live="polite" aria-atomic="true">
+                        <div class="url-typer--empty"><?php _e('Enter a title to preview your URL'); ?></div>
+                        <div class="url-typer--message displayNone"><?php _e('Your URL preview:'); ?> <strong>articles.alpha.canada.ca/<span id="url-typer__preview"></span></strong></div>
+                    </div>
+                </div>
                 <!-- end site -->
 
                 <!-- usage -->

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
@@ -25,7 +25,14 @@ class Setup
             ]);
         });
 
+        add_action('wp_enqueue_scripts', [$this, 'enqueue']);
+
         new RequestSiteForm();
+    }
+
+    public function enqueue()
+    {
+        wp_enqueue_script('cds-url-typer-js', plugin_dir_url(__FILE__) . './src/url-typer.js', ['jquery'], "1.0.0", true);
     }
 
     protected function removeslashes($str)

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/src/url-typer.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/src/url-typer.js
@@ -1,0 +1,38 @@
+(function ($) {
+    $requestForm = $('#cds-form-step-1');
+    var previewVisible = false;
+
+    if($requestForm.length) {
+
+        $requestForm.find('input#site').on('keyup', function () {
+            var inputValue = $(this).val()
+                .toLowerCase()
+                .trim()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // replace accented letters with latin characters
+                .replace(/ +/g,'-') // replace whitespace with hyphens
+                .replace(/[^a-z0-9-]/g,'') // replace anything that's not a letter, number, or a hyphen
+
+            // if there is an input value at all
+            if(inputValue.length) {
+                if(!previewVisible) {
+                    // show the "Your preview URL" string
+                    $requestForm.find('.url-typer--empty').addClass('displayNone')
+                    $requestForm.find('.url-typer--message').removeClass('displayNone');
+                    previewVisible = true;
+                }
+
+                // update preview text with cleaned input text
+                $('#url-typer__preview').text(inputValue);
+            } else {
+                if(previewVisible) {
+                    // show the "enter your title to get a preview URL" string
+                    $requestForm.find('.url-typer--empty').removeClass('displayNone')
+                    $requestForm.find('.url-typer--message').addClass('displayNone');
+                    previewVisible = false;
+                }
+            }
+        });
+
+    }
+
+})(jQuery);


### PR DESCRIPTION
# Summary | Résumé

This PR actually includes everything in #629, but also adds a URL preview indicator to the form. Check out the latest commit to see the code for this preview by itself.

The URL preview widget sits underneath the "Title of your site" field on the signup form and it converts whatever is typed in into something that could be in a URL. 
- lowercase everything
- no apostrophes
- accents are removed

I added an `aria-live` role to the preview text container, and an `aria-describedby` attribute to the input to point at the preview container. I think those two together should make for a reasonable accessible solution to this.

## gif

![Screen Recording 2022-03-16 at 14 40 14](https://user-images.githubusercontent.com/2454380/158677476-a74f87c5-e84b-430e-8278-54b6742dcf34.gif)

## Accessibility

Tried it out in voice over and it seems like it actually works pretty well with "aria-live" added.

<img width="637" alt="Screen Shot 2022-03-16 at 15 53 15" src="https://user-images.githubusercontent.com/2454380/158679692-9816fbf0-d21d-4d17-86c5-582403ec5c9f.png">
