### PR TITLE
Hide "Canada.ca" menu + unassign custom menu if exists

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor.css
@@ -235,3 +235,12 @@ width: 80px;
 #list-manager-app input.button[type="submit"] {
   margin-right: 10px;
 }
+
+.settings-warning {
+  display: inline-block;
+  border-radius: 4px;
+  border: 1px solid #dba617;
+  background: rgba(219, 166, 23, .3);
+  margin-bottom: 5px;
+  padding: 2px;
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor.css
@@ -235,12 +235,3 @@ width: 80px;
 #list-manager-app input.button[type="submit"] {
   margin-right: 10px;
 }
-
-.settings-warning {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #dba617;
-  background: rgba(219, 166, 23, .3);
-  margin-bottom: 5px;
-  padding: 2px;
-}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -97,6 +97,11 @@ header .gcweb-menu {
   display: none;
 }
 
+/* Hide menu (keeps the blue bar) */
+.hide-wet-menu .gcweb-menu .container {
+  display: none;
+}
+
 /* Forms */
 form * {
   font-size: 20px;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
@@ -18,6 +18,8 @@ class SettingsFunctions
 
     public function addActions()
     {
+        add_action('init', [$this, 'dequeuePrimaryMenu'], 999);
+
         add_filter('body_class', [$this, 'addBodyClasses']);
     }
 
@@ -42,5 +44,28 @@ class SettingsFunctions
         }
 
         return $classes;
+    }
+
+    public function dequeuePrimaryMenu()
+    {
+        $showWetMenu = get_option('show_wet_menu');
+        $locations = get_nav_menu_locations();
+
+        if (
+            $showWetMenu === 'off' &&                   // if we _don't_ want to show the "wet menu"
+            array_key_exists('header', $locations) &&   // if there _is_ a header 'location'
+            is_int($locations['header'])                // if 'header' is assigned to an integer
+        ) {
+            $current_page_path = $_SERVER['REQUEST_URI'];
+
+            // if we are explicitly setting a menu, turn on the "show canada.ca menu" option
+            if (str_contains($current_page_path, "nav-menus.php")) {
+                update_option('show_wet_menu', 'on');
+            } else {
+                // if not, remove 'header' menu
+                $locations['header'] = null; // remove assigned menu
+                set_theme_mod('nav_menu_locations', $locations); // save the new "locations" array
+            }
+        }
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
@@ -18,7 +18,7 @@ class SettingsFunctions
 
     public function addActions()
     {
-        add_action('init', [$this, 'dequeuePrimaryMenu'], 999);
+        add_action('admin_head', [$this, 'dequeuePrimaryMenu']);
 
         add_filter('body_class', [$this, 'addBodyClasses']);
     }
@@ -53,7 +53,7 @@ class SettingsFunctions
 
         if (
             $showWetMenu === 'off' &&                   // if we _don't_ want to show the "wet menu"
-            array_key_exists('header', $locations) &&   // if there _is_ a header 'location'
+            array_key_exists('header', $locations) &&   // if there _is_ a 'header' location
             is_int($locations['header'])                // if 'header' is assigned to an integer
         ) {
             $current_page_path = $_SERVER['REQUEST_URI'];

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
@@ -23,6 +23,12 @@ class SettingsFunctions
 
     public function addBodyClasses($classes)
     {
+        $showWetMenu = get_option('show_wet_menu');
+
+        if ($showWetMenu === 'off') {
+            $classes[] = 'hide-wet-menu';
+        }
+
         $showSearch = get_option('show_search');
 
         if ($showSearch === 'off') {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -249,8 +249,12 @@ class SiteSettings
     {
         $show_wet_menu = get_option('show_wet_menu');
 
+        printf('<div class="settings-warning">⚠️ <span>%s</span></div>', __('This setting will have no effect because you have a custom menu activated.', "cds-snc"));
+
+        printf('<div>');
         printf('<input type="radio" name="show_wet_menu" id="show_wet_menu_on" value="on" %s /> <label for="show_wet_menu_on">%s</label><br />', checked("on", $show_wet_menu, false), __('Show Canada.ca menu', "cds-snc"));
         printf('<input type="radio" name="show_wet_menu" id="show_wet_menu_off" value="off" %s /> <label for="show_wet_menu_off">%s</label><br />', checked("off", $show_wet_menu, false), __('Hide Canada.ca menu', "cds-snc"));
+        printf('</div>');
     }
 
     public function showSearchCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -249,12 +249,8 @@ class SiteSettings
     {
         $show_wet_menu = get_option('show_wet_menu');
 
-        printf('<div class="settings-warning">⚠️ <span>%s</span></div>', __('This setting will have no effect because you have a custom menu activated.', "cds-snc"));
-
-        printf('<div>');
         printf('<input type="radio" name="show_wet_menu" id="show_wet_menu_on" value="on" %s /> <label for="show_wet_menu_on">%s</label><br />', checked("on", $show_wet_menu, false), __('Show Canada.ca menu', "cds-snc"));
         printf('<input type="radio" name="show_wet_menu" id="show_wet_menu_off" value="off" %s /> <label for="show_wet_menu_off">%s</label><br />', checked("off", $show_wet_menu, false), __('Hide Canada.ca menu', "cds-snc"));
-        printf('</div>');
     }
 
     public function showSearchCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -115,6 +115,11 @@ class SiteSettings
 
         register_setting(
             'site_settings_group', // option_group
+            'show_wet_menu',
+        );
+
+        register_setting(
+            'site_settings_group', // option_group
             'show_search',
         );
 
@@ -193,6 +198,17 @@ class SiteSettings
 
         // add fields MAINTENANCE
         add_settings_field(
+            'show_wet_menu', // id
+            __('Canada.ca top menu', 'cds-snc'), // title
+            array( $this, 'wetMenuCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_config', // section
+            [
+                'label_for' => 'show_wet_menu'
+            ]
+        );
+
+        add_settings_field(
             'show_search', // id
             __('Search bar', 'cds-snc'), // title
             array( $this, 'showSearchCallback'), // callback
@@ -227,6 +243,14 @@ class SiteSettings
 
         printf('<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />', checked('maintenance', $collection_mode, false), __('Turn on', "cds-snc"));
         printf('<input type="radio" name="collection_mode" id="collection_live" value="live" %s /> <label for="collection_live">%s</label><br />', checked('live', $collection_mode, false), __('Turn off', "cds-snc"));
+    }
+
+    public function wetMenuCallback()
+    {
+        $show_wet_menu = get_option('show_wet_menu');
+
+        printf('<input type="radio" name="show_wet_menu" id="show_wet_menu_on" value="on" %s /> <label for="show_wet_menu_on">%s</label><br />', checked("on", $show_wet_menu, false), __('Show Canada.ca menu', "cds-snc"));
+        printf('<input type="radio" name="show_wet_menu" id="show_wet_menu_off" value="off" %s /> <label for="show_wet_menu_off">%s</label><br />', checked("off", $show_wet_menu, false), __('Hide Canada.ca menu', "cds-snc"));
     }
 
     public function showSearchCallback()


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new setting option to hide the Canada.ca menu.

It was a little tricky figuring out what hook to use, but it seems like it works now.

### Steps to test this:

- Look your default setup (Canada.ca menu should be there)
- Click "Hide Canada.ca menu" in the site settings. You should see the blue line only.
- Add your own custom menu to the header (it should appear, and then in the settings the option to "show the menu" should be selected)
- Click "Hide Canada.ca menu" in the site settings. Your custom menu should be gone. If you visit "Appearance > Menus > Locations", there should be no menu assigned to the header.

## Screenshots

| default page | page with only canada.ca menu removed | page with all header elements removed | page with custom menu |
|--------------|---------------------------------------|---------------------------------------|-----------------------|
|      ![Screen Shot 2022-03-21 at 14 47 13](https://user-images.githubusercontent.com/2454380/159343310-3c9a6b3b-1a4c-48f8-ae17-78e43a09f9b6.png)     |            ![Screen Shot 2022-03-21 at 14 47 29](https://user-images.githubusercontent.com/2454380/159343320-2ea51bd3-2978-4dae-a9c4-8ce6c68b75a8.png)                   |  ![Screen Shot 2022-03-21 at 14 47 45](https://user-images.githubusercontent.com/2454380/159343322-37be88a7-923a-42ad-8ae9-05e770363a42.png)                                  |         ![Screen Shot 2022-03-21 at 14 47 58](https://user-images.githubusercontent.com/2454380/159343326-4afe57e3-bb85-4f0b-b6db-72e3a0fa6926.png)          |



## Notes

Essentially, we have 3 different states we can be in:
1. Canada.ca top menu
2. We have our own top menu that we set
3. We don't want a top menu

In this PR, we are going to assume
- someone who clicks option (3) wants to get rid of _any_ top menu they have assigned (whether 1 OR 2) 
- someone who assigns a top menu (option 2) wants to unset option (3) 

What we want to avoid:
- someone builds their own menu but is not able to ever see it because they previously selected "hide canada.ca top menu" (in this case, it keeps getting programatically unassigned)
- Someone sets "hide canada.ca top menu" and then it still still shows their custom menu that they don't want

