### PR TITLE
Add simple-history plugin and log SiteSettings changes

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -98,7 +98,8 @@
     "yoast/duplicate-post": "^4.4",
     "shawnhooper/delete-orphaned-multisite-tables": "1.0",
     "league/html-to-markdown": "^5.1",
-    "wpackagist-plugin/publishpress-checklists": "^2.7"
+    "wpackagist-plugin/publishpress-checklists": "^2.7",
+    "wpackagist-plugin/simple-history": "^3.2"
   },
   "require-dev": {
     "pestphp/pest": "^1.16",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa841d24ac5a60293880dde3ad69c661",
+    "content-hash": "4120214c784e7c71135e1530b4e604df",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -328,7 +328,7 @@
             "dist": {
                 "type": "path",
                 "url": "wp-content/themes/cds-default",
-                "reference": "fe05215494044ac9aaadcaf0f3bee3e606339821"
+                "reference": "ff6db1b6b764e0deb42aca033e899fede69ee7d8"
             },
             "require": {
                 "paquettg/php-html-parser": "^3.0.1",
@@ -3939,6 +3939,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/publishpress-checklists/"
+        },
+        {
+            "name": "wpackagist-plugin/simple-history",
+            "version": "3.2.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/simple-history/",
+                "reference": "tags/3.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/simple-history.3.2.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/simple-history/"
         },
         {
             "name": "wpackagist-plugin/two-factor",

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -16,10 +16,34 @@ class SiteSettings
 
         add_action('admin_menu', [$instance, 'collectionSettingsAddPluginPage'], 99);
         add_action('admin_init', [$instance, 'collectionSettingsPageInit']);
+        add_action('update_option', [$instance, 'logChangedOption'], 10, 4);
 
         add_filter('collection_settings_option_group', function ($capability) {
             return user_can('manage_options');
         });
+    }
+
+    public function logChangedOption($option, $old_value, $value)
+    {
+        $filterOptions = [
+            'collection_mode',
+            'collection_mode_maintenance_page' .
+            'show_on_front',
+            'page_on_front',
+            'collection_mode',
+            'blogname',
+            'blogdescription',
+            'show_wet_menu',
+            'show_search',
+            'show_breadcrumbs',
+            'fip_href',
+        ];
+
+        if (function_exists("SimpleLogger")) {
+            if (in_array($option, $filterOptions)) {
+                SimpleLogger()->info("$option changed from $old_value to $value");
+            }
+        }
     }
 
     public function collectionSettingsAddPluginPage()


### PR DESCRIPTION
# Summary | Résumé

Adds the simple-history plugin to log activity within a site.

## To test
- Activate the plugin (by Network or Site)
- You will now see a "Simple History" option under Dashboard
- Make some changes in SiteSettings
- See the logs show up on the Simple History page

## Notes
The plugin by default logs a bunch of stuff across WordPress - Page/Post updates, User Profile changes, User management actions, Site settings... 

Because we have a custom Site Settings page, those settings weren't being logged by default. So added a hook on update_option, which triggers on *every* option change (including transients), and was pretty noisy ... so for now we're just filtering on the options on our custom SiteSettings page:

```
$filterOptions = [
            'collection_mode',
            'collection_mode_maintenance_page' .
            'show_on_front',
            'page_on_front',
            'collection_mode',
            'blogname',
            'blogdescription',
            'show_wet_menu',
            'show_search',
            'show_breadcrumbs',
            'fip_href',
        ];
```

Which of course we can further customize as needed.
