### PR TITLE
Add site status panel

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteStatus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteStatus.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CDS\Modules\Site;
+
+class SiteStatus
+{
+    public function __construct()
+    {
+    }
+
+    public static function register()
+    {
+        $instance = new self();
+        $instance->addActions();
+    }
+
+    public function addActions()
+    {
+        add_action('wp_dashboard_setup', [$this, 'dashboardWidget']);
+    }
+
+    public function dashboardWidget(): void
+    {
+        if (!is_super_admin()) {
+            return;
+        }
+
+        wp_add_dashboard_widget(
+            'cds_status_widget',
+            __('Site Status', 'cds'),
+            [$this, 'siteStatusPanelHandler'],
+        );
+    }
+
+    public function renderSiteAvailability()
+    {
+        $label = __('Site Availability', 'cds-snc');
+        $status = __('Live', 'cds-snc');
+        if (get_option("collection_mode") === "maintenance") {
+            $status =  __('Maintenance', 'cds-snc');
+        }
+
+        return sprintf("<tr><td>%s</td><td>%s</td></tr>", $label, $status);
+    }
+
+    public function renderSearchEngineVisibility()
+    {
+        $label = __('Search Engine Visibility', 'cds-snc');
+        $status = __('On', 'cds-snc');
+        if (intVal(get_option("blog_public")) === 0) {
+            $status =  __('Off', 'cds-snc');
+        }
+
+        return sprintf("<tr><td>%s</td><td>%s</td></tr>", $label, $status);
+    }
+
+    public function siteStatusPanelHandler(): void
+    {
+        $instance = new self();
+
+        $updateText = sprintf(
+            __('Update your <a href="%s">site settings</a>.', 'cds-snc'),
+            esc_url('options-general.php?page=collection-settings')
+        );
+
+        echo '<div id="site-status-panel">';
+        echo '<table class="wp-list-table widefat">';
+        echo $instance->renderSiteAvailability();
+        echo $instance->renderSearchEngineVisibility();
+        echo '</table>';
+        echo '<p>' . $updateText . '</p>';
+        echo '</div>';
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Setup.php
@@ -37,6 +37,7 @@ use CDS\Modules\Releases\Releases;
 use CDS\Modules\Site\SiteSettings;
 use CDS\Modules\Site\SettingsFunctions;
 use CDS\Modules\Site\SiteSetup;
+use CDS\Modules\Site\SiteStatus;
 use CDS\Modules\Wpml\Wpml;
 use CDS\Modules\Users\EmailDomains;
 use CDS\Modules\Markdown\Markdown;
@@ -63,6 +64,7 @@ class Setup
         DBInsights::register();
         Releases::register();
         SiteSettings::register();
+        SiteStatus::register();
         SettingsFunctions::register();
         SiteSetup::register();
         Cache::register();


### PR DESCRIPTION
# Summary | Résumé

Adds a site status panel and link to site settings

<img width="502" alt="Screen Shot 2022-04-01 at 9 19 08 AM" src="https://user-images.githubusercontent.com/62242/161272028-81903e0b-56af-48bf-86a1-878139275028.png">

Fixes https://github.com/cds-snc/gc-articles-issues/issues/288


# Test instructions | Instructions pour tester la modification

Update site settings + visit admin dashboard to see the new panel


