### PR TITLE
Add site url to welcome email

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
@@ -196,8 +196,7 @@ class Users
             $password_message = $uniqueUrl;
         }
 
-        if($userExists) 
-        {
+        if ($userExists) {
             $site_url = get_site_url(get_current_blog_id());
         }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
@@ -208,7 +208,7 @@ class Users
                 $email,
                 "a11693cb-2b84-4920-9e66-e9eb649fc948",
                 [
-                    "password_message" => $password_message
+                    "password_message" => $password_message,
                     "site_url" => $site_url
                 ],
             );

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
@@ -191,9 +191,7 @@ class Users
                 sprintf("wp-login.php?action=rp&key=%s&login=%s", $unique, rawurlencode($userInfo->user_login)),
                 'login'
             );
-        }
 
-        if (!$userExists) {
             // we don't need to send this for existing users
             $password_message = $uniqueUrl;
         }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
@@ -196,7 +196,8 @@ class Users
             $password_message = $uniqueUrl;
         }
 
-        if($userExists){
+        if($userExists) 
+        {
             $site_url = get_site_url(get_current_blog_id());
         }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/Users.php
@@ -181,6 +181,7 @@ class Users
     {
 
         $password_message = "";
+        $site_url = "";
 
         if (!$userExists) {
             $userInfo = get_userdata($uId);
@@ -197,6 +198,10 @@ class Users
             $password_message = $uniqueUrl;
         }
 
+        if($userExists){
+            $site_url = get_site_url(get_current_blog_id());
+        }
+
         try {
             $notifyClient = new NotifyClient();
             $notifyClient->sendMail(
@@ -204,6 +209,7 @@ class Users
                 "a11693cb-2b84-4920-9e66-e9eb649fc948",
                 [
                     "password_message" => $password_message
+                    "site_url" => $site_url
                 ],
             );
         } catch (\Alphagov\Notifications\Exception\NotifyException $e) {


### PR DESCRIPTION
Adds ((site_url)) variable for existing users 

When sending the Welcome email we don't want to use the password reset link for existing users.  This adds a site_url variable for that use case.

Fixes 

https://github.com/cds-snc/gc-articles-issues/issues/298