### PR TITLE
Add cloudfront security headers config

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -60,6 +60,8 @@ resource "aws_cloudfront_distribution" "wordpress" {
     default_ttl            = 86400
     max_ttl                = 31536000
     compress               = true
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy.id
   }
 
   ordered_cache_behavior {

--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -8,10 +8,6 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
       frame_option = "SAMEORIGIN"
       override     = true
     }
-    # referrer_policy {
-    #   referrer_policy = "same-origin"
-    #   override        = true
-    # }
     xss_protection {
       mode_block = true
       protection = true
@@ -23,9 +19,9 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
       preload                    = true
       override                   = true
     }
-    content_security_policy {
-      content_security_policy = "frame-ancestors 'none'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
-      override                = true
-    }
+    # content_security_policy {
+    #   content_security_policy = "frame-ancestors 'none'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+    #   override                = true
+    # }
   }
 }

--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -1,0 +1,31 @@
+resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
+  name = "my-security-headers-policy"
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override        = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = "63072000"
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+    content_security_policy {
+      content_security_policy = "frame-ancestors 'none'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+      override                = true
+    }
+  }
+}

--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -5,20 +5,20 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
       override = true
     }
     frame_options {
-      frame_option = "DENY"
+      frame_option = "SAMEORIGIN"
       override     = true
     }
-    referrer_policy {
-      referrer_policy = "same-origin"
-      override        = true
-    }
+    # referrer_policy {
+    #   referrer_policy = "same-origin"
+    #   override        = true
+    # }
     xss_protection {
       mode_block = true
       protection = true
       override   = true
     }
     strict_transport_security {
-      access_control_max_age_sec = "63072000"
+      access_control_max_age_sec = "31536000"
       include_subdomains         = true
       preload                    = true
       override                   = true


### PR DESCRIPTION
# Summary | Résumé

Adds security headers to CloudFront including:
- X-Content-Type-Options
- X-Frame-Options 
- X-XSS-Protection
- Strict-Transport-Security

Leaving the CSP header commented out for now, as that will require some further configuration and testing.
