### PR TITLE
Update list manager to work for local dev outside of WP

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/public/index.html
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/public/index.html
@@ -3,11 +3,81 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <!-- for dev load styles from localhost -->
+
+    <link
+      rel="stylesheet"
+      id="buttons-css"
+      href="http://localhost/wp-includes/css/buttons.css?ver=5.9.2"
+      media="all"
+    />
+
+    <link
+      rel="stylesheet"
+      id="common-css"
+      href="http://localhost/wp-admin/css/common.css?ver=5.9.2"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      id="forms-css"
+      href="http://localhost/wp-admin/css/forms.css?ver=5.9.2"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      id="list-tables-css"
+      href="http://localhost/wp-admin/css/list-tables.css?ver=5.9.2"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      id="list-manager-css"
+      href="http://localhost/wp-content/plugins/cds-base/classes/Modules/ListManager/app/build/static/css/main.7ec911f9.css?ver=1.0.0"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      id="cds-base-style-admin-css"
+      href="http://localhost/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css?ver=2.21.0"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      id="cds-base-style-admin-wet-css"
+      href="http://localhost/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css?ver=2.21.0"
+      media="all"
+    />
     <title>List Manager</title>
   </head>
-  <body>
+  <body
+    class="
+      wp-admin wp-core-ui
+      js
+      bulk-send_page_lists
+      auto-fold
+      admin-bar admin-color-fresh
+      locale-en-ca
+      multisite
+      customize-support
+      svg
+    "
+  >
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="list-manager-app" data-ids='[{"name":"List One","service_id":"a7902fc7-37f0-419c-84c8-3ab499ee24c8"},{"name":"Service 222","service_id":"9e7cf7e0-d40d-4e43-a3c7-ea84344f4291"}]'></div>
+    <div id="wpwrap">
+      <div id="wpcontent">
+        <div id="wpbody">
+          <div id="wpbody-content">
+            <div class="wrap">
+              <h1>List Manager</h1>
+              <div
+                id="list-manager-app"
+                data-ids='[{"name":"List One","service_id":"a7902fc7-37f0-419c-84c8-3ab499ee24c8"},{"name":"Service 222","service_id":"9e7cf7e0-d40d-4e43-a3c7-ea84344f4291"}]'
+              ></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/public/index.html
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/public/index.html
@@ -8,44 +8,44 @@
     <link
       rel="stylesheet"
       id="buttons-css"
-      href="http://localhost/wp-includes/css/buttons.css?ver=5.9.2"
+      href="https://articles.alpha.canada.ca/wp-includes/css/buttons.css?ver=5.9.2"
       media="all"
     />
 
     <link
       rel="stylesheet"
       id="common-css"
-      href="http://localhost/wp-admin/css/common.css?ver=5.9.2"
+      href="https://articles.alpha.canada.ca/wp-admin/css/common.css?ver=5.9.2"
       media="all"
     />
     <link
       rel="stylesheet"
       id="forms-css"
-      href="http://localhost/wp-admin/css/forms.css?ver=5.9.2"
+      href="https://articles.alpha.canada.ca/wp-admin/css/forms.css?ver=5.9.2"
       media="all"
     />
     <link
       rel="stylesheet"
       id="list-tables-css"
-      href="http://localhost/wp-admin/css/list-tables.css?ver=5.9.2"
+      href="https://articles.alpha.canada.ca/wp-admin/css/list-tables.css?ver=5.9.2"
       media="all"
     />
     <link
       rel="stylesheet"
       id="list-manager-css"
-      href="http://localhost/wp-content/plugins/cds-base/classes/Modules/ListManager/app/build/static/css/main.7ec911f9.css?ver=1.0.0"
+      href="https://articles.alpha.canada.ca/wp-content/plugins/cds-base/classes/Modules/ListManager/app/build/static/css/main.7ec911f9.css?ver=1.0.0"
       media="all"
     />
     <link
       rel="stylesheet"
       id="cds-base-style-admin-css"
-      href="http://localhost/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css?ver=2.21.0"
+      href="https://articles.alpha.canada.ca/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css?ver=2.21.0"
       media="all"
     />
     <link
       rel="stylesheet"
       id="cds-base-style-admin-wet-css"
-      href="http://localhost/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css?ver=2.21.0"
+      href="https://articles.alpha.canada.ca/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css?ver=2.21.0"
       media="all"
     />
     <title>List Manager</title>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/public/list.json
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/public/list.json
@@ -1,0 +1,45 @@
+[
+    {
+        "name": "List 1",
+        "language": "en",
+        "service_id": "c7902fc7-37f0-419c-84c8-3ab499ee24c8",
+        "subscribe_email_template_id": "4c19c576-3cb0-452f-a573-fb6b126b680f",
+        "unsubscribe_email_template_id": "827aca5f-bd87-4d4e-b516-5695dc360f09",
+        "subscribe_redirect_url": "https:\/\/articles.alpha.canada.ca\/thanks-for-subscribing-merci-pour-votre-labonnement",
+        "confirm_redirect_url": "https:\/\/articles.alpha.canada.ca\/confirmation",
+        "unsubscribe_redirect_url": "https:\/\/articles.alpha.canada.ca\/unsubscribed-from-mailing-list-labonnement-supprime",
+        "id": "10883abf-9bcf-4466-a641-ca433043ef48",
+        "subscriber_count": 0
+    },
+    {
+        "name": "List 2",
+        "language": "en",
+        "service_id": "c7902fc7-37f0-419c-84c8-3ab499ee24c8",
+        "id": "6c0dbe26-d842-49e8-9139-5f28b5c2aefa",
+        "subscriber_count": 0
+    },
+    {
+        "name": "List 3",
+        "language": "en",
+        "service_id": "c9902fc7-37f0-419c-84c8-5ab499ee24c8",
+        "subscribe_email_template_id": "4c19c576-3cb0-452f-a573-fb6b126b680f",
+        "unsubscribe_email_template_id": "827aca5f-bd87-4d4e-b516-5695dc360f09",
+        "subscribe_redirect_url": "https:\/\/articles.alpha.canada.ca\/thanks-for-subscribing-merci-pour-votre-labonnement",
+        "confirm_redirect_url": "https:\/\/articles.alpha.canada.ca\/confirmation",
+        "unsubscribe_redirect_url": "https:\/\/articles.alpha.canada.ca\/unsubscribed-from-mailing-list-labonnement-supprime",
+        "id": "d6313e29-721d-4263-b0bb-58bed90571f4",
+        "subscriber_count": 0
+    },
+    {
+        "name": "List 4",
+        "language": "en",
+        "service_id": "c9902fc7-37f0-419c-84c8-5ab499ee24c8",
+        "subscribe_email_template_id": "4c19c576-3cb0-452f-a573-fb6b126b680f",
+        "unsubscribe_email_template_id": "827aca5f-bd87-4d4e-b516-5695dc360f09",
+        "subscribe_redirect_url": "https:\/\/articles.alpha.canada.ca\/thanks-for-subscribing-merci-pour-votre-labonnement",
+        "confirm_redirect_url": "https:\/\/articles.alpha.canada.ca\/confirmation",
+        "unsubscribe_redirect_url": "https:\/\/articles.alpha.canada.ca\/unsubscribed-from-mailing-list-labonnement-supprime",
+        "id": "x2ca100c-5e31-4b7a-a928-f4c933f7299c",
+        "subscriber_count": 4
+    }
+]

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/App.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/App.tsx
@@ -14,7 +14,11 @@ const UpdateList = React.lazy(() => import("./components/UpdateList"));
 const CreateList = React.lazy(() => import("./components/CreateList"));
 const UploadList = React.lazy(() => import("./components/UploadList"));
 
-const endpoint = "/wp-json/list-manager";
+let endpoint = "/wp-json/list-manager";
+
+if(process.env.NODE_ENV === "development"){
+  endpoint = "http://localhost:3000";
+}
 
 const App = ({ serviceData }: { serviceData: ServiceData }) => {
   const options = {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/DeleteActionLink.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/DeleteActionLink.tsx
@@ -5,16 +5,24 @@ import { useList } from "../store/ListContext";
 import { ConfirmActionLink } from "./ConfirmActionLink"
 
 
-export const DeleteActionLink = ({id = ''}:{id: string}) => {
+export const DeleteActionLink = ({ id = '' }: { id: string }) => {
     const { request, response } = useFetch({ data: [] })
     const { dispatch } = useList();
 
     const deleteList = async ({ id = '' }: { id: string }) => {
-        await request.delete(`/list/${id}`)
 
-        if (response.ok) {
+        if (process.env.NODE_ENV !== "development") {
+            await request.delete(`/list/${id}`);
+
+            if (response.ok) {
+                dispatch({ type: "delete", payload: { id } });
+            }
+        } else {
+            // for local dev --- dispatch the delete
             dispatch({ type: "delete", payload: { id } });
         }
+
+
     }
 
     return <ConfirmActionLink text={"Delete"} isConfirmedHandler={() => deleteList({ id })} />

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListForm.tsx
@@ -34,93 +34,95 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
         <form onSubmit={handleSubmit(handler)}>
             <input id="service_id" type="hidden" {...register("service_id", { required: true })} />
             <table id="form-table" className="form-table">
-                <tr>
-                    <th><label className="required" htmlFor="name"><Asterisk />{__("Name", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.name ? "error-wrapper" : ""}>
-                            {errors.name && <span className="validation-error">{errors.name?.message || __("Name is required", "cds-snc")}</span>}
-                            <input id="name" style={textWidth} type="text" {...register("name", { required: true })} />
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label className="required" htmlFor="language"><Asterisk />{__("Language", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.language ? "error-wrapper" : ""}>
-                            {errors.language && <span className="validation-error">{errors.language?.message || __("Language is required", "cds-snc")}</span>}
-                            <fieldset>
-                                <label htmlFor="en">
-                                    <input id="en" {...register("language", { required: true })} type="radio" value="en" />
-                                    {" "}English
-                                </label>
-                                <br />
-                                <label htmlFor="fr">
-                                    <input id="fr" {...register("language", { required: true })} type="radio" value="fr" />
-                                    {" "}French
-                                </label>
-                            </fieldset>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label htmlFor="subscribe_email_template_id">{__("Subscribe template id", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.subscribe_email_template_id ? "error-wrapper" : ""}>
-                            {errors.subscribe_email_template_id && <span className="validation-error">{errors.subscribe_email_template_id?.message}</span>}
-                            <input id="subscribe_email_template_id" style={textWidth} type="text" {...register("subscribe_email_template_id")} />
-                            <div className="role-desc description">
-                                <details>
-                                    <summary>{__("See example template ID format.", "cds-snc")}</summary><code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
-                                </details>
+                <tbody>
+                    <tr>
+                        <td><label className="required" htmlFor="name"><Asterisk />{__("Name", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.name ? "error-wrapper" : ""}>
+                                {errors.name && <span className="validation-error">{errors.name?.message || __("Name is required", "cds-snc")}</span>}
+                                <input id="name" style={textWidth} type="text" {...register("name", { required: true })} />
                             </div>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label htmlFor="unsubscribe_email_template_id">{__("Unsubscribe template id", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.unsubscribe_email_template_id ? "error-wrapper" : ""}>
-                            {errors.unsubscribe_email_template_id && <span className="validation-error">{errors.unsubscribe_email_template_id?.message}</span>}
-                            <input id="unsubscribe_email_template_id" style={textWidth} type="text" {...register("unsubscribe_email_template_id")} />
-                            <div className="role-desc description">
-                                <details>
-                                    <summary>{__("See example template ID format.", "cds-snc")}</summary><code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
-                                </details>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label className="required" htmlFor="language"><Asterisk />{__("Language", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.language ? "error-wrapper" : ""}>
+                                {errors.language && <span className="validation-error">{errors.language?.message || __("Language is required", "cds-snc")}</span>}
+                                <fieldset>
+                                    <label htmlFor="en">
+                                        <input id="en" {...register("language", { required: true })} type="radio" value="en" />
+                                        {" "}English
+                                    </label>
+                                    <br />
+                                    <label htmlFor="fr">
+                                        <input id="fr" {...register("language", { required: true })} type="radio" value="fr" />
+                                        {" "}French
+                                    </label>
+                                </fieldset>
                             </div>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label className="gc-label" htmlFor="subscribe_redirect_url">{__("Subscribe redirect url", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.subscribe_redirect_url ? "error-wrapper" : ""}>
-                            {errors.subscribe_redirect_url && <span className="validation-error">{errors.subscribe_redirect_url?.message}</span>}
-                            <input id="subscribe_redirect_url" style={textWidth} type="text" {...register("subscribe_redirect_url")} />
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe redirect url", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
-                            {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
-                            <input id="unsubscribe_redirect_url" style={textWidth} type="text" {...register("unsubscribe_redirect_url")} />
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label htmlFor="confirm_redirect_url">{__("Confirm redirect url", "cds-snc")}</label></th>
-                    <td>
-                        <div className={errors.confirm_redirect_url ? "error-wrapper" : ""}>
-                            {errors.confirm_redirect_url && <span className="validation-error">{errors.confirm_redirect_url?.message}</span>}
-                            <input id="confirm_redirect_url" style={textWidth} type="text" {...register("confirm_redirect_url")} />
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <th></th>
-                    <td><input className="button button-primary" type="submit" /><Back /></td>
-                </tr>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label htmlFor="subscribe_email_template_id">{__("Subscribe template id", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.subscribe_email_template_id ? "error-wrapper" : ""}>
+                                {errors.subscribe_email_template_id && <span className="validation-error">{errors.subscribe_email_template_id?.message}</span>}
+                                <input id="subscribe_email_template_id" style={textWidth} type="text" {...register("subscribe_email_template_id")} />
+                                <div className="role-desc description">
+                                    <details>
+                                        <summary>{__("See example template ID format.", "cds-snc")}</summary><code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
+                                    </details>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label htmlFor="unsubscribe_email_template_id">{__("Unsubscribe template id", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.unsubscribe_email_template_id ? "error-wrapper" : ""}>
+                                {errors.unsubscribe_email_template_id && <span className="validation-error">{errors.unsubscribe_email_template_id?.message}</span>}
+                                <input id="unsubscribe_email_template_id" style={textWidth} type="text" {...register("unsubscribe_email_template_id")} />
+                                <div className="role-desc description">
+                                    <details>
+                                        <summary>{__("See example template ID format.", "cds-snc")}</summary><code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
+                                    </details>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label className="gc-label" htmlFor="subscribe_redirect_url">{__("Subscribe redirect url", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.subscribe_redirect_url ? "error-wrapper" : ""}>
+                                {errors.subscribe_redirect_url && <span className="validation-error">{errors.subscribe_redirect_url?.message}</span>}
+                                <input id="subscribe_redirect_url" style={textWidth} type="text" {...register("subscribe_redirect_url")} />
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe redirect url", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
+                                {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
+                                <input id="unsubscribe_redirect_url" style={textWidth} type="text" {...register("unsubscribe_redirect_url")} />
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label htmlFor="confirm_redirect_url">{__("Confirm redirect url", "cds-snc")}</label></td>
+                        <td>
+                            <div className={errors.confirm_redirect_url ? "error-wrapper" : ""}>
+                                {errors.confirm_redirect_url && <span className="validation-error">{errors.confirm_redirect_url?.message}</span>}
+                                <input id="confirm_redirect_url" style={textWidth} type="text" {...register("confirm_redirect_url")} />
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td><input className="button button-primary" type="submit" /><Back /></td>
+                    </tr>
+                </tbody>
             </table>
         </form>
     );

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListForm.tsx
@@ -36,7 +36,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
             <table id="form-table" className="form-table">
                 <tbody>
                     <tr>
-                        <td><label className="required" htmlFor="name"><Asterisk />{__("Name", "cds-snc")}</label></td>
+                        <th scope="row"><label className="required" htmlFor="name"><Asterisk />{__("Name", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.name ? "error-wrapper" : ""}>
                                 {errors.name && <span className="validation-error">{errors.name?.message || __("Name is required", "cds-snc")}</span>}
@@ -45,7 +45,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                         </td>
                     </tr>
                     <tr>
-                        <td><label className="required" htmlFor="language"><Asterisk />{__("Language", "cds-snc")}</label></td>
+                        <th scope="row"><label className="required" htmlFor="language"><Asterisk />{__("Language", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.language ? "error-wrapper" : ""}>
                                 {errors.language && <span className="validation-error">{errors.language?.message || __("Language is required", "cds-snc")}</span>}
@@ -64,7 +64,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                         </td>
                     </tr>
                     <tr>
-                        <td><label htmlFor="subscribe_email_template_id">{__("Subscribe template id", "cds-snc")}</label></td>
+                        <th scope="row"><label htmlFor="subscribe_email_template_id">{__("Subscribe template id", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.subscribe_email_template_id ? "error-wrapper" : ""}>
                                 {errors.subscribe_email_template_id && <span className="validation-error">{errors.subscribe_email_template_id?.message}</span>}
@@ -78,7 +78,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                         </td>
                     </tr>
                     <tr>
-                        <td><label htmlFor="unsubscribe_email_template_id">{__("Unsubscribe template id", "cds-snc")}</label></td>
+                        <th scope="row"><label htmlFor="unsubscribe_email_template_id">{__("Unsubscribe template id", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.unsubscribe_email_template_id ? "error-wrapper" : ""}>
                                 {errors.unsubscribe_email_template_id && <span className="validation-error">{errors.unsubscribe_email_template_id?.message}</span>}
@@ -92,7 +92,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                         </td>
                     </tr>
                     <tr>
-                        <td><label className="gc-label" htmlFor="subscribe_redirect_url">{__("Subscribe redirect url", "cds-snc")}</label></td>
+                        <th scope="row"><label className="gc-label" htmlFor="subscribe_redirect_url">{__("Subscribe redirect url", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.subscribe_redirect_url ? "error-wrapper" : ""}>
                                 {errors.subscribe_redirect_url && <span className="validation-error">{errors.subscribe_redirect_url?.message}</span>}
@@ -101,7 +101,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                         </td>
                     </tr>
                     <tr>
-                        <td><label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe redirect url", "cds-snc")}</label></td>
+                        <th scope="row"><label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe redirect url", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
                                 {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
@@ -110,7 +110,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                         </td>
                     </tr>
                     <tr>
-                        <td><label htmlFor="confirm_redirect_url">{__("Confirm redirect url", "cds-snc")}</label></td>
+                        <th scope="row"><label htmlFor="confirm_redirect_url">{__("Confirm redirect url", "cds-snc")}</label></th>
                         <td>
                             <div className={errors.confirm_redirect_url ? "error-wrapper" : ""}>
                                 {errors.confirm_redirect_url && <span className="validation-error">{errors.confirm_redirect_url?.message}</span>}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ResetActionLink.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ResetActionLink.tsx
@@ -3,17 +3,23 @@ import useFetch from "use-http";
 import { useList } from "../store/ListContext";
 import { ConfirmActionLink } from "./ConfirmActionLink"
 
-export const ResetActionLink = ({id = ''}:{id: string}) => {
+export const ResetActionLink = ({ id = '' }: { id: string }) => {
     const { request, response } = useFetch({ data: [] })
     const { dispatch } = useList();
-    
-    const resetList = async ({id = ''}:{id: string}) => {
-        await request.put(`/list/${id}/reset`)
-    
-        if (response.ok) {
+
+    const resetList = async ({ id = '' }: { id: string }) => {
+
+        if (process.env.NODE_ENV !== "development") {
+            await request.put(`/list/${id}/reset`)
+
+            if (response.ok) {
+                dispatch({ type: "reset", payload: { id } });
+            }
+        } else {
+            // for local dev --- dispatch the reset
             dispatch({ type: "reset", payload: { id } });
-        } 
+        }
     }
 
-    return <ConfirmActionLink text={"Reset"} isConfirmedHandler={ () => resetList({id}) } />
+    return <ConfirmActionLink text={"Reset"} isConfirmedHandler={() => resetList({ id })} />
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/UseListFetch.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/UseListFetch.tsx
@@ -15,7 +15,12 @@ export const useListFetch = () => {
     useEffect(() => {
         const fetchData = async () => {
             setStatus("loading")
-            await request.get(`/lists/${serviceId}`);
+
+            if (process.env.NODE_ENV === "development") {
+                await request.get("list.json");
+            } else {
+                await request.get(`/lists/${serviceId}`);
+            }
 
             if (response.ok) {
                 dispatch({ type: "load", payload: await response.json() })
@@ -29,8 +34,8 @@ export const useListFetch = () => {
             const lists = listData.map((list: any) => {
                 return { id: list?.id, label: list?.name, type: "email" }
             })
-            const REST_URL = window.CDS_VARS.rest_url;
-            const REST_NONCE = window.CDS_VARS.rest_nonce;
+            const REST_URL = window?.CDS_VARS?.rest_url;
+            const REST_NONCE = window?.CDS_VARS?.rest_nonce;
             await sendListData(`${REST_URL}list-manager-settings/list/save`, REST_NONCE, { "list_values": lists });
         }
 


### PR DESCRIPTION
Updating so we can do local dev for List Manager outside of WP 

This adds a simple json file vs hitting the list manager API --- also pulls in WP styles.

This isn't intended to be a 1:1 match for look or functionality just easier app updating.  

To test

From the ListManager app directory 

```
npm run start
```

View your http:localhost:3000

<img width="1316" alt="Screen Shot 2022-04-04 at 10 18 29 AM" src="https://user-images.githubusercontent.com/62242/161565055-cc1337c9-6dd3-4619-a71f-10c9cc94256f.png">


<hr>

Once this is merged we can look to upgrade to React 18