### PR TITLE
Add Headers module to apply security headers

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -1,27 +1,20 @@
 resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
-  name = "my-security-headers-policy"
+  name = "gc-articles-security-headers"
   security_headers_config {
     content_type_options {
-      override = true
+      override = false
     }
     frame_options {
-      frame_option = "SAMEORIGIN"
-      override     = true
+      override = false
     }
     xss_protection {
-      mode_block = true
-      protection = true
-      override   = true
+      override = false
     }
     strict_transport_security {
-      access_control_max_age_sec = "31536000"
-      include_subdomains         = true
-      preload                    = true
-      override                   = true
+      override = false
     }
-    # content_security_policy {
-    #   content_security_policy = "frame-ancestors 'none'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
-    #   override                = true
-    # }
+    content_security_policy {
+      override = false
+    }
   }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Http/Headers.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Http/Headers.php
@@ -16,8 +16,10 @@ class Headers
     {
         $headers['X-XSS-Protection'] = '1; mode=block';
         $headers['X-Content-Type-Options'] = 'nosniff';
+        $headers['X-Frame-Options'] = 'SAMEORIGIN';
+        $headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubdomains; preload';
 
-        // Don't add CSP for logged in users or admin pages
+        // Only add CSP for front-end not-logged-in users
         if (!is_admin() && !is_user_logged_in()) {
             $headers['X-Content-Security-Policy'] = $this->getCSPHeaders();
         }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Http/Headers.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Http/Headers.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Http;
+
+class Headers
+{
+    public static function register()
+    {
+        $instance = new self();
+        add_filter('wp_headers', [$instance, 'addHeaders']);
+    }
+
+    public function addHeaders($headers)
+    {
+        $headers['X-XSS-Protection'] = '1; mode=block';
+        $headers['X-Content-Type-Options'] = 'nosniff';
+
+        // Don't add CSP for logged in users or admin pages
+        if (!is_admin() && !is_user_logged_in()) {
+            $headers['X-Content-Security-Policy'] = $this->getCSPHeaders();
+        }
+
+        return $headers;
+    }
+
+    protected function getCSPHeaders(): string
+    {
+        $csp = "base-uri 'self';";
+        $csp .= "connect-src 'self';";
+        $csp .= "default-src 'self';";
+        $csp .= "font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca;";
+        $csp .= "frame-src 'self';";
+        $csp .= "img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca;";
+        $csp .= "manifest-src 'self';";
+        $csp .= "media-src 'self';";
+        $csp .= "object-src 'none';";
+        $csp .= "script-src 'report-sample' 'self' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js;";
+        $csp .= "style-src 'report-sample' 'self' https://use.fontawesome.com https://www.canada.ca;";
+        $csp .= "worker-src 'none';";
+        return $csp;
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Http/Headers.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Http/Headers.php
@@ -36,9 +36,10 @@ class Headers
         $csp .= "manifest-src 'self';";
         $csp .= "media-src 'self';";
         $csp .= "object-src 'none';";
-        $csp .= "script-src 'report-sample' 'self' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js;";
-        $csp .= "style-src 'report-sample' 'self' https://use.fontawesome.com https://www.canada.ca;";
+        $csp .= "script-src 'self' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js;";
+        $csp .= "style-src 'unsafe-inline' 'self' https://use.fontawesome.com https://www.canada.ca;";
         $csp .= "worker-src 'none';";
+
         return $csp;
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Setup.php
@@ -23,6 +23,7 @@ use CDS\Modules\Cleanup\CreateSites;
 use CDS\Modules\Cleanup\Media;
 use CDS\Modules\Cli\GenerateEncryptionKey;
 use CDS\Modules\Forms\Setup as SetupForms;
+use CDS\Modules\Http\Headers;
 use CDS\Modules\Meta\Favicon;
 use CDS\Modules\Meta\MetaTags;
 use CDS\Modules\Notify\SendTemplateDashboardPanel;
@@ -59,6 +60,7 @@ class Setup
         $this->setupMeta();
         $this->setupCli();
 
+        Headers::register();
         TrackLogins::register();
         DBInsights::register();
         Releases::register();


### PR DESCRIPTION
# Summary | Résumé

Adds a new `Http/Headers` module to manage HTTP security headers.

Previously had applied directly at the CloudFront layer, but it seems from docs that we can just tell CloudFront to pass these through from Origin, allowing us to manage them at the WordPress layer. This means that we can turn the CSP headers on/off depending on whether the user is logged in or not. 

This is useful because WordPress Admin has a *lot* of inline scripts, so we can't disable `unsafe-inline` scripts without severely breaking the interface. However, we should be able to disable them on the frontend, protecting end users from XSS scripting attacks.

# Unsafe inline scripts
Currently there are two inline scripts being loaded on the frontend of the site:

Directive | Blocked URI | Document URI | Line Number | Column Number | Script Sample
-- | -- | -- | -- | -- | --
script-src-elem | inline | https://articles.cdssandbox.xyz/ | 41 | 0 | window._wpemojiSettings = {"baseUrl":"ht
script-src-elem | inline | https://articles.cdssandbox.xyz/ | 250 | 0 | var CDS_VARS = {"rest_url":"https:\/\/ar

We should be able to remove both of these, but if we can't, it's probably inconsequential to leave them in and disabled due to the CSP header.

For emoji scripts: https://www.denisbouquet.com/remove-wordpress-emoji-code/

# Unsafe inline styles
Unfortunately, there are quite a few inline styles that will prevent us from disabling `unsafe-inline` styles.

Directive | Blocked URI | Document URI | Line Number | Column Number | Script Sample
-- | -- | -- | -- | -- | --
style-src-attr | inline | https://articles.cdssandbox.xyz/ | 100 | 0 | visibility: hidden; position: absolute;
style-src-attr | inline | https://articles.cdssandbox.xyz/ | 212 | 0 | display:none;
style-src-attr | inline | https://articles.cdssandbox.xyz/features/ | 246 | 0 | flex-basis:66.66%
style-src-attr | inline | https://articles.cdssandbox.xyz/features/ | 256 | 0 | flex-basis:33.33%
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 61 | 0 |  
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 248 | 0 | .wp-container-6245fa0a194b0 {display: fl
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 248 | 0 | .wp-container-6245ff2477609 {display: fl
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 248 | 0 | .wp-container-6245ff030544a {display: fl
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 8 | 21971 | @font-face {font-family:"font";src:url("
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 73 | 0 | body{--wp--preset--color--black: #000000
style-src-elem | inline | https://articles.cdssandbox.xyz/ | 46 | 0 | img.wp-smiley, img.emoji { display: inl

