### PR TITLE
Move CDS_VARS block to header/meta tags

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Setup.php
@@ -25,10 +25,5 @@ class Setup
     public function enqueue()
     {
         wp_enqueue_script('cds-blocks-js', plugin_dir_url(__FILE__) . 'js/handler.js', ['jquery'], "1.0.0", true);
-
-        wp_localize_script("cds-blocks-js", "CDS_VARS", array(
-            "rest_url" => esc_url_raw(rest_url()),
-            "rest_nonce" => wp_create_nonce("wp_rest"),
-        ));
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/js/handler.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/js/handler.js
@@ -1,10 +1,22 @@
 (function ($) {
+    function initVars() {
+        try{
+            const rest_url = document.querySelector('meta[name="rest_url"]').content;
+            const rest_nonce = document.querySelector('meta[name="rest_nonce"]').content;
+            window.CDS_VARS = {rest_nonce: rest_nonce, rest_url: rest_url};
+        }catch(e){
+            console.log("meta not set");
+        }
+    }
+
+    initVars();
+
     function toggleOptional($el) {
         $controlsElement = $('#' + $el.attr('aria-controls'));
 
         // only change attributes if "aria-controls" element exists
-        if($controlsElement) {
-            if($el.is(':checked')) {
+        if ($controlsElement) {
+            if ($el.is(':checked')) {
                 //show element
                 $el.attr('aria-expanded', true);
                 $controlsElement.removeClass('displayNone');
@@ -19,7 +31,7 @@
     $('input[aria-controls]').on("click", function (e) {
         // add click handler
         toggleOptional($(e.target));
-    }).each(function() {
+    }).each(function () {
         // run it once on page load
         toggleOptional($(this));
     });
@@ -44,7 +56,7 @@
             data: $form.serialize(), // serializes the form's elements.
             success: function (data) {
                 // handle redirect if provided
-                if(data.redirect) {
+                if (data.redirect) {
                     window.location.href = data.redirect
                     return;
                 }
@@ -56,10 +68,10 @@
                     var errorEl = '<div id="cds-form-error" class="gc-alert gc-alert--error gc-alert--validation" data-testid="alert" tabindex="0" role="alert">';
                     errorEl += '<div class="gc-alert__body">';
                     errorEl += '<h2 class="gc-h3">' + data.error_message + '</h2>';
-                    if(data['keys']) {
+                    if (data['keys']) {
                         errorEl += '<ol class="gc-ordered-list">';
                         data['keys'].forEach(key => {
-                            errorEl += '<li><a href="#' + key + '" class="gc-error-link">' + key +'</li>'
+                            errorEl += '<li><a href="#' + key + '" class="gc-error-link">' + key + '</li>'
 
                             var $validationMsg = '<p data-testid="errorMessage" class="gc-error-message" role="alert">' + data.error_message + '</p>'
                             $($validationMsg).insertBefore('#' + key);

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -29,6 +29,9 @@ declare(strict_types=1);
   <?php wp_head(); ?>
   <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/wet-boew.min.css" />
   <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css" />
+
+  <meta name="rest_url" content="<?php echo esc_url_raw(rest_url()) ?>">
+  <meta name="rest_nonce" content="<?php echo wp_create_nonce("wp_rest") ?>">
 </head>
 
 <body <?php body_class(); ?> vocab="http://schema.org/" resource="#wb-webpage" typeof="WebPage">


### PR DESCRIPTION
# Summary | Résumé

To help our efforts to tighten up our CSP header on the frontend of the site, move the CDS_VARS properties to meta tags in the header, and then access them from there.

This will allow us to disable `unsafe-inline` scripts on the user-facing end of the site.
