### PR TITLE
Remove phone templates from List Table View

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListViewTable.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListViewTable.tsx
@@ -68,7 +68,7 @@ const CreateListLink = () => {
     return <Link className="button button-primary" to={{ pathname: `list/create` }}>Create new list</Link>
 }
 
-const UploadListLink = ({ name, listId, serviceId }: { name: string, listId: string, serviceId: string|undefined }) => {
+const UploadListLink = ({ name, listId, serviceId }: { name: string, listId: string, serviceId: string | undefined }) => {
     return <Link aria-label={`${name} upload list`} className="button action" to={{ pathname: `/service/${serviceId}/list/${listId}/upload` }}>Upload List</Link>
 }
 
@@ -138,13 +138,6 @@ export const ListViewTable = () => {
                                         <DetailsLinkStyles><a href={templateLink(values.serviceId, values.subscribe_email_template_id)}>Subscribe</a></DetailsLinkStyles>
                                         <DetailsLinkStyles><a href={templateLink(values.serviceId, values.unsubscribe_email_template_id)}>Unsubscribe</a></DetailsLinkStyles>
                                     </TemplateGroupStyles>
-
-                                    <TemplateGroupStyles>
-                                        <div><strong>Phone</strong></div>
-                                        <DetailsLinkStyles><a href={templateLink(values.serviceId, values.subscribe_phone_template_id)}>Subscribe</a></DetailsLinkStyles>
-                                        <DetailsLinkStyles><a href={templateLink(values.serviceId, values.unsubscribe_phone_template_id)}>Unsubscribe</a></DetailsLinkStyles>
-                                    </TemplateGroupStyles>
-
                                     <TemplateGroupStyles>
                                         <div><strong>Confirm Url</strong></div>
                                         <DetailsLinkStyles><a href={values.confirm_redirect_url}>Confirm</a></DetailsLinkStyles>


### PR DESCRIPTION
Removes phone templates from the List Table View

<img width="672" alt="Screen Shot 2022-03-24 at 9 51 30 AM" src="https://user-images.githubusercontent.com/62242/159931256-7b21fae7-bad5-493f-99ea-c97529608ad4.png">
