### PR TITLE
Bugfix: Add Production ECR Registry url

### DIFF
--- a/.github/workflows/build_push_apache_container.yml
+++ b/.github/workflows/build_push_apache_container.yml
@@ -12,6 +12,7 @@ env:
   DOCKER_BUILDKIT: 1
   REPO_NAME: platform/apache
   STAGING_ECR_REGISTRY: 729164266357.dkr.ecr.ca-central-1.amazonaws.com
+  PRODUCTION_ECR_REGISTRY: 472286471787.dkr.ecr.ca-central-1.amazonaws.com
 
 jobs:
   build-push-staging-container:


### PR DESCRIPTION
# Summary | Résumé

Follow-up to #659 - forgot to add the production ecr url.
