### PR TITLE
Remove unneeded styles scripts

### DIFF
--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -324,12 +324,14 @@ function fix_svg()
 add_action('admin_head', 'fix_svg');
 
 /**
- * Remove global-styles-inline-css and Gutenberg/duotone svg that appears under the body tag
+ * Remove global-styles-inline-css and Gutenberg/duotone svg
  */
 remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');
 remove_action('wp_body_open', 'wp_global_styles_render_svg_filters');
 
-// REMOVE WP EMOJI
+/**
+ * Remove WP EMOJI
+ */
 remove_action('wp_head', 'print_emoji_detection_script', 7);
 remove_action('wp_print_styles', 'print_emoji_styles');
 

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -328,3 +328,10 @@ add_action('admin_head', 'fix_svg');
  */
 remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');
 remove_action('wp_body_open', 'wp_global_styles_render_svg_filters');
+
+// REMOVE WP EMOJI
+remove_action('wp_head', 'print_emoji_detection_script', 7);
+remove_action('wp_print_styles', 'print_emoji_styles');
+
+remove_action('admin_print_scripts', 'print_emoji_detection_script');
+remove_action('admin_print_styles', 'print_emoji_styles');

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -322,3 +322,9 @@ function fix_svg()
 }
 
 add_action('admin_head', 'fix_svg');
+
+/**
+ * Remove global-styles-inline-css and Gutenberg/duotone svg that appears under the body tag
+ */
+remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');
+remove_action('wp_body_open', 'wp_global_styles_render_svg_filters');


### PR DESCRIPTION
# Summary | Résumé

Rather than maintaining a bunch of sha hashes in our CSP headers for these, remove a bunch of unnecessary scripts/styles that get injected by WP in our theme.
