### PR TITLE
chore: remove old LB and WAF S3 log buckets

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/kinesis.tf
@@ -51,25 +51,6 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_us_east" {
 }
 
 #
-# S3 waf log destination
-#
-module "firehose_waf_log_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.33//S3"
-  bucket_name       = "platform-ircc-${var.env}-waf-logs"
-  billing_tag_value = var.billing_tag_value
-
-  lifecycle_rule = [
-    {
-      id      = "expire"
-      enabled = true
-      expiration = {
-        days = 30
-      }
-    }
-  ]
-}
-
-#
 # IAM
 #
 resource "aws_iam_role" "firehose_waf_logs" {

--- a/infrastructure/terragrunt/aws/load-balancer/s3.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/s3.tf
@@ -40,22 +40,3 @@ resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
-
-#
-# Load balancer logs
-#
-module "wordpress_lb_logs" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.33//S3"
-  bucket_name       = "platform-ircc-${var.env}-lb-logs"
-  billing_tag_value = var.billing_tag_value
-
-  lifecycle_rule = [
-    {
-      id      = "expire"
-      enabled = true
-      expiration = {
-        days = 30
-      }
-    }
-  ]
-}


### PR DESCRIPTION
# Summary
The load balancer and firewall logs are now being sent to the Cloud
Based Sensor satellite bucket.

Both of these buckets are now empty in Staging and Production because
of the 30 day expiration lifecycle rule.

![image](https://user-images.githubusercontent.com/2110107/160398344-ba8d0273-d379-44fb-accc-a6444f425b2f.png)

![image](https://user-images.githubusercontent.com/2110107/160398372-31290582-cd17-47bb-a379-3683ace7b7b6.png)
