### PR TITLE
Update WordPress to 5.9.2

### DIFF
--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN npm --unsafe-perm install
 
 ## Release build
 
-FROM wordpress:5.9.1-php8.0-fpm-alpine
+FROM wordpress:5.9.2-php8.0-fpm-alpine
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.9.1-php8.0-fpm-alpine
+FROM wordpress:5.9.2-php8.0-fpm-alpine
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary | Résumé

[WordPress Security/Maintenance Updates release 5.9.2](https://wordpress.org/support/wordpress-version/version-5-9-2/)

Updates our docker containers to the latest WordPress image.

To update local:
- `articles down` (or `ctrl-c` to stop service)
- You will need to delete the wordpress docker volume, or delete all gc-articles docker volumes and start fresh
- `articles up --build`