### PR TITLE
Remove the Yoast SettingsPanel and close the Yoast Metabox by default

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -72,7 +72,7 @@ class Setup
             remove_submenu_page('ppch-checklists', 'ppch-checklists-menu-upgrade-link');
     }
 
-    function enqueueGutenbergScripts()
+    public function enqueueGutenbergScripts()
     {
         wp_enqueue_script(
             'cds-base-checklists-gutenberg-js',

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -36,6 +36,7 @@ class Setup
             // only add hooks when Checklists plugin is installed
             add_action('admin_enqueue_scripts', [$this, 'enqueue']);
             add_action('admin_init', [$this, 'removeUpgradeToProLink']);
+            add_action('enqueue_block_editor_assets', [$this, 'enqueueGutenbergScripts']);
         }
     }
 
@@ -69,6 +70,16 @@ class Setup
     public function removeUpgradeToProLink()
     {
             remove_submenu_page('ppch-checklists', 'ppch-checklists-menu-upgrade-link');
+    }
+
+    function enqueueGutenbergScripts()
+    {
+        wp_enqueue_script(
+            'cds-base-checklists-gutenberg-js',
+            plugin_dir_url(__FILE__) . '/js/index.js',
+            array('wp-blocks', 'wp-element'),
+            '1.0.0'
+        );
     }
 
     public function enqueue()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/index.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/index.js
@@ -1,0 +1,5 @@
+const { dispatch } = wp.data;
+
+/* Remove the Yoast gutenberg panel */
+dispatch('core/edit-post').removeEditorPanel('yoast-seo/document-panel'); // Remove the Yoast Panel
+

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/index.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/index.js
@@ -1,5 +1,40 @@
-const { dispatch } = wp.data;
+const { select, dispatch } = wp.data;
 
 /* Remove the Yoast gutenberg panel */
 dispatch('core/edit-post').removeEditorPanel('yoast-seo/document-panel'); // Remove the Yoast Panel
 
+/* Set the Yoast Metabox to "closed" */
+const isYoastPanelOpen = select("core/edit-post").isEditorPanelOpened('meta-box-wpseo_meta');
+if (isYoastPanelOpen) {
+  // sets the "opened" attribute to false, but doesn't actually close the SEO panel
+  dispatch('core/edit-post').toggleEditorPanelOpened('meta-box-wpseo_meta');
+}
+
+/* Actually hide the Yoast metabox */
+
+// Wait for element to appear and then click it: https://stackoverflow.com/a/29754070
+const buttonSelector = "#wpseo_meta button.handlediv[aria-expanded='true']";
+waitForElementToDisplay(buttonSelector,
+  function() {
+    document.querySelector(buttonSelector).click();
+  },
+  1000, // check once per second
+  4001  // stop after 4 seconds
+);
+
+function waitForElementToDisplay(selector, callback, checkFrequencyInMs, timeoutInMs) {
+  var startTimeInMs = Date.now();
+  (function loopSearch() {
+    if (document.querySelector(selector) != null) {
+      callback();
+      return;
+    }
+    else {
+      setTimeout(function () {
+        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs)
+          return;
+        loopSearch();
+      }, checkFrequencyInMs);
+    }
+  })();
+}


### PR DESCRIPTION
# Summary | Résumé

This PR deemphasizes the Yoast options when writing articles. 
1. Removes the Yoast settings panel in the Gutenberg sidebar
2. Closes the Yoast SEO stuff by default

Yoast actually takes up a huge amount of screen real estate for new posts: it gets so that it's overwhelming. This PR moderates the Yoast stuff a bit.

## Screenshots

| before | after |
|--------|-------|
|  <img width="1458" alt="Screen Shot 2022-04-11 at 14 03 05" src="https://user-images.githubusercontent.com/2454380/162746234-b89983d3-78eb-4b89-968c-900596fdfcb4.png">    |   <img width="1458" alt="Screen Shot 2022-04-11 at 14 02 42" src="https://user-images.githubusercontent.com/2454380/162746208-c5f08b1a-6760-4a31-9abd-21c0a97831ed.png">  |

