### PR TITLE
Hide error messages during password reset requests

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
@@ -15,6 +15,7 @@ class Login
         add_action('wp_login_failed', [$this, 'loginFailed']);
         add_filter('login_redirect', [$this, 'loginRedirect'], 10, 3);
         add_filter('login_message', [$this, 'addLangLink']);
+        add_action('lostpassword_post', [$this, 'redirectToSuccessPageIfNoUser'], 10, 2);
 
         add_action('admin_page_access_denied', [$this, 'redirectToNewestBlog'], 98);
     }
@@ -161,5 +162,14 @@ class Login
     {
         $siteName = __("GC Articles", "cds-snc");
         return str_replace(array('&lsaquo;', 'WordPress'), array( '', $siteName), $login_title);
+    }
+
+    public function redirectToSuccessPageIfNoUser($errors, $user_data)
+    {
+        // if no $user_data (bad user id or bad email), immediately return to success page
+        // by doing this, we avoid error messages exposing which accounts and emails are valid
+        if (! $user_data) {
+            return wp_safe_redirect('wp-login.php?checkemail=confirm');
+        }
     }
 }


### PR DESCRIPTION
# Summary 

By default, password resets will return a revealing error message if someone enters a user id or email that doesn't exist:

- `Error: There is no account with that username or email address.`

Since this is a security risk (it allows people to enumerate through potential accounts), we want to stop this from happening.

This PR will send all password reset requests to the 'success' page, so there is no apparent difference between valid and invalid accounts. People who enter a legit email address will get their reset email, people who enter bad email addresses will have no way to tell they aren't sent.

Resolves: https://github.com/cds-snc/gc-articles/pull/657

Relevant source code:
- https://github.com/WordPress/WordPress/blob/master/wp-login.php#L779
- https://github.com/WordPress/WordPress/blob/8dc9fafcb6c9036ec2207e66534352983029cd4b/wp-includes/user.php#L3062

## Screenshots

| before | after |
|--------|-------|
|    descriptive error message lets everyone know which accounts don't really exist    |  now it appears that the account exists, even when it doesn't     |
|  <img width="1245" alt="Screen Shot 2022-03-29 at 16 13 58" src="https://user-images.githubusercontent.com/2454380/160699080-f7cc44a3-708e-4a21-9972-f5e4147a959d.png">  |  <img width="1245" alt="Screen Shot 2022-03-29 at 16 14 11" src="https://user-images.githubusercontent.com/2454380/160699086-9a871307-9fd1-45de-b3bd-9b30d4e2078c.png">  |


