### PR TITLE
Use separate CSP policies for frontend/backend

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -61,7 +61,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
     max_ttl                = 31536000
     compress               = true
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_frontend.id
   }
 
   ordered_cache_behavior {
@@ -104,6 +104,8 @@ resource "aws_cloudfront_distribution" "wordpress" {
     max_ttl                = 0
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_admin.id
   }
 
   ordered_cache_behavior {

--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
-  name = "my-security-headers-policy"
+resource "aws_cloudfront_response_headers_policy" "security_headers_policy_frontend" {
+  name = "gc-articles-security-headers-frontend"
   security_headers_config {
     content_type_options {
       override = true
@@ -19,9 +19,37 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
       preload                    = true
       override                   = true
     }
-    # content_security_policy {
-    #   content_security_policy = "frame-ancestors 'none'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
-    #   override                = true
-    # }
+    content_security_policy {
+      content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js; style-src 'self' https://use.fontawesome.com https://www.canada.ca; worker-src 'none';"
+      override                = true
+    }
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "security_headers_policy_admin" {
+  name = "gc-articles-security-headers-admin"
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "SAMEORIGIN"
+      override     = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = "31536000"
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+    content_security_policy {
+      content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://www.canada.ca; worker-src 'none';"
+      override                = true
+    }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Conditionally set separate CSP headers for frontend vs admin. This way we can allow `unsafe-inline` for `script-src` and `style-src` for users logged into the admin panel, but not for users accessing the frontend.
