### PR TITLE
Set options + dismiss for "Finish site setup"

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSetup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSetup.php
@@ -24,8 +24,6 @@ class SiteSetup
         add_action('rest_api_init', [$this, 'registerRestRoutes']);
     }
 
-
-
     public function enqueue()
     {
         wp_enqueue_style(
@@ -56,6 +54,14 @@ class SiteSetup
                 return current_user_can('administrator');
             }
         ]);
+
+        register_rest_route('setup/v1', '/dismiss-options', [
+            'methods' => 'POST',
+            'callback' => [$this, 'dismissOptions'],
+            'permission_callback' => function () {
+                return current_user_can('administrator');
+            }
+        ]);
     }
 
     public function setOptions()
@@ -67,8 +73,9 @@ class SiteSetup
             update_option("collection_mode", "maintenance");
             update_option("blog_public", 0);
             update_option("options_set", 1);
-            update_option("options_set", 1);
             update_option("blogdescription", get_bloginfo("name"));
+            update_option("show_search", "on");
+            update_option("show_breadcrumbs", "on");
 
             if (isset($_POST['homeId'])) {
                 $homeId = intval($_POST['homeId']);
@@ -84,6 +91,12 @@ class SiteSetup
         } catch (\Exception $e) {
             return $e->getMessage();
         }
+    }
+
+    public function dismissOptions()
+    {
+        update_option("options_set", 1);
+        return "options_set";
     }
 
     public function finishPanel()
@@ -106,8 +119,9 @@ class SiteSetup
         } ?>
         <div class="wrap">
             <div class="finish-setup-content">
+                <span id="finish-setup-dismiss" class="notice-dismiss"><span class="screen-reader-text"><?php _e("Dismiss", 'cds'); ?></span></span>
                 <h3><?php _e('Finish Site Setup', 'cds-snc'); ?></h3>
-                <p><?php _e("Your almost done.  Let's create some pages, articles and default settings.", 'cds-snc'); ?></p>
+                <p><?php _e("Your almost done.  Let's create some pages and default settings.", 'cds-snc'); ?></p>
                 <div class="actions">
                     <a class="button" id="add-pages" href="#"><?php _e("Let's go!", 'cds'); ?></a>
                 </div>
@@ -117,7 +131,6 @@ class SiteSetup
                         <div class="loader"></div>
                     </div>
                 </div>
-
             </div>
         </div>
         <?php

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSetup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSetup.php
@@ -121,7 +121,7 @@ class SiteSetup
             <div class="finish-setup-content">
                 <span id="finish-setup-dismiss" class="notice-dismiss"><span class="screen-reader-text"><?php _e("Dismiss", 'cds'); ?></span></span>
                 <h3><?php _e('Finish Site Setup', 'cds-snc'); ?></h3>
-                <p><?php _e("Your almost done.  Let's create some pages and default settings.", 'cds-snc'); ?></p>
+                <p><?php _e("You're almost done.  Let's create some pages and default settings.", 'cds-snc'); ?></p>
                 <div class="actions">
                     <a class="button" id="add-pages" href="#"><?php _e("Let's go!", 'cds'); ?></a>
                 </div>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/css/styles.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/css/styles.css
@@ -10,7 +10,18 @@
 
 .finish-setup-content.notice-dismiss{
   position: absolute;
+  
 }
+
+#finish-setup-dismiss:before {
+  color: #fff !important;
+}
+
+#finish-setup-dismiss:hover:before {
+  color: #b3e3ff !important;
+}
+  
+  
 
 .finish-setup-content h3 {
   margin: 0;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/css/styles.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/css/styles.css
@@ -1,4 +1,5 @@
 .finish-setup-content {
+  position: relative;
   background-color: #26374a;
   padding: 1rem;
   margin: 16px 0;
@@ -7,9 +8,21 @@
   min-height:200px;
 }
 
+.finish-setup-content.notice-dismiss{
+  position: absolute;
+}
+
 .finish-setup-content h3 {
   margin: 0;
   font-size: 28px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: #fff;
+}
+
+.finish-setup-content h4 {
+  margin: 0;
+  font-size: 22px;
   font-weight: 600;
   line-height: 1.25;
   color: #fff;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/js/index.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/js/index.js
@@ -87,6 +87,21 @@ API.setOptions = async ($, data) => {
    });
 }
 
+API.dismissOptions = async ($) => {
+   const endpoint = window.ADMIN_REST.ENDPOINT;
+   return new Promise(async (resolve, reject) => {
+      const result = await $.ajax({
+         type: "POST",
+         headers: {
+            'X-WP-Nonce': CDS_VARS.rest_nonce
+         },
+         url: endpoint + `/wp-json/setup/v1/dismiss-options`,
+      });
+      resolve(result);
+      $(".finish-setup-content").hide();
+   });
+}
+
 (function ($) {
 
    const BASE_SITE = "/template-site" // this is the site to pull content from
@@ -116,7 +131,12 @@ API.setOptions = async ($, data) => {
          await API.translatePage($, BASE_SITE, { post_id: maintenanceId, fr_slug: "maintenance-fr" });
 
          $('.loader-container').fadeOut();
-         $('.text-status').html(`Finished. You can now <a href="users.php?page=users-add">add a user</a>.`);
+         $('.text-status').html(`<h4>Finished 🎉</h4> 
+         <p>Next steps:<br><ul>
+         <li>Check <a href="options-general.php?page=collection-settings">site settings</a></li>
+         <li>Add <a href="users.php?page=users-add">user</a></li>
+         </ul></p>
+         `);
 
       } catch (e) {
          $('.text-status').text(`⚠️ Error: ${e.message}`);
@@ -137,5 +157,9 @@ API.setOptions = async ($, data) => {
             initSetup();
          });
       });
+   });
+
+   $(document).on("click", "#finish-setup-dismiss", async () => {
+      API.dismissOptions($);
    });
 })(jQuery);


### PR DESCRIPTION
- Adds dismiss "Finish site setup" + updated some text.
- Sets "site search" + "breadcrumb" options


<img width="1072" alt="Screen Shot 2022-03-18 at 9 19 25 AM" src="https://user-images.githubusercontent.com/62242/159010063-5077d2c9-39b1-4301-bece-b905deb5c607.png">

Closes 
https://github.com/cds-snc/gc-articles-issues/issues/269
https://github.com/cds-snc/gc-articles-issues/issues/273