### PR TITLE
Add a CLI command to configure WPML

### DIFF
--- a/cli/bin/articles
+++ b/cli/bin/articles
@@ -149,7 +149,6 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
                 "$CLI_SERVICE" \
                 bash "$@"
         else
@@ -180,6 +179,11 @@ if [ $# -gt 0 ]; then
           "$CLI_SERVICE" \
           bash < ./cli/bin/db-cleanup-list.sh
       fi
+
+    elif [ "$1" == "configure-wpml" ]; then
+        docker exec -i \
+          "$CLI_SERVICE" \
+          bash < ./cli/bin/configure-wpml.sh
 
     # Pass unknown commands to the "docker-compose" binary...
     else

--- a/cli/bin/configure-wpml.sh
+++ b/cli/bin/configure-wpml.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd /usr/src/wordpress
-wp install-wpml
+wp configure-wpml

--- a/cli/bin/configure-wpml.sh
+++ b/cli/bin/configure-wpml.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd /usr/src/wordpress
+wp install-wpml

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cli/InstallWpmlCLI.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cli/InstallWpmlCLI.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Cli;
+
+use CDS\Modules\Wpml\Installer as WPMLInstaller;
+use WP_CLI;
+
+class InstallWpmlCLI
+{
+    protected WPMLInstaller $wpml;
+
+    public function __construct(WPMLInstaller $wpml)
+    {
+        $this->wpml = $wpml;
+    }
+
+    public static function register(WPMLInstaller $wpml)
+    {
+        $instance = new self($wpml);
+
+        add_action('cli_init', function () use ($instance) {
+            WP_CLI::add_command('install-wpml', [$instance, 'installWpml']);
+        });
+    }
+
+    public function installWpml()
+    {
+        $this->wpml->installWpml();
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cli/InstallWpmlCLI.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cli/InstallWpmlCLI.php
@@ -21,7 +21,7 @@ class InstallWpmlCLI
         $instance = new self($wpml);
 
         add_action('cli_init', function () use ($instance) {
-            WP_CLI::add_command('install-wpml', [$instance, 'installWpml']);
+            WP_CLI::add_command('configure-wpml', [$instance, 'installWpml']);
         });
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cli/InstallWpmlCLI.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cli/InstallWpmlCLI.php
@@ -27,6 +27,12 @@ class InstallWpmlCLI
 
     public function installWpml()
     {
+        if (!getenv("WPML_SITE_KEY")) {
+            WP_CLI::error("You must set your WPML_SITE_KEY in your environment");
+            exit;
+        }
+
         $this->wpml->installWpml();
+        WP_CLI::success("WPML has been installed");
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Installer.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Installer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CDS\Modules\Wpml;
 
+use CDS\Modules\Cli\InstallWpmlCLI;
 use WPML\Collect\Support\Collection;
 use WPML\Media\Setup\Endpoint\PrepareSetup;
 use WPML\Media\Translate\Endpoint\DuplicateFeaturedImages;
@@ -115,6 +116,8 @@ class Installer
     {
         $instance = new self();
 
+        InstallWpmlCLI::register($instance);
+
         add_action('wp_initialize_site', [$instance, 'onInit']);
     }
 
@@ -143,8 +146,17 @@ class Installer
     {
         switch_to_blog($newSite->id);
 
+        $this->installWpml();
+
+        restore_current_blog();
+    }
+
+    public function installWpml()
+    {
         // If this doesn't exist, WPML doesn't exist
         if (function_exists('icl_sitepress_activate')) {
+            $this->updateLangLocale();
+
             // Activates the plugin and installs database tables for new site
             icl_sitepress_activate();
 
@@ -153,10 +165,6 @@ class Installer
                 $this->runAction($step['endpoint'], new Collection($step['data']));
             }
         }
-
-        $this->updateLangLocale();
-
-        restore_current_blog();
     }
 
     /**
@@ -174,7 +182,7 @@ class Installer
     /**
      * Updates the default WPML en/fr language locales to CA
      */
-    protected function updateLangLocale()
+    public function updateLangLocale()
     {
         global $wpdb;
 


### PR DESCRIPTION
# Summary | Résumé

When setting up a local environment, there are some manual steps that must be taken to configure WPML and ensure the correct language codes are set on the default site.

This adds a WP CLI command and an `articles cli` wrapper for it.

## Usage
You'll need the `WPML_SITE_KEY` in your .env file.

There are two ways to use this command:

WP CLI:
- Bring up a fresh local environment
- run `npm run cli` to get into the devcontainer
- `cd /usr/src/wordpress`
- `wp configure-wpml`

Articles CLI:
- Bring up a fresh local environment
- run `articles configure-wpml`