### PR TITLE
Change FIP link

### DIFF
--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -16,6 +16,20 @@ describe('Site Settings', () => {
     cy.get('#collection_live').should('be.empty');
   });
 
+  it('Changes FIP link', () => {
+    cy.visit('/wp-admin/options-general.php?page=collection-settings');
+
+    cy.get('h1').should('have.text', 'Site Settings');
+
+    cy.get('input#fip_href').clear().type("canada.ca/en.html");
+    cy.get('#submit').click();
+    cy.get('#setting-error-settings_updated').should('contain.text', 'Settings saved');
+
+    cy.visit('/');
+
+    cy.get('header .brand a').should("have.attr", "href", "http://canada.ca/en.html");
+  });
+
   it('Can save collection settings and show maintenance page', () => {
     cy.visit('/wp-admin/options-general.php?page=collection-settings');
     cy.get('#collection_maintenance').check();

--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -27,7 +27,7 @@ describe('Site Settings', () => {
 
     cy.visit('/');
 
-    cy.get('header .brand a').should("have.attr", "href", "http://canada.ca/en.html");
+    cy.get('header .brand a').should("have.attr", "href", "https://canada.ca/en.html");
   });
 
   it('Can save collection settings and show maintenance page', () => {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -289,6 +289,7 @@ class SiteSettings
     {
         $fipUrl = get_option("fip_href", "");
         $value = $fipUrl ? esc_url($fipUrl) : home_url();
+        $value = str_replace('http://', 'https://', $value);
 
         ?>
         <input name="fip_href" type="text" id="fip_href" class="regular-text" value="<?php echo $value; ?>">

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -128,6 +128,11 @@ class SiteSettings
             'show_breadcrumbs',
         );
 
+        register_setting(
+            'site_settings_group', // option_group
+            'fip_href',
+        );
+
         // add fields GENERAL
         add_settings_field(
             'blogname', // id
@@ -235,6 +240,17 @@ class SiteSettings
                 'label_for' => 'show_breadcrumbs'
             ]
         );
+
+        add_settings_field(
+            'fip_href', // id
+            __('Where should the Canada.ca header link to?', 'cds-snc'), // title
+            array( $this, 'fipHrefCallback'), // callback
+            'collection-settings-admin', // page
+            'collection_settings_section_config', // section
+            [
+                'label_for' => 'fip_href'
+            ]
+        );
     }
 
     public function collectionModeCallback()
@@ -268,6 +284,17 @@ class SiteSettings
         printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_on" value="on" %s /> <label for="show_breadcrumbs_on">%s</label><br />', checked("on", $show_breadcrumbs, false), __('Show breadcrumbs', "cds-snc"));
         printf('<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_off" value="off" %s /> <label for="show_breadcrumbs_off">%s</label><br />', checked("off", $show_breadcrumbs, false), __('Hide breadcrumbs', "cds-snc"));
     }
+
+    public function fipHrefCallback()
+    {
+        $fipUrl = get_option("fip_href", "");
+        $value = $fipUrl ? esc_url($fipUrl) : home_url();
+
+        ?>
+        <input name="fip_href" type="text" id="fip_href" class="regular-text" value="<?php echo $value; ?>">
+        <?php
+    }
+
 
     public function collectionMaintenancePageCallback()
     {

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -52,7 +52,7 @@ declare(strict_types=1);
         <?php $langText = get_language_text(); ?>
       <div class="brand col-xs-9 col-sm-5 col-md-4" property="publisher" resource="#wb-publisher"
            typeof="GovernmentOrganization">
-        <a href="<?php echo home_url(); ?>" property="url">
+        <a href="<?php echo get_fip_url(); ?>" property="url">
             <?php if (get_active_language() === 'fr') { ?>
               <img src="https://canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-fr.svg"
                    alt="Gouvernement du Canada" property="logo">

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -195,6 +195,12 @@ function get_language_text($lang = ''): array
     return ['full' => 'English', 'abbr' => 'en'];
 }
 
+function get_fip_url(): string
+{
+    $fipUrl = get_option('fip_href');
+    return $fipUrl ? esc_url($fipUrl) : home_url();
+}
+
 function get_active_language(): string
 {
     if (function_exists('icl_get_languages')) {

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -198,7 +198,8 @@ function get_language_text($lang = ''): array
 function get_fip_url(): string
 {
     $fipUrl = get_option('fip_href');
-    return $fipUrl ? esc_url($fipUrl) : home_url();
+    $value = $fipUrl ? esc_url($fipUrl) : home_url();
+    return str_replace('http://', 'https://', $value);
 }
 
 function get_active_language(): string


### PR DESCRIPTION
# Summary | Résumé

Pretty small change, includes a cypress test as well. 

Adds a new settings menu item that lets users change the FIP link. Doesn't actually do any validation to make sure it's actually a link, but does `esc_url` the value. If you put `a`, the fip link becomes `http://a`.