### PR TITLE
Add new rest field for Markdown content

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -96,7 +96,8 @@
     "digitalcube/c3-cloudfront-clear-cache": "dev-master",
     "wpackagist-plugin/jwt-authentication-for-wp-rest-api": "^1.2",
     "yoast/duplicate-post": "^4.4",
-    "shawnhooper/delete-orphaned-multisite-tables": "1.0"
+    "shawnhooper/delete-orphaned-multisite-tables": "1.0",
+    "league/html-to-markdown": "^5.1"
   },
   "require-dev": {
     "pestphp/pest": "^1.16",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e70e4e398afaf9cc572b7a9fc0586713",
+    "content-hash": "2d621106f133b15e69094fd20c5295eb",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -270,7 +270,7 @@
             "dist": {
                 "type": "path",
                 "url": "wp-content/plugins/cds-base",
-                "reference": "7b0a98e150d24af0ee406c8ad78cec4afc7a9b3b"
+                "reference": "b8961814c7c6e8acbc25e1965a7cf77a6a947e3b"
             },
             "require": {
                 "alphagov/notifications-php-client": "^3.2",
@@ -302,11 +302,15 @@
                 "compile-mo": [
                     "msgfmt -o ./languages/cds-snc-fr_CA.mo ./languages/cds-snc-fr_CA.po"
                 ],
+                "clean-json": [
+                    "rm ./languages/*.json"
+                ],
                 "compile-json": [
                     "wp i18n make-json ./languages/cds-snc-fr_CA.po --no-purge"
                 ],
                 "compile-translations": [
                     "@compile-mo",
+                    "@clean-json",
                     "@compile-json"
                 ],
                 "prepare-translations": [
@@ -1522,6 +1526,95 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2022-02-07T21:23:13+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "e0fc8cf07bdabbcd3765341ecb50c34c271d64e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/e0fc8cf07bdabbcd3765341ecb50c34c271d64e1",
+                "reference": "e0fc8cf07bdabbcd3765341ecb50c34c271d64e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "^1.1.0",
+                "phpstan/phpstan": "^0.12.99",
+                "phpunit/phpunit": "^8.5 || ^9.2",
+                "scrutinizer/ocular": "^1.6",
+                "unleashedtech/php-coding-standard": "^2.7",
+                "vimeo/psalm": "^4.22"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/html-to-markdown/issues",
+                "source": "https://github.com/thephpleague/html-to-markdown/tree/5.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/html-to-markdown",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-02T17:24:08+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -7411,5 +7504,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -23,6 +23,17 @@ class Markdown
 
     public function addMarkdownToPages()
     {
+
+        $markdown = false;
+
+        if (isset($_GET["markdown"])) {
+            $markdown = filter_var($_GET["markdown"], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        if (!$markdown) {
+            return;
+        }
+
         /**
          * Add a 'markdown' field to the REST response for a page
          * Returns content rendered in Markdown format

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -12,7 +12,7 @@ class Markdown
     {
         $instance = new self();
 
-        add_action('rest_api_init', [$instance, 'addMarkdownToPages']);
+        add_action('rest_api_init', [$instance, 'addMarkdownToPagesAndPosts']);
     }
 
     public static function render($content)
@@ -21,7 +21,15 @@ class Markdown
         return $converter->convert($content);
     }
 
-    public function addMarkdownToPages()
+    public function post2Markdown($post): array
+    {
+        return [
+            'excerpt' => ["rendered" => Markdown::render($post['excerpt']['rendered'])],
+            'content' => ["rendered" => Markdown::render($post['content']['rendered'])]
+        ];
+    }
+
+    public function addMarkdownToPagesAndPosts()
     {
 
         $markdown = false;
@@ -38,18 +46,26 @@ class Markdown
          * Add a 'markdown' field to the REST response for a page
          * Returns content rendered in Markdown format
          */
-         register_rest_field('page', 'markdown', array(
+        register_rest_field('page', 'markdown', array(
             'get_callback' => function ($post, $field_name, $request) {
-                return [
-                    'excerpt' => ["rendered" => Markdown::render($post['excerpt']['rendered'])],
-                    'content' => ["rendered" => Markdown::render($post['content']['rendered'])]
-                ];
+                return $this->post2Markdown($post);
             },
             'update_callback' => null,
             'schema' => array(
-                'description' => __('Page content markdown', 'cds-snc'),
+                'description' => __('Page content as markdown', 'cds-snc'),
                 'type'        => 'string'
             ),
-         ));
+        ));
+
+        register_rest_field('post', 'markdown', array(
+            'get_callback' => function ($post, $field_name, $request) {
+                return $this->post2Markdown($post);
+            },
+            'update_callback' => null,
+            'schema' => array(
+                'description' => __('Post content as markdown', 'cds-snc'),
+                'type'        => 'string'
+            ),
+        ));
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -15,10 +15,10 @@ class Markdown
         add_action('rest_api_init', [$instance, 'addMarkdownToPages']);
     }
 
-    public static function render($post)
+    public static function render($content)
     {
         $converter = new HtmlConverter(array('header_style' => 'atx'));
-        return $converter->convert($post['content']['rendered']);
+        return $converter->convert($content);
     }
 
     public function addMarkdownToPages()
@@ -27,15 +27,18 @@ class Markdown
          * Add a 'markdown' field to the REST response for a page
          * Returns content rendered in Markdown format
          */
-        register_rest_field('page', 'markdown', array(
+         register_rest_field('page', 'markdown', array(
             'get_callback' => function ($post, $field_name, $request) {
-                return ["rendered" => Markdown::render($post)];
+                return [
+                    'excerpt' => ["rendered" => Markdown::render($post['excerpt']['rendered'])],
+                    'content' => ["rendered" => Markdown::render($post['content']['rendered'])]
+                ];
             },
             'update_callback' => null,
             'schema' => array(
                 'description' => __('Page content markdown', 'cds-snc'),
                 'type'        => 'string'
             ),
-        ));
+         ));
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Markdown;
+
+use League\HTMLToMarkdown\HtmlConverter;
+
+class Markdown
+{
+    public static function register()
+    {
+        $instance = new self();
+
+        add_action('rest_api_init', [$instance, 'addMarkdownToPages']);
+    }
+
+    public static function render($post)
+    {
+        $converter = new HtmlConverter();
+        return $converter->convert($post['content']['rendered']);
+    }
+
+    public function addMarkdownToPages()
+    {
+
+        /**
+         * Add a 'markdown' field to the REST response for a page
+         * Returns a `rendered` content in Markdown format
+         */
+        register_rest_field('page', 'markdown', array(
+            'get_callback' => function ($post, $field_name, $request) {
+                return Markdown::render($post);
+            },
+            'update_callback' => null,
+            'schema' => array(
+                'description' => __('Page content markdown', 'cds-snc'),
+                'type'        => 'string'
+            ),
+        ));
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -17,7 +17,7 @@ class Markdown
 
     public static function render($post)
     {
-        $converter = new HtmlConverter();
+        $converter = new HtmlConverter(array('header_style' => 'atx'));
         return $converter->convert($post['content']['rendered']);
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -23,7 +23,6 @@ class Markdown
 
     public function addMarkdownToPages()
     {
-
         /**
          * Add a 'markdown' field to the REST response for a page
          * Returns a `rendered` content in Markdown format

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Markdown/Markdown.php
@@ -25,11 +25,11 @@ class Markdown
     {
         /**
          * Add a 'markdown' field to the REST response for a page
-         * Returns a `rendered` content in Markdown format
+         * Returns content rendered in Markdown format
          */
         register_rest_field('page', 'markdown', array(
             'get_callback' => function ($post, $field_name, $request) {
-                return Markdown::render($post);
+                return ["rendered" => Markdown::render($post)];
             },
             'update_callback' => null,
             'schema' => array(

--- a/wordpress/wp-content/plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Setup.php
@@ -39,6 +39,7 @@ use CDS\Modules\Site\SettingsFunctions;
 use CDS\Modules\Site\SiteSetup;
 use CDS\Modules\Wpml\Wpml;
 use CDS\Modules\Users\EmailDomains;
+use CDS\Modules\Markdown\Markdown;
 use Exception;
 
 class Setup
@@ -67,6 +68,7 @@ class Setup
         Cache::register();
         Wpml::register();
         EmailDomains::register();
+        Markdown::register();
 
         new SetupForms();
         new Styles();


### PR DESCRIPTION
For testing purposes:

Added Markdown output to the REST API

Note: 
- field will only be included if you add `markdown=true` to the `URL`
- this is built in but noting you can pass _embed to get author into + featured image info


<img width="707" alt="Screen Shot 2022-03-25 at 8 57 57 AM" src="https://user-images.githubusercontent.com/62242/160125349-65d62c6a-a683-40fc-9487-277e7ed6ce57.png">

