### PR TITLE
Add testing headers, and try adding a new behaviour

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -61,7 +61,7 @@ resource "aws_cloudfront_distribution" "wordpress" {
     max_ttl                = 31536000
     compress               = true
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_admin.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_frontend.id
   }
 
   ordered_cache_behavior {
@@ -84,6 +84,29 @@ resource "aws_cloudfront_distribution" "wordpress" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }
+
+  ordered_cache_behavior {
+      path_pattern     = "*/wp-admin/*"
+      allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
+      cached_methods   = ["GET", "HEAD", "OPTIONS"]
+      target_origin_id = aws_lb.wordpress.name
+
+      forwarded_values {
+        query_string = true
+        headers      = ["Host", "Origin", "User-Agent"]
+        cookies {
+          forward = "all"
+        }
+      }
+
+      min_ttl                = 0
+      default_ttl            = 0
+      max_ttl                = 0
+      compress               = true
+      viewer_protocol_policy = "redirect-to-https"
+
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_admin.id
+    }
 
   ordered_cache_behavior {
     path_pattern     = "wp-admin/*"

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -86,27 +86,27 @@ resource "aws_cloudfront_distribution" "wordpress" {
   }
 
   ordered_cache_behavior {
-      path_pattern     = "*/wp-admin/*"
-      allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
-      cached_methods   = ["GET", "HEAD", "OPTIONS"]
-      target_origin_id = aws_lb.wordpress.name
+    path_pattern     = "*/wp-admin/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "DELETE", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = aws_lb.wordpress.name
 
-      forwarded_values {
-        query_string = true
-        headers      = ["Host", "Origin", "User-Agent"]
-        cookies {
-          forward = "all"
-        }
+    forwarded_values {
+      query_string = true
+      headers      = ["Host", "Origin", "User-Agent"]
+      cookies {
+        forward = "all"
       }
-
-      min_ttl                = 0
-      default_ttl            = 0
-      max_ttl                = 0
-      compress               = true
-      viewer_protocol_policy = "redirect-to-https"
-
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_admin.id
     }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_admin.id
+  }
 
   ordered_cache_behavior {
     path_pattern     = "wp-admin/*"

--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -19,10 +19,18 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy_front
       preload                    = true
       override                   = true
     }
-    content_security_policy {
-      content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca https://secure.gravatar.com; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'sha256-DdN0UNltr41cvBTgBr0owkshPbwM95WknOV9rvTA7pg=' 'sha256-MF5ZCDqcQxsjnFVq0T7A8bpEWUJiuO9Qx1MqSYvCwds=' 'sha256-8//zSBdstORCAlBMo1/Cig3gKc7QlPCh9QfWbRu0OjU=' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js https://www.canada.ca/etc/designs/canada/wet-boew/js/i18n/en.min.js; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://www.canada.ca; worker-src 'none';"
-      override                = true
+
+    custom_headers_config {
+      items {
+        header   = "X-Is-WP-Admin"
+        override = true
+        value    = "false"
+      }
     }
+    # content_security_policy {
+    #   content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca https://secure.gravatar.com; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'sha256-DdN0UNltr41cvBTgBr0owkshPbwM95WknOV9rvTA7pg=' 'sha256-MF5ZCDqcQxsjnFVq0T7A8bpEWUJiuO9Qx1MqSYvCwds=' 'sha256-8//zSBdstORCAlBMo1/Cig3gKc7QlPCh9QfWbRu0OjU=' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js https://www.canada.ca/etc/designs/canada/wet-boew/js/i18n/en.min.js; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://www.canada.ca; worker-src 'none';"
+    #   override                = true
+    # }
   }
 }
 
@@ -46,6 +54,13 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy_admin
       include_subdomains         = true
       preload                    = true
       override                   = true
+    }
+    custom_headers_config {
+      items {
+        header   = "X-Is-WP-Admin"
+        override = true
+        value    = "true"
+      }
     }
     # content_security_policy {
     #   content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://www.canada.ca https://fonts.googleapis.com; worker-src 'none';"

--- a/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/security-headers.tf
@@ -20,17 +20,17 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy_front
       override                   = true
     }
 
-    custom_headers_config {
-      items {
-        header   = "X-Is-WP-Admin"
-        override = true
-        value    = "false"
-      }
-    }
     # content_security_policy {
     #   content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca https://secure.gravatar.com; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'sha256-DdN0UNltr41cvBTgBr0owkshPbwM95WknOV9rvTA7pg=' 'sha256-MF5ZCDqcQxsjnFVq0T7A8bpEWUJiuO9Qx1MqSYvCwds=' 'sha256-8//zSBdstORCAlBMo1/Cig3gKc7QlPCh9QfWbRu0OjU=' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js https://www.canada.ca/etc/designs/canada/wet-boew/js/i18n/en.min.js; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://www.canada.ca; worker-src 'none';"
     #   override                = true
     # }
+  }
+  custom_headers_config {
+    items {
+      header   = "X-Is-WP-Admin"
+      override = true
+      value    = "false"
+    }
   }
 }
 
@@ -55,16 +55,16 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy_admin
       preload                    = true
       override                   = true
     }
-    custom_headers_config {
-      items {
-        header   = "X-Is-WP-Admin"
-        override = true
-        value    = "true"
-      }
-    }
     # content_security_policy {
     #   content_security_policy = "base-uri 'self'; connect-src 'self'; default-src 'self'; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://www.canada.ca; frame-src 'self'; img-src 'self' https://canada.ca https://wet-boew.github.io https://www.canada.ca; manifest-src 'self'; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://www.canada.ca https://fonts.googleapis.com; worker-src 'none';"
     #   override                = true
     # }
+  }
+  custom_headers_config {
+    items {
+      header   = "X-Is-WP-Admin"
+      override = true
+      value    = "true"
+    }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Adds a new ordered cache behaviour to hopefully catch admin paths for subsites, ie: `/[subsite]/wp-admin/*` 

Also adds a custom header to help with testing, since now that CSP is disabled, both header policies were the same.