### PR TITLE
Allow email addresses ending with "onmicrosoft.com"

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/EmailDomains.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/EmailDomains.php
@@ -8,8 +8,7 @@ use WP_Error;
 
 class EmailDomains
 {
-    public const ALLOWED_EMAIL_DOMAINS = ['cds-snc.ca', 'gc.ca', 'canada.ca'];
-
+    public const ALLOWED_EMAIL_DOMAINS = ['cds-snc.ca', 'gc.ca', 'canada.ca', 'onmicrosoft.com'];
 
     public function __construct()
     {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/EmailDomains.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/EmailDomains.php
@@ -8,7 +8,7 @@ use WP_Error;
 
 class EmailDomains
 {
-    public const ALLOWED_EMAIL_DOMAINS = ['cds-snc.ca', 'gc.ca', 'canada.ca', 'onmicrosoft.com'];
+    public const ALLOWED_EMAIL_DOMAINS = ['cds-snc.ca', 'gc.ca', 'canada.ca', '.onmicrosoft.com'];
 
     public function __construct()
     {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/tests/EmailDomainsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/tests/EmailDomainsTest.php
@@ -4,21 +4,6 @@ use CDS\Modules\Users\EmailDomains;
 
 class TestEmailDomains extends \WP_Mock\Tools\TestCase
 {
-    private $badEmails = [
-        'justin.trudeau@gmail.com',
-        'justin.trudeau@cds-snc',
-        'justin.trudeaucds-snc.ca',
-        'cds-snc.ca',
-        '@cds-snc.ca',
-        ''
-    ];
-
-    private $goodEmails = [
-        'justin.trudeau@cds-snc.ca',
-        'justin.trudeau@tbs-sct.gc.ca',
-        'admin@cds-snc.ca'
-    ];
-
     private $users;
 
     public function setUp(): void
@@ -63,6 +48,8 @@ class TestEmailDomains extends \WP_Mock\Tools\TestCase
             'Canada domain' => ['justin.trudeau@canada.ca'],
             'Service Canada domain' => ['justin.trudeau@servicecanada.ca'],
             'random Canada domain' => ['justin.trudeau@hockey.night.in.canada.ca'],
+            '‘innovation’ government domain @ PSPC' => ['justin.trudeau@pspcinnovation.onmicrosoft.com'],
+            'random ‘innovation’ Canada domain' => ['justin.trudeau@onmicrosoft.com'],
         ];
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/tests/EmailDomainsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/tests/EmailDomainsTest.php
@@ -26,6 +26,7 @@ class TestEmailDomains extends \WP_Mock\Tools\TestCase
             "no TLD" => ['justin.trudeau@cds-snc'],
             "no @" => ['justin.trudeaucds-snc.ca'],
             "no username" => ['@cds-snc.ca'],
+            "onmicrosoft without domain" => ['justin.trudeau@onmicrosoft.com'],
             'empty' => [''],
         ];
     }
@@ -49,7 +50,7 @@ class TestEmailDomains extends \WP_Mock\Tools\TestCase
             'Service Canada domain' => ['justin.trudeau@servicecanada.ca'],
             'random Canada domain' => ['justin.trudeau@hockey.night.in.canada.ca'],
             '‘innovation’ government domain @ PSPC' => ['justin.trudeau@pspcinnovation.onmicrosoft.com'],
-            'random ‘innovation’ Canada domain' => ['justin.trudeau@onmicrosoft.com'],
+            'random ‘innovation’ Canada domain' => ['justin.trudeau@esdc-innovation.onmicrosoft.com'],
         ];
     }
 


### PR DESCRIPTION
# Summary | Résumé

Several departments are using these for their Azure landing zones. PSPC uses it, and ESDC was using it too. We will probably see this come up from a few departments.

Note that the `$goodEmails`, `$badEmails` variables in the test file weren't getting used, so I deleted them.

Resolves this ticket: https://github.com/cds-snc/gc-articles-issues/issues/297

