### PR TITLE
Cleanup old compiled .json translation files before compiling new ones

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/composer.json
+++ b/wordpress/wp-content/plugins/cds-base/composer.json
@@ -24,9 +24,11 @@
         "make-pot": "wp i18n make-pot --domain=cds-snc . languages/cds-snc.pot",
         "merge-po": "msgmerge -U ./languages/cds-snc-fr_CA.po ./languages/cds-snc.pot",
         "compile-mo": "msgfmt -o ./languages/cds-snc-fr_CA.mo ./languages/cds-snc-fr_CA.po",
+        "clean-json": "rm ./languages/*.json",
         "compile-json": "wp i18n make-json ./languages/cds-snc-fr_CA.po --no-purge",
         "compile-translations": [
             "@compile-mo",
+            "@clean-json",
             "@compile-json"
         ],
         "prepare-translations": [


### PR DESCRIPTION
# Summary | Résumé

Every time we run our compile-translations command, it generates a bunch of .json files with random strings in the filename. This means that they accumulate over time with a bunch of stale files hanging around.

This simply deletes previous .json files before generating new ones.
