### PR TITLE
Proxy Confirm and Unsubscribe endpoints

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Setup.php
@@ -17,7 +17,7 @@ class Setup
     {
         new SetupRequestSiteForm();
         new SetupContactForm();
-        new SetupSubscribeForm();
+        SetupSubscribeForm::register();
 
         add_action('wp_enqueue_scripts', [$this, 'enqueue']);
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
@@ -20,11 +20,7 @@ class Confirm
     {
         $subscriptionId = $request['id'];
 
-        $client = new Client([
-            'headers' => [
-                "Authorization" => getenv('DEFAULT_LIST_MANAGER_API_KEY')
-            ]
-        ]);
+        $client = new Client();
 
         $endpoint = getenv('LIST_MANAGER_ENDPOINT');
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
@@ -40,18 +40,23 @@ class Confirm
                     }
                 ]
             ]);
-        } catch (ClientException $e) { // @TODO: handle 400 level error responses
+        } catch (ClientException $e) {
             error_log($e->getMessage());
-        } catch (ServerException $e) { // @TODO: handle 500 level error responses
+            wp_redirect('/list-manager-error');
+            exit();
+        } catch (ServerException $e) {
             error_log($e->getMessage());
-        } // @TODO: handle GuzzleHttp\Exception\ConnectException (retry?)
+            wp_redirect('/list-manager-error');
+            exit();
+        }
 
+        // If a redirect was returned from the endpoint, handle it
         if ($this->redirect) {
             wp_redirect($this->redirect);
             exit();
         }
 
-        // @TODO: What do we do if no redirect set? Or default action on error?
-        error_log($request['id']);
+        // Default redirect
+        wp_redirect('/confirmation');
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Forms\Subscribe;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use WP_REST_Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+class Confirm
+{
+    protected string $redirect = '';
+
+    public function confirm(WP_REST_Request $request)
+    {
+        $subscriptionId = $request['id'];
+
+        $client = new Client([
+            'headers' => [
+                "Authorization" => getenv('DEFAULT_LIST_MANAGER_API_KEY')
+            ]
+        ]);
+
+        $endpoint = getenv('LIST_MANAGER_ENDPOINT');
+
+        try {
+            $client->request('GET', $endpoint . '/subscription/' . $subscriptionId . '/confirm', [
+                'allow_redirects' => [
+                    'on_redirect' => function (
+                        RequestInterface $request,
+                        ResponseInterface $response,
+                        UriInterface $uri
+                    ) {
+                        $this->redirect = strval($uri);
+                    }
+                ]
+            ]);
+        } catch (ClientException $e) {
+            // @TODO: handle error responses (including 404 not found)
+            error_log($e->getMessage());
+        }
+
+        if ($this->redirect) {
+            wp_redirect($this->redirect);
+            exit();
+        }
+
+        // @TODO: What do we do if no redirect set?
+        error_log($request['id']);
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Confirm.php
@@ -6,6 +6,7 @@ namespace CDS\Modules\Forms\Subscribe;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use WP_REST_Request;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -39,17 +40,18 @@ class Confirm
                     }
                 ]
             ]);
-        } catch (ClientException $e) {
-            // @TODO: handle error responses (including 404 not found)
+        } catch (ClientException $e) { // @TODO: handle 400 level error responses
             error_log($e->getMessage());
-        }
+        } catch (ServerException $e) { // @TODO: handle 500 level error responses
+            error_log($e->getMessage());
+        } // @TODO: handle GuzzleHttp\Exception\ConnectException (retry?)
 
         if ($this->redirect) {
             wp_redirect($this->redirect);
             exit();
         }
 
-        // @TODO: What do we do if no redirect set?
+        // @TODO: What do we do if no redirect set? Or default action on error?
         error_log($request['id']);
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Endpoints.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Endpoints.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Forms\Subscribe;
+
+class Endpoints
+{
+    public static function register()
+    {
+        /*
+         * Note - if testing with WP ENV
+         * https://wordpress.org/support/topic/wp-env-with-gutenber-doesnt-have-a-rest-api/
+         */
+        add_action('rest_api_init', function () {
+            $subscribe = new Subscribe();
+
+            register_rest_route('subscribe/v1', '/process/', [
+                'methods' => 'POST',
+                'callback' => [$subscribe, 'confirmSubscription'],
+                'permission_callback' => function () {
+                    return '';
+                }
+            ]);
+
+            $unsubscribe = new Unsubscribe();
+            register_rest_route('subscription', '/(?P<id>[a-z0-9\-_/]*)/unsubscribe', [
+                'methods' => 'GET',
+                'callback' => [$unsubscribe, 'unsubscribe'],
+                'permission_callback' => function () {
+                    return '';
+                }
+            ]);
+
+            $confirm = new Confirm();
+            register_rest_route('subscription', '/(?P<id>[a-z0-9\-_/]*)/confirm', [
+                'methods' => 'GET',
+                'callback' => [$confirm, 'confirm'],
+                'permission_callback' => function () {
+                    return '';
+                }
+            ]);
+        });
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Endpoints.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Endpoints.php
@@ -14,7 +14,6 @@ class Endpoints
          */
         add_action('rest_api_init', function () {
             $subscribe = new Subscribe();
-
             register_rest_route('subscribe/v1', '/process/', [
                 'methods' => 'POST',
                 'callback' => [$subscribe, 'confirmSubscription'],

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
@@ -6,44 +6,9 @@ namespace CDS\Modules\Forms\Subscribe;
 
 class Setup
 {
-    protected string $redirect = '';
-
-    public function __construct()
+    public static function register()
     {
-        /*
-         * Note - if testing with WP ENV
-         * https://wordpress.org/support/topic/wp-env-with-gutenber-doesnt-have-a-rest-api/
-         */
-        add_action('rest_api_init', function () {
-            $subscribe = new Subscribe();
-
-            register_rest_route('subscribe/v1', '/process/', [
-                'methods' => 'POST',
-                'callback' => [$subscribe, 'confirmSubscription'],
-                'permission_callback' => function () {
-                    return '';
-                }
-            ]);
-
-            $unsubscribe = new Unsubscribe();
-            register_rest_route('subscription', '/(?P<id>[a-z0-9\-_/]*)/unsubscribe', [
-                'methods' => 'GET',
-                'callback' => [$unsubscribe, 'unsubscribe'],
-                'permission_callback' => function () {
-                    return '';
-                }
-            ]);
-
-            $confirm = new Confirm();
-            register_rest_route('subscription', '/(?P<id>[a-z0-9\-_/]*)/confirm', [
-                'methods' => 'GET',
-                'callback' => [$confirm, 'confirm'],
-                'permission_callback' => function () {
-                    return '';
-                }
-            ]);
-        });
-
-        new SubscriptionForm();
+        Endpoints::register();
+        SubscriptionForm::register();
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
@@ -26,7 +26,7 @@ class Setup
             ]);
 
             $unsubscribe = new Unsubscribe();
-            register_rest_route('subscribe/v1', '/unsubscribe/(?P<id>[a-z0-9\-_/]*)', [
+            register_rest_route('subscription', '/(?P<id>[a-z0-9\-_/]*)/unsubscribe', [
                 'methods' => 'GET',
                 'callback' => [$unsubscribe, 'unsubscribe'],
                 'permission_callback' => function () {
@@ -35,7 +35,7 @@ class Setup
             ]);
 
             $confirm = new Confirm();
-            register_rest_route('subscribe/v1', '/confirm/(?P<id>[a-z0-9\-_/]*)', [
+            register_rest_route('subscription', '/(?P<id>[a-z0-9\-_/]*)/confirm', [
                 'methods' => 'GET',
                 'callback' => [$confirm, 'confirm'],
                 'permission_callback' => function () {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
@@ -24,6 +24,24 @@ class Setup
                     return '';
                 }
             ]);
+
+            $unsubscribe = new Unsubscribe();
+            register_rest_route('subscribe/v1', '/unsubscribe/(?P<id>[a-z0-9\-_/]*)', [
+                'methods' => 'GET',
+                'callback' => [$unsubscribe, 'unsubscribe'],
+                'permission_callback' => function () {
+                    return '';
+                }
+            ]);
+
+            $confirm = new Confirm();
+            register_rest_route('subscribe/v1', '/confirm/(?P<id>[a-z0-9\-_/]*)', [
+                'methods' => 'GET',
+                'callback' => [$confirm, 'confirm'],
+                'permission_callback' => function () {
+                    return '';
+                }
+            ]);
         });
 
         new SubscriptionForm();

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Setup.php
@@ -4,15 +4,6 @@ declare(strict_types=1);
 
 namespace CDS\Modules\Forms\Subscribe;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\RequestException;
-use PHPUnit\TextUI\Exception;
-use CDS\Modules\Forms\Utils;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
-
 class Setup
 {
     protected string $redirect = '';
@@ -24,9 +15,11 @@ class Setup
          * https://wordpress.org/support/topic/wp-env-with-gutenber-doesnt-have-a-rest-api/
          */
         add_action('rest_api_init', function () {
+            $subscribe = new Subscribe();
+
             register_rest_route('subscribe/v1', '/process/', [
                 'methods' => 'POST',
-                'callback' => [$this, 'confirmSubscription'],
+                'callback' => [$subscribe, 'confirmSubscription'],
                 'permission_callback' => function () {
                     return '';
                 }
@@ -34,110 +27,5 @@ class Setup
         });
 
         new SubscriptionForm();
-    }
-
-    protected function isJson($string): bool
-    {
-        json_decode($string);
-
-        return json_last_error() === JSON_ERROR_NONE;
-    }
-
-    public function handleException($e): string
-    {
-        $exception = (string)$e->getResponse()->getBody();
-
-        error_log($exception);
-
-        if ($this->isJson($exception)) {
-            try {
-                $exceptions = json_decode($exception);
-
-                $errors = "";
-
-                if (!$exceptions || !property_exists($exceptions, "detail")) {
-                    throw new \Exception("details not found");
-                }
-
-                foreach ($exceptions->detail as $error) {
-                    $errors = $errors . $error->loc[1] . ': ' . $error->msg . '<br>';
-                }
-
-                return $errors;
-            } catch (\Exception $e) {
-                return __("Internal server error", "cds-snc");
-            }
-        }
-
-        return __("Internal server error", "cds-snc");
-    }
-
-    protected function subscribe(string $email, string $listId): array
-    {
-        try {
-            $client = new Client([
-                'headers' => [
-                    "Authorization" => getenv('DEFAULT_LIST_MANAGER_API_KEY')
-                ]
-            ]);
-
-            $endpoint = getenv('LIST_MANAGER_ENDPOINT');
-
-            $client->request('POST', $endpoint . '/subscription', [
-                'json' => [
-                    "email" => $email,
-                    "list_id" => $listId,
-                    "service_api_key" => get_option('NOTIFY_API_KEY')
-                ],
-                'allow_redirects' => [
-                    'on_redirect' => function (
-                        RequestInterface $request,
-                        ResponseInterface $response,
-                        UriInterface $uri
-                    ) {
-                        $this->redirect = strval($uri);
-                    }
-                ]
-            ]);
-
-            return ["success" => __("Thanks for subscribing", "cds-snc"), "redirect" => $this->redirect];
-        } catch (ClientException $exception) {
-            $error = $this->handleException($exception);
-            return ["error" => $error];
-        } catch (RequestException  $exception) {
-            return ["error" => __("Internal server error", "cds-snc")];
-        }
-    }
-
-    public function confirmSubscription(): array
-    {
-        $nonceErrorMessage = Utils::isNonceErrorMessage($_POST);
-        if ($nonceErrorMessage) {
-            return ['error' => true, "error_message" => $nonceErrorMessage];
-        }
-
-        if (!isset($_POST["email"]) || $_POST["email"] === "") {
-            return [
-                'error' =>  true,
-                'error_message' => __(
-                    'Please complete the required field(s) to continue',
-                    'cds-snc',
-                ),
-                'keys' => ['email']
-            ];
-        }
-
-        if (!isset($_POST["list_id"]) || $_POST["list_id"] === "") {
-            return [
-                'error' =>  true,
-                'error_message' => __('Unknown subscription', 'cds-snc'),
-                'keys' => ['list_id']
-            ];
-        }
-
-        $email = sanitize_email($_POST["email"]);
-        $listId = sanitize_text_field($_POST['list_id']);
-
-        return $this->subscribe($email, $listId);
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Subscribe.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Subscribe.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Forms\Subscribe;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use CDS\Modules\Forms\Utils;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+class Subscribe
+{
+    protected function isJson($string): bool
+    {
+        json_decode($string);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    public function handleException($e): string
+    {
+        $exception = (string)$e->getResponse()->getBody();
+
+        error_log($exception);
+
+        if ($this->isJson($exception)) {
+            try {
+                $exceptions = json_decode($exception);
+
+                $errors = "";
+
+                if (!$exceptions || !property_exists($exceptions, "detail")) {
+                    throw new \Exception("details not found");
+                }
+
+                foreach ($exceptions->detail as $error) {
+                    $errors = $errors . $error->loc[1] . ': ' . $error->msg . '<br>';
+                }
+
+                return $errors;
+            } catch (\Exception $e) {
+                return __("Internal server error", "cds-snc");
+            }
+        }
+
+        return __("Internal server error", "cds-snc");
+    }
+
+    protected function subscribe(string $email, string $listId): array
+    {
+        try {
+            $client = new Client([
+                'headers' => [
+                    "Authorization" => getenv('DEFAULT_LIST_MANAGER_API_KEY')
+                ]
+            ]);
+
+            $endpoint = getenv('LIST_MANAGER_ENDPOINT');
+
+            $client->request('POST', $endpoint . '/subscription', [
+                'json' => [
+                    "email" => $email,
+                    "list_id" => $listId,
+                    "service_api_key" => get_option('NOTIFY_API_KEY')
+                ],
+                'allow_redirects' => [
+                    'on_redirect' => function (
+                        RequestInterface $request,
+                        ResponseInterface $response,
+                        UriInterface $uri
+                    ) {
+                        $this->redirect = strval($uri);
+                    }
+                ]
+            ]);
+
+            return ["success" => __("Thanks for subscribing", "cds-snc"), "redirect" => $this->redirect];
+        } catch (ClientException $exception) {
+            $error = $this->handleException($exception);
+            return ["error" => $error];
+        } catch (RequestException  $exception) {
+            return ["error" => __("Internal server error", "cds-snc")];
+        }
+    }
+
+    public function confirmSubscription(): array
+    {
+        $nonceErrorMessage = Utils::isNonceErrorMessage($_POST);
+        if ($nonceErrorMessage) {
+            return ['error' => true, "error_message" => $nonceErrorMessage];
+        }
+
+        if (!isset($_POST["email"]) || $_POST["email"] === "") {
+            return [
+                'error' =>  true,
+                'error_message' => __(
+                    'Please complete the required field(s) to continue',
+                    'cds-snc',
+                ),
+                'keys' => ['email']
+            ];
+        }
+
+        if (!isset($_POST["list_id"]) || $_POST["list_id"] === "") {
+            return [
+                'error' =>  true,
+                'error_message' => __('Unknown subscription', 'cds-snc'),
+                'keys' => ['list_id']
+            ];
+        }
+
+        $email = sanitize_email($_POST["email"]);
+        $listId = sanitize_text_field($_POST['list_id']);
+
+        return $this->subscribe($email, $listId);
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/SubscriptionForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/SubscriptionForm.php
@@ -8,12 +8,13 @@ use CDS\Modules\Forms\Utils;
 
 class SubscriptionForm
 {
-    public function __construct()
+    public static function register()
     {
-        add_action('init', [$this, 'register']);
+        $instance = new self();
+        add_action('init', [$instance, 'registerShortCode']);
     }
 
-    public function register()
+    public function registerShortCode()
     {
         add_shortcode('subscribe', [$this, 'render']);
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Forms\Subscribe;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use WP_REST_Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+class Unsubscribe
+{
+    protected string $redirect;
+
+    public function unsubscribe(WP_REST_Request $request)
+    {
+        $subscriptionId = $request['id'];
+
+        $client = new Client([
+            'headers' => [
+                "Authorization" => getenv('DEFAULT_LIST_MANAGER_API_KEY')
+            ]
+        ]);
+
+        $endpoint = getenv('LIST_MANAGER_ENDPOINT');
+
+        try {
+            $client->request('GET', $endpoint . '/unsubscribe/' . $subscriptionId, [
+                'allow_redirects' => [
+                    'on_redirect' => function (
+                        RequestInterface $request,
+                        ResponseInterface $response,
+                        UriInterface $uri
+                    ) {
+                        $this->redirect = strval($uri);
+                    }
+                ]
+            ]);
+        } catch (ClientException $e) {
+            // @TODO: handle error responses (including 404 not found)
+            // @TODO: unsubscribe seems to always return 500 error?
+            error_log($e->getMessage());
+        }
+
+        if ($this->redirect) {
+            wp_redirect($this->redirect);
+            exit();
+        }
+
+        // @TODO: What do we do if no redirect set?
+        error_log($request['id']);
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
@@ -40,18 +40,24 @@ class Unsubscribe
                     }
                 ]
             ]);
-        } catch (ClientException $e) { // @TODO: handle 400 level error responses
+        } catch (ClientException $e) {
             error_log($e->getMessage());
-        } catch (ServerException $e) { // @TODO: handle 500 level error responses
+            wp_redirect('/list-manager-error');
+            exit();
+        } catch (ServerException $e) {
             error_log($e->getMessage());
-        } // @TODO: handle GuzzleHttp\Exception\ConnectException (retry?)
+            wp_redirect('/list-manager-error');
+            exit();
+        }
 
+        // If a redirect was returned from the endpoint, handle it
         if ($this->redirect) {
             wp_redirect($this->redirect);
             exit();
         }
 
-        // @TODO: What do we do if no redirect set? Or default action on error?
-        error_log($request['id']);
+        // Default redirect
+        wp_redirect('/unsubscribed-from-mailing-list-labonnement-supprime');
+        exit();
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
@@ -20,11 +20,7 @@ class Unsubscribe
     {
         $subscriptionId = $request['id'];
 
-        $client = new Client([
-            'headers' => [
-                "Authorization" => getenv('DEFAULT_LIST_MANAGER_API_KEY')
-            ]
-        ]);
+        $client = new Client();
 
         $endpoint = getenv('LIST_MANAGER_ENDPOINT');
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Subscribe/Unsubscribe.php
@@ -6,6 +6,7 @@ namespace CDS\Modules\Forms\Subscribe;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use WP_REST_Request;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -13,7 +14,7 @@ use Psr\Http\Message\UriInterface;
 
 class Unsubscribe
 {
-    protected string $redirect;
+    protected string $redirect = '';
 
     public function unsubscribe(WP_REST_Request $request)
     {
@@ -39,18 +40,18 @@ class Unsubscribe
                     }
                 ]
             ]);
-        } catch (ClientException $e) {
-            // @TODO: handle error responses (including 404 not found)
-            // @TODO: unsubscribe seems to always return 500 error?
+        } catch (ClientException $e) { // @TODO: handle 400 level error responses
             error_log($e->getMessage());
-        }
+        } catch (ServerException $e) { // @TODO: handle 500 level error responses
+            error_log($e->getMessage());
+        } // @TODO: handle GuzzleHttp\Exception\ConnectException (retry?)
 
         if ($this->redirect) {
             wp_redirect($this->redirect);
             exit();
         }
 
-        // @TODO: What do we do if no redirect set?
+        // @TODO: What do we do if no redirect set? Or default action on error?
         error_log($request['id']);
     }
 }


### PR DESCRIPTION
# Summary | Résumé

Currently, Confirmation and Unsubscribe links in list-manager emails reference the `list-manager.alpha.canada.ca` domain. ie: 
- `https://list-manager.alpha.canada.ca/subscription/37bab31c-ffa6-4228-ac9a-24dbba9969c9/confirm`
- `https://list-manager.alpha.canada.ca/unsubscribe/37bab31c-ffa6-4228-ac9a-24dbba9969c9`

This PR adds a couple GC Articles proxy endpoints so that those links can appear to be from the gc-articles domain. ie,
- `https://articles.alpha.canada.ca/wp-json/subscription/37bab31c-ffa6-4228-ac9a-24dbba9969c9/confirm`
- `https://articles.alpha.canada.ca/wp-json/subscription/37bab31c-ffa6-4228-ac9a-24dbba9969c9/unsubscribe`

Also includes a small refactor moving the Subscribe endpoint code to its own dedicated class.

## TODO
Once this PR is merged, in order to use these endpoints, we'll need to [update the relevant links in List Manager](https://github.com/cds-snc/list-manager/blob/main/api/api_gateway/api.py#L755-L760).

Should also ensure that default bilingual content pages are created for:
- `/confirmation`
- `/unsubscribed-from-mailing-list-labonnement-supprime`
- `/list-manager-error`
