### PR TITLE
Add a modal popover to make the Checklists interactions more obvious

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -114,8 +114,6 @@ class Setup
         if (! isset($ppc_screen->parent_base) || ( isset($ppc_screen->parent_base) && 'edit' !== $ppc_screen->parent_base )) {
             return;
         }
-        // wp_enqueue_script( 'ppc_backend_checkbox_js' );
-        // wp_enqueue_style( 'ppc_backend_css' );
         ?>
         <div class="ppc-modal-warn">
             <div id="ppc_notifications" class="ppc-popup-warn">

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -37,6 +37,7 @@ class Setup
             add_action('admin_enqueue_scripts', [$this, 'enqueue']);
             add_action('admin_init', [$this, 'removeUpgradeToProLink']);
             add_action('enqueue_block_editor_assets', [$this, 'enqueueGutenbergScripts']);
+            add_action('admin_footer', [$this, 'ppc_markup']);
         }
     }
 
@@ -90,5 +91,44 @@ class Setup
             null,
             '1.0.0',
         );
+    }
+
+    /**
+     * Function for HTML markup of notification.
+     *
+     * Shows the pop-up of warning a user or preventing a user.
+     *
+     * @since 1.0.0
+     */
+    public function ppc_markup()
+    {
+        $ppc_screen = get_current_screen();
+        // If not edit or add new page, post or custom post type window then return.
+        if (! isset($ppc_screen->parent_base) || ( isset($ppc_screen->parent_base) && 'edit' !== $ppc_screen->parent_base )) {
+            return;
+        }
+        // wp_enqueue_script( 'ppc_backend_checkbox_js' );
+        // wp_enqueue_style( 'ppc_backend_css' );
+        ?>
+        <div class="ppc-modal-warn">
+            <div id="ppc_notifications" class="ppc-popup-warn">
+                <h2><?php esc_html_e('Pre-Publish Checklist', 'pre-publish-checklist'); ?></h2>
+                <p class="ppc-popup-description"><?php esc_html_e('Your Pre-Publish Checklist is incomplete. What would you like to do?', 'pre-publish-checklist'); ?></p>
+                <div class="ppc-button-wrapper">
+                    <div class="ppc-popup-option-dontpublish"><?php esc_html_e("Don't Publish", 'pre-publish-checklist'); ?></div>
+                    <div class="ppc-popup-options-publishanyway"><?php esc_html_e('Publish Anyway', 'pre-publish-checklist'); ?></div>
+                </div>
+            </div>
+        </div>
+        <div class="ppc-modal-prevent">
+            <div id="ppc_notifications" class="ppc-popup-prevent">
+                <h2><?php esc_html_e('Pre-Publish Checklist', 'pre-publish-checklist'); ?></h2>
+                <p class="ppc-popup-description"> <?php esc_html_e('Please check all the checklist items before publishing.', 'pre-publish-checklist'); ?></p>
+                <div class="ppc-prevent-button-wrapper">
+                    <div class="ppc-popup-option-okay"><?php esc_html_e('Okay, Take Me to the List!', 'pre-publish-checklist'); ?></div>
+                </div>
+            </div>
+        </div>
+        <?php
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -85,7 +85,7 @@ class Setup
         wp_enqueue_script(
             'cds-base-checklists-meta-box-js',
             plugin_dir_url(__FILE__) . '/js/meta-box.js',
-            array('jquery'),
+            array('jquery', 'wp-blocks', 'wp-element'),
             '1.0.0'
         );
     }
@@ -115,22 +115,22 @@ class Setup
             return;
         }
         ?>
-        <div class="ppc-modal-warn">
-            <div id="ppc_notifications" class="ppc-popup-warn">
+        <div class="ppc-modal-warn" >
+            <div id="ppc_notifications" class="ppc-popup-warn" tabindex="-1">
                 <h2><?php esc_html_e('Pre-Publish Checklist', 'pre-publish-checklist'); ?></h2>
                 <p class="ppc-popup-description"><?php esc_html_e('Your Pre-Publish Checklist is incomplete. What would you like to do?', 'pre-publish-checklist'); ?></p>
                 <div class="ppc-button-wrapper">
-                    <div class="ppc-popup-option-dontpublish"><?php esc_html_e("Don't Publish", 'pre-publish-checklist'); ?></div>
-                    <div class="ppc-popup-options-publishanyway"><?php esc_html_e('Publish Anyway', 'pre-publish-checklist'); ?></div>
+                    <button class="ppc-popup-option-dontpublish"><?php esc_html_e("Don't Publish", 'pre-publish-checklist'); ?></button>
+                    <button class="ppc-popup-options-publishanyway"><?php esc_html_e('Publish Anyway', 'pre-publish-checklist'); ?></button>
                 </div>
             </div>
         </div>
         <div class="ppc-modal-prevent">
-            <div id="ppc_notifications" class="ppc-popup-prevent">
+            <div id="ppc_notifications" class="ppc-popup-prevent" tabindex="-1">
                 <h2><?php esc_html_e('Pre-Publish Checklist', 'pre-publish-checklist'); ?></h2>
                 <p class="ppc-popup-description"> <?php esc_html_e('Please check all the checklist items before publishing.', 'pre-publish-checklist'); ?></p>
                 <div class="ppc-prevent-button-wrapper">
-                    <div class="ppc-popup-option-okay"><?php esc_html_e('Okay, Take Me to the List!', 'pre-publish-checklist'); ?></div>
+                    <button class="ppc-popup-option-okay"><?php esc_html_e('Okay, Take Me to the List!', 'pre-publish-checklist'); ?></button>
                 </div>
             </div>
         </div>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -81,6 +81,13 @@ class Setup
             array('wp-blocks', 'wp-element'),
             '1.0.0'
         );
+
+        wp_enqueue_script(
+            'cds-base-checklists-meta-box-js',
+            plugin_dir_url(__FILE__) . '/js/meta-box.js',
+            array('jquery'),
+            '1.0.0'
+        );
     }
 
     public function enqueue()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -37,7 +37,7 @@ class Setup
             add_action('admin_enqueue_scripts', [$this, 'enqueue']);
             add_action('admin_init', [$this, 'removeUpgradeToProLink']);
             add_action('enqueue_block_editor_assets', [$this, 'enqueueGutenbergScripts']);
-            add_action('admin_footer', [$this, 'ppc_markup']);
+            add_action('admin_footer', [$this, 'ppcMarkup']);
         }
     }
 
@@ -107,7 +107,7 @@ class Setup
      *
      * @since 1.0.0
      */
-    public function ppc_markup()
+    public function ppcMarkup()
     {
         $ppc_screen = get_current_screen();
         // If not edit or add new page, post or custom post type window then return.

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
@@ -66,6 +66,7 @@
 
 .ppc-popup-option-okay {
   display: block;
+  width: 100%;
   border-right: 1px solid #ccc;
   border-radius: 0px 0px 5px 5px;
 }
@@ -93,7 +94,7 @@
   display: flex;
 }
 
-div#ppc_custom_meta_box,
+#ppc_custom_meta_box,
 .ppc-metabox-background
  {
   transition:1.0s ease;
@@ -105,6 +106,6 @@ div#ppc_custom_meta_box,
   background:  #fff8e5;
 }
 
-p.ppc-popup-description {
+.ppc-popup-description {
   padding: 0px 20px 0px 20px;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
@@ -7,3 +7,154 @@
 {
   display: none;
 }
+
+/* All the CSS needed for the modal */
+#ppc-update{
+  padding: 0 12px 2px;
+  height: 33px;
+  line-height: 32px;
+  font-size: 13px;
+  margin: 0 12px 0 3px;
+}
+
+#ppc-publish{
+  padding: 0 12px 2px;
+  height: 33px;
+  line-height: 32px;
+  font-size: 13px;
+  padding: 0 12px 2px;
+  margin: 0 12px 0 3px;
+}
+
+.ppc-popup-warn  {
+  width: 400px;
+  text-align: center;
+  box-shadow: 0px 0px 15px -6px rgba(0,0,0,0.75);
+  background-color: #ffffff;
+  transition: opacity 0.8s;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50% , -70%);
+  position: absolute;
+  z-index: 99;
+  border-radius: 5px;
+  margin-top: 50;
+  margin-left: 50;
+}
+
+.ppc-popup-prevent {
+  width: 400px;
+  text-align: center;
+  box-shadow: 0px 0px 15px -6px rgba(0,0,0,0.75);
+  background-color: #ffffff;
+  transition: opacity 0.8s;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50% , -70%);
+  position: absolute;
+  z-index: 99;
+  border-radius: 5px;
+  margin-top: 50;
+  margin-left: 50;
+}
+
+.ppc-modal-warn {
+  display: none;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 9999;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  background-color: rgba(0, 0, 0, 0.4);
+  -webkit-transition: 0.5s;
+  overflow: auto;
+  transition: all 0.3s linear;
+}
+
+.ppc-modal-prevent{
+  display: none;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 9999;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  background-color: rgba(0, 0, 0, 0.4);
+  -webkit-transition: 0.5s;
+  overflow: auto;
+  transition: all 0.3s linear;
+}
+
+.ppc-popup-option-dontpublish:hover {
+  background-color: #e5e5e5;
+  color: #444;
+}
+
+.ppc-popup-options-publishanyway:hover {
+  background-color: #e5e5e5;
+  color: #444;
+}
+
+.ppc-popup-option-okay:hover {
+  background-color: #e5e5e5;
+  color: #444;
+}
+
+.ppc-popup-option-okay {
+  display: block;
+  padding: 15px 0 15px 0px;
+  cursor: pointer;
+  background: #f1f1f1;
+  border-right: 1px solid #ccc;
+  border-radius: 0px 0px 5px 5px;
+}
+
+.ppc-prevent-button-wrapper {
+  margin-top: 50px;
+  border-top: 1px solid #ccc;
+}
+
+.ppc-popup-option-dontpublish {
+  display: inline-block;
+  width: 50%;
+  padding: 15px 0 15px 0px;
+  cursor: pointer;
+  background: #f1f1f1;
+  border-right: 1px solid #ccc;
+  border-radius: 0px 0px 0px 5px;
+}
+
+.ppc-popup-options-publishanyway {
+  display: inline;
+  width: 50%;
+  padding: 15px 0 15px 0px;
+  cursor: pointer;
+  background: #f1f1f1;
+  border-radius: 0px 0px 5px 0px;
+}
+
+.ppc-button-wrapper {
+  display: flex;
+  margin-top: 50px;
+  border-top: 1px solid #ccc;
+}
+
+div#ppc_custom_meta_box {
+  transition:1.0s ease;
+  -moz-transition:1.0s ease;
+  -webkit-transition:1.0s ease;
+}
+
+.ppc-metabox-background {
+  background:  #fff8e5;
+  transition:1.0s ease;
+  -moz-transition:1.0s ease;
+  -webkit-transition:1.0s ease;
+}
+
+p.ppc-popup-description {
+  padding: 0px 20px 0px 20px;
+}

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
@@ -9,15 +9,7 @@
 }
 
 /* All the CSS needed for the modal */
-#ppc-update{
-  padding: 0 12px 2px;
-  height: 33px;
-  line-height: 32px;
-  font-size: 13px;
-  margin: 0 12px 0 3px;
-}
-
-#ppc-publish{
+#ppc-update, #ppc-publish {
   padding: 0 12px 2px;
   height: 33px;
   line-height: 32px;
@@ -26,7 +18,7 @@
   margin: 0 12px 0 3px;
 }
 
-.ppc-popup-warn  {
+.ppc-popup-warn, .ppc-popup-prevent {
   width: 400px;
   text-align: center;
   box-shadow: 0px 0px 15px -6px rgba(0,0,0,0.75);
@@ -42,23 +34,7 @@
   margin-left: 50;
 }
 
-.ppc-popup-prevent {
-  width: 400px;
-  text-align: center;
-  box-shadow: 0px 0px 15px -6px rgba(0,0,0,0.75);
-  background-color: #ffffff;
-  transition: opacity 0.8s;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50% , -70%);
-  position: absolute;
-  z-index: 99;
-  border-radius: 5px;
-  margin-top: 50;
-  margin-left: 50;
-}
-
-.ppc-modal-warn {
+.ppc-modal-warn, .ppc-modal-prevent{
   display: none;
   position: fixed;
   left: 0;
@@ -73,76 +49,53 @@
   transition: all 0.3s linear;
 }
 
-.ppc-modal-prevent{
-  display: none;
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: 9999;
-  width: 100%;
-  height: 100%;
-  background-color: black;
-  background-color: rgba(0, 0, 0, 0.4);
-  -webkit-transition: 0.5s;
-  overflow: auto;
-  transition: all 0.3s linear;
-}
-
-.ppc-popup-option-dontpublish:hover {
-  background-color: #e5e5e5;
-  color: #444;
-}
-
-.ppc-popup-options-publishanyway:hover {
-  background-color: #e5e5e5;
-  color: #444;
-}
-
+.ppc-popup-option-dontpublish:hover, 
+.ppc-popup-options-publishanyway:hover,
 .ppc-popup-option-okay:hover {
   background-color: #e5e5e5;
   color: #444;
 }
 
-.ppc-popup-option-okay {
-  display: block;
+.ppc-popup-option-okay,
+.ppc-popup-option-dontpublish,
+.ppc-popup-options-publishanyway {
   padding: 15px 0 15px 0px;
   cursor: pointer;
   background: #f1f1f1;
-  border-right: 1px solid #ccc;
-  border-radius: 0px 0px 5px 5px;
 }
 
-.ppc-prevent-button-wrapper {
-  margin-top: 50px;
-  border-top: 1px solid #ccc;
+.ppc-popup-option-okay {
+  display: block;
+  border-right: 1px solid #ccc;
+  border-radius: 0px 0px 5px 5px;
 }
 
 .ppc-popup-option-dontpublish {
   display: inline-block;
   width: 50%;
-  padding: 15px 0 15px 0px;
-  cursor: pointer;
-  background: #f1f1f1;
   border-right: 1px solid #ccc;
   border-radius: 0px 0px 0px 5px;
 }
 
 .ppc-popup-options-publishanyway {
-  display: inline;
+  display: inline-block;
   width: 50%;
-  padding: 15px 0 15px 0px;
-  cursor: pointer;
-  background: #f1f1f1;
   border-radius: 0px 0px 5px 0px;
 }
 
+.ppc-prevent-button-wrapper,
 .ppc-button-wrapper {
-  display: flex;
   margin-top: 50px;
   border-top: 1px solid #ccc;
 }
 
-div#ppc_custom_meta_box {
+.ppc-button-wrapper {
+  display: flex;
+}
+
+div#ppc_custom_meta_box,
+.ppc-metabox-background
+ {
   transition:1.0s ease;
   -moz-transition:1.0s ease;
   -webkit-transition:1.0s ease;
@@ -150,9 +103,6 @@ div#ppc_custom_meta_box {
 
 .ppc-metabox-background {
   background:  #fff8e5;
-  transition:1.0s ease;
-  -moz-transition:1.0s ease;
-  -webkit-transition:1.0s ease;
 }
 
 p.ppc-popup-description {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,0 +1,229 @@
+jQuery(document).ready(
+    function() {
+        /* Assigning vars */
+        var ppc_publish_flag = 0;
+        var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
+        var ppc_checkboxes_length = jQuery('.ppc_checkboxes[type="checkbox"]').length;
+        var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
+        var ppc_percentage_completed = (countCheckedppc_checkboxes / ppc_checkboxes_length) * 100;
+        jQuery('.ppc-percentage').attr('style', 'width:' + ppc_percentage_completed + '%');
+        jQuery(".ppc-percentage-value").html(Math.round(ppc_percentage_completed) + "%");
+
+
+        // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
+        // .editor-post-publish-button          = "update" button for already-published posts
+
+        //function to be executed when the itemlist changes.
+        
+        var ppc_checkbox_function = function() {
+            var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
+            var ppc_checkboxes_length = jQuery('.ppc_checkboxes[type="checkbox"]').length;
+            var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
+            if (ppc_checkboxes_length == countCheckedppc_checkboxes) { // if all the checkboxes are checked (lets publish!!)
+                if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                    jQuery('.edit-post-header__settings').children(jQuery('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
+                    jQuery('.edit-post-header__settings').children(jQuery('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
+                    jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+                } else if (jQuery('.editor-post-publish-button').length == 1) {
+                    jQuery('.edit-post-header__settings').children(':eq(2)').after(jQuery('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Publish" button
+                    jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+                }
+            // if not all the checkboxes are checked (lets not publish!!)
+            } else if (ppc_checkboxes_length != countCheckedppc_checkboxes) { 
+                // if not all the checkboxes are checked (lets not publish!!)
+                if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                    jQuery('#ppc-update').attr('style', 'display:none'); // hide the custom "update" button
+                    jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide the "publish" button
+                    jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after(jQuery('#ppc-publish').attr('style', 'display:inline-flex')); // (I think) show the custom "Publish" button
+                    // Add the (custom) publish button
+                    if (jQuery('#ppc-publish').length == 0) {
+                        jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish...</button>');
+                    }
+                // I am pretty sure this is the difference between an already published post and a new post
+                } else if (jQuery('.editor-post-publish-button').length == 1) {
+                    jQuery('.editor-post-publish-button').attr('style', 'display:none');
+                    jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after(jQuery('#ppc-update').attr('style', 'display:inline-flex'));
+                    if (jQuery('#ppc-update').length == 0) {
+                        // Add the (custom) "update" button
+                        jQuery('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update</button>');
+                    }
+                }
+            }
+        }
+
+        // Click "switch to draft" button (unpublish a post)
+        jQuery(document).on('click', '.editor-post-switch-to-draft', function() {
+            // remove the custom "update" button, show the custom "publish" button
+            jQuery('#ppc_update').attr('style', 'display:none');
+            jQuery('#ppc_publish').attr('style', 'display:inline-block');
+        });
+
+
+        // not sure what this is
+        if (jQuery('#publish').length !== 1) {
+            setTimeout(
+                function() {
+                    if (ppc_error_level.option != 3 && (ppc_checkboxes_length != countCheckedppc_checkboxes)) {
+                        // new article
+                        if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                            jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide "publish" the button
+                        } else if (jQuery('.editor-post-publish-button').length == 1) {
+                            jQuery('.editor-post-publish-button').attr('style', 'display:none'); // hide the "update" button
+                        }
+                        if (jQuery('.edit-post-header__settings').find('.editor-post-save-draft').length != 0) { // if "save draft"
+                            // add a custom "publish" button
+                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish...</button>');
+                        } else if (jQuery('.edit-post-header__settings').find('.editor-post-switch-to-draft').length == 1) { // if "switch to draft"
+                            // add a custom "update" button
+                            jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update</button>');
+                        } else if (jQuery('.edit-post-header__settings').find('.editor-post-switch-to-draft').length == 0) {  // if no "switch to draft"
+                            // add a custom "publish" button
+                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish...</button>');
+                        }
+                    }
+                }, 10
+            );
+
+            /**
+             * "ppc_error_level" is in the plugin settings
+             * 
+             * - 1: Prevent User from Publishing Page/Post
+             * - 2: Warn User Before Publishing
+             * - 3: Do Nothing and Publish
+             */ 
+            if (ppc_error_level.option == 1 || ppc_error_level.option == 2) {
+                // run "ppc_checkbox_function" when the checkboxes are updated 
+                ppc_checkboxes.change(ppc_checkbox_function);
+            }
+            else if (ppc_error_level.option == 3) {
+                /* 
+                This block of code seems to update the "title" of the publish button or the update button 
+                */
+                var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
+                var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
+                ppc_checkboxes.change(
+                    function() {
+                        var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
+                        var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
+                        if (ppc_checkboxes.length == countCheckedppc_checkboxes) {
+                            //all checkboxes are checked
+                            if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                                jQuery('.editor-post-publish-panel__toggle').prop('title', 'All items checked ! You are good to publish');
+                            } else if (jQuery('.editor-post-publish-button').length == 1) {
+                                jQuery('.editor-post-publish-button').prop('title', 'All items checked ! You are good to publish');
+                            }
+                        } else if (ppc_checkboxes.length != countCheckedppc_checkboxes) {
+                            // All ppc_checkboxes are not yet checked                                
+                            if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                                jQuery('.editor-post-publish-panel__toggle').prop('title', 'Pre-Publish-Checklist some items still remaining ');
+                            } else if (jQuery('.editor-post-publish-button').length == 1) {
+                                jQuery('.editor-post-publish-button').prop('title', 'Pre-Publish-Checklist some items still remaining !');
+                            }
+                        }
+                    }
+                );
+            }
+        }
+
+        //  Warn User Before Publishing
+        if (ppc_error_level.option == 2) {
+            // Show the "warning" modal
+            jQuery(document).on('click', "#ppc-update", function() {
+                jQuery('.ppc-modal-warn').attr('style', 'display:block');
+            });
+            jQuery(document).on('click', "#ppc-publish", function() {
+                jQuery('.ppc-modal-warn').attr('style', 'display:block');
+            });
+        // Prevent User from Publishing Page/Post
+        } else if (ppc_error_level.option == 1) {
+            // Show the "prevent publishing" modal
+            jQuery(document).on('click', "#ppc-update", function() {
+                jQuery('.ppc-modal-prevent').attr('style', 'display:inline-block');
+            });
+            jQuery(document).on('click', "#ppc-publish", function() {
+                jQuery('.ppc-modal-prevent').attr('style', 'display:block');
+                jQuery("#ppc_custom_meta_box").html();
+            });
+        }
+        // Click "Publish anyway" on the "warning" modal
+        jQuery(document).on('click', ".ppc-popup-options-publishanyway", function() {
+            // Hide the warning modal
+            jQuery('.ppc-modal-warn').attr('style', 'display:none');
+            // If it's a new post
+            if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                // Hide custom "publish" button
+                jQuery('#ppc-publish').attr('style', 'display:none');
+                // Hide custom "update" button
+                jQuery('#ppc-update').attr('style', 'display:none');
+                // Show the real "publish" button
+                jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex');
+                // Click the real "publish" button
+                jQuery('.editor-post-publish-panel__toggle').trigger('click', 'publish');
+            // If it's an update to a post
+            } else if (jQuery('.editor-post-publish-button').length == 1) {
+                // Hide custom "update" button
+                jQuery('#ppc-update').attr('style', 'display:none');
+                // Show the real "Update" button
+                jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex');
+                // Click the real "Update" button
+                jQuery('.editor-post-publish-button').trigger('click', 'update');
+                // Hide the real "Update" button
+                jQuery('.editor-post-publish-button').attr('style', 'display:none');
+                // Show the custom "Update" button
+                jQuery('#ppc-update').attr('style', 'display:inline-block');
+            } else {
+                // Hide the modal, and click the publish button
+                ppc_publish_flag = 1;
+                jQuery('.ppc-modal-warn').attr('style', 'display:none');
+                jQuery('#publish').trigger('click', 'publish');
+            }
+        });
+        // Click "Don't publish" on the "warning" modal
+        jQuery(document).on('click', ".ppc-popup-option-dontpublish", function() {
+            // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
+            jQuery('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
+            if (jQuery('#ppc_custom_meta_box').attr("class") == 'postbox closed') {
+                // Open the "pre-publish checklists" metabox
+                jQuery('#ppc_custom_meta_box').attr('class', 'postbox');
+            }
+            // Hide the "warning" modal
+            jQuery('.ppc-modal-warn').attr('style', 'display:none');
+            // scroll the "pre-publish checklists" metabox into view
+            document.querySelector('#ppc_custom_meta_box').scrollIntoView({
+                behavior: 'smooth',
+                block: "end",
+                inline: "nearest"
+            });
+            jQuery("#ppc_custom_meta_box").scrollTop += 50;
+            // focus the "pre-publish checklists" metabox
+            jQuery('#ppc_custom_meta_box').focus();
+            // Add class that gives the custom metabox a yellow background which fades
+            jQuery('#ppc_custom_meta_box').addClass('ppc-metabox-background');
+            setTimeout(function() {
+                jQuery('#ppc_custom_meta_box').removeClass('ppc-metabox-background');
+            }, 1000)
+        });
+        // Click "Okay" on the "not allowed to publish" modal
+        jQuery(document).on('click', ".ppc-popup-option-okay", function() {
+            // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
+            jQuery('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
+            if (jQuery('#ppc_custom_meta_box').attr("class") == 'postbox closed') {
+                // Open the "pre-publish checklists" metabox
+                jQuery('#ppc_custom_meta_box').attr('class', 'postbox');
+            }
+            // Hide the "not allowed to publish modal"
+            jQuery('.ppc-modal-prevent').attr('style', 'display:none');
+            // scroll the "pre-publish checklists" metabox into view
+            document.querySelector('#ppc_custom_meta_box').scrollIntoView({
+                behavior: 'smooth',
+                block: "end",
+                inline: "nearest"
+            });
+            // Add class that gives the custom metabox a yellow background which fades
+            jQuery('#ppc_custom_meta_box').addClass('ppc-metabox-background');
+            setTimeout(function() {
+                jQuery('#ppc_custom_meta_box').removeClass('ppc-metabox-background');
+            }, 1000)
+        });
+    }
+);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,14 +1,25 @@
-jQuery(document).ready(
-    function() {
-        /* Assigning vars */
-        var ppc_publish_flag = 0;
+jQuery(document).ready(    
+    function($) {
+
+        /* Assigning vars: Their vars (get rid of these) */
         var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
         var ppc_checkboxes_length = jQuery('.ppc_checkboxes[type="checkbox"]').length;
         var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
-        var ppc_percentage_completed = (countCheckedppc_checkboxes / ppc_checkboxes_length) * 100;
-        jQuery('.ppc-percentage').attr('style', 'width:' + ppc_percentage_completed + '%');
-        jQuery(".ppc-percentage-value").html(Math.round(ppc_percentage_completed) + "%");
 
+        /* ~TESTED */
+
+        /* Assigning vars: Our vars */
+        const ppc_error_level = {option: 1}; // 1 is "required", 2 is "recommended"
+        const $items = $('.pp-checklists-req')
+        const numItems = $items.length
+        const $requiredItems = $items.filter('.pp-checklists-block')
+        const numRequiredItems = $requiredItems.length
+        const $recommendedItems = $items.filter('.pp-checklists-warning')
+        const numRecommendedItems = $recommendedItems.length
+        const metaboxID = '#pp_checklist_meta'
+
+        console.log('items', $items)
+        console.log('numItems', numItems)
 
         // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
         // .editor-post-publish-button          = "update" button for already-published posts
@@ -16,10 +27,16 @@ jQuery(document).ready(
         //function to be executed when the itemlist changes.
         
         var ppc_checkbox_function = function() {
-            var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
-            var ppc_checkboxes_length = jQuery('.ppc_checkboxes[type="checkbox"]').length;
-            var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
-            if (ppc_checkboxes_length == countCheckedppc_checkboxes) { // if all the checkboxes are checked (lets publish!!)
+            // check if all the required && recommended checklists are checked
+            console.log('ppc_checkbox_function called')
+            // TODO: this length is off, it happens too quickly
+            numCheckedItems = $items.filter('.status-yes').length
+            console.log('numCheckedItems', numCheckedItems)
+
+            /* ~END TESTED */
+
+            if (numItems === numCheckedItems) { // if all the checkboxes are checked (lets publish!!)
+                console.log('all items are checked')
                 if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
                     jQuery('.edit-post-header__settings').children(jQuery('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
                     jQuery('.edit-post-header__settings').children(jQuery('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
@@ -29,27 +46,36 @@ jQuery(document).ready(
                     jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
                 }
             // if not all the checkboxes are checked (lets not publish!!)
-            } else if (ppc_checkboxes_length != countCheckedppc_checkboxes) { 
+            } else if (numItems !== numCheckedItems) { 
+                console.log('all items are NOT checked')
+
                 // if not all the checkboxes are checked (lets not publish!!)
                 if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+                    console.log('toggle length == 1')
+
                     jQuery('#ppc-update').attr('style', 'display:none'); // hide the custom "update" button
                     jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide the "publish" button
                     jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after(jQuery('#ppc-publish').attr('style', 'display:inline-flex')); // (I think) show the custom "Publish" button
                     // Add the (custom) publish button
                     if (jQuery('#ppc-publish').length == 0) {
-                        jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish...</button>');
+                        jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
                     }
                 // I am pretty sure this is the difference between an already published post and a new post
                 } else if (jQuery('.editor-post-publish-button').length == 1) {
+                    /* ~TESTED */
                     jQuery('.editor-post-publish-button').attr('style', 'display:none');
                     jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after(jQuery('#ppc-update').attr('style', 'display:inline-flex'));
                     if (jQuery('#ppc-update').length == 0) {
                         // Add the (custom) "update" button
-                        jQuery('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update</button>');
+                        jQuery('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
                     }
                 }
             }
         }
+
+
+        setTimeout(ppc_checkbox_function, 1000);
+        /* ~END TESTED */
 
         // Click "switch to draft" button (unpublish a post)
         jQuery(document).on('click', '.editor-post-switch-to-draft', function() {
@@ -63,7 +89,7 @@ jQuery(document).ready(
         if (jQuery('#publish').length !== 1) {
             setTimeout(
                 function() {
-                    if (ppc_error_level.option != 3 && (ppc_checkboxes_length != countCheckedppc_checkboxes)) {
+                    if (ppc_checkboxes_length != countCheckedppc_checkboxes) {
                         // new article
                         if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
                             jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide "publish" the button
@@ -72,13 +98,13 @@ jQuery(document).ready(
                         }
                         if (jQuery('.edit-post-header__settings').find('.editor-post-save-draft').length != 0) { // if "save draft"
                             // add a custom "publish" button
-                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish...</button>');
+                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
                         } else if (jQuery('.edit-post-header__settings').find('.editor-post-switch-to-draft').length == 1) { // if "switch to draft"
                             // add a custom "update" button
-                            jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update</button>');
+                            jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
                         } else if (jQuery('.edit-post-header__settings').find('.editor-post-switch-to-draft').length == 0) {  // if no "switch to draft"
                             // add a custom "publish" button
-                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish...</button>');
+                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
                         }
                     }
                 }, 10
@@ -95,42 +121,16 @@ jQuery(document).ready(
                 // run "ppc_checkbox_function" when the checkboxes are updated 
                 ppc_checkboxes.change(ppc_checkbox_function);
             }
-            else if (ppc_error_level.option == 3) {
-                /* 
-                This block of code seems to update the "title" of the publish button or the update button 
-                */
-                var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
-                var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
-                ppc_checkboxes.change(
-                    function() {
-                        var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
-                        var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
-                        if (ppc_checkboxes.length == countCheckedppc_checkboxes) {
-                            //all checkboxes are checked
-                            if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
-                                jQuery('.editor-post-publish-panel__toggle').prop('title', 'All items checked ! You are good to publish');
-                            } else if (jQuery('.editor-post-publish-button').length == 1) {
-                                jQuery('.editor-post-publish-button').prop('title', 'All items checked ! You are good to publish');
-                            }
-                        } else if (ppc_checkboxes.length != countCheckedppc_checkboxes) {
-                            // All ppc_checkboxes are not yet checked                                
-                            if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
-                                jQuery('.editor-post-publish-panel__toggle').prop('title', 'Pre-Publish-Checklist some items still remaining ');
-                            } else if (jQuery('.editor-post-publish-button').length == 1) {
-                                jQuery('.editor-post-publish-button').prop('title', 'Pre-Publish-Checklist some items still remaining !');
-                            }
-                        }
-                    }
-                );
-            }
         }
 
         //  Warn User Before Publishing
         if (ppc_error_level.option == 2) {
             // Show the "warning" modal
+            /* ~TESTED */
             jQuery(document).on('click', "#ppc-update", function() {
                 jQuery('.ppc-modal-warn').attr('style', 'display:block');
             });
+            /* ~END TESTED */
             jQuery(document).on('click', "#ppc-publish", function() {
                 jQuery('.ppc-modal-warn').attr('style', 'display:block');
             });
@@ -142,7 +142,6 @@ jQuery(document).ready(
             });
             jQuery(document).on('click', "#ppc-publish", function() {
                 jQuery('.ppc-modal-prevent').attr('style', 'display:block');
-                jQuery("#ppc_custom_meta_box").html();
             });
         }
         // Click "Publish anyway" on the "warning" modal
@@ -178,52 +177,51 @@ jQuery(document).ready(
                 jQuery('#publish').trigger('click', 'publish');
             }
         });
+        
+        /* ~TESTED */
+        const scrollToMetabox = (_metaboxID) => {
+            document.querySelector(_metaboxID).scrollIntoView({
+                behavior: 'smooth',
+                block: 'end',
+                inline: 'nearest'
+            });
+            $(_metaboxID).scrollTop += 50;
+            // focus the metabox
+            $(_metaboxID).focus();
+            // Add class that gives the metabox a yellow background which fades
+            $(metaboxID).addClass('ppc-metabox-background');
+            setTimeout(function() {
+                $(metaboxID).removeClass('ppc-metabox-background');
+            }, 1000)
+        }
+
         // Click "Don't publish" on the "warning" modal
         jQuery(document).on('click', ".ppc-popup-option-dontpublish", function() {
             // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
             jQuery('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
-            if (jQuery('#ppc_custom_meta_box').attr("class") == 'postbox closed') {
+            if (jQuery(metaboxID).attr("class") === 'postbox closed') {
                 // Open the "pre-publish checklists" metabox
-                jQuery('#ppc_custom_meta_box').attr('class', 'postbox');
+                jQuery(metaboxID).attr('class', 'postbox');
             }
             // Hide the "warning" modal
             jQuery('.ppc-modal-warn').attr('style', 'display:none');
             // scroll the "pre-publish checklists" metabox into view
-            document.querySelector('#ppc_custom_meta_box').scrollIntoView({
-                behavior: 'smooth',
-                block: "end",
-                inline: "nearest"
-            });
-            jQuery("#ppc_custom_meta_box").scrollTop += 50;
-            // focus the "pre-publish checklists" metabox
-            jQuery('#ppc_custom_meta_box').focus();
-            // Add class that gives the custom metabox a yellow background which fades
-            jQuery('#ppc_custom_meta_box').addClass('ppc-metabox-background');
-            setTimeout(function() {
-                jQuery('#ppc_custom_meta_box').removeClass('ppc-metabox-background');
-            }, 1000)
+            scrollToMetabox(metaboxID);
         });
+
         // Click "Okay" on the "not allowed to publish" modal
         jQuery(document).on('click', ".ppc-popup-option-okay", function() {
             // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
             jQuery('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
-            if (jQuery('#ppc_custom_meta_box').attr("class") == 'postbox closed') {
+            if (jQuery(metaboxID).attr("class") === 'postbox closed') {
                 // Open the "pre-publish checklists" metabox
-                jQuery('#ppc_custom_meta_box').attr('class', 'postbox');
+                jQuery(metaboxID).attr('class', 'postbox');
             }
             // Hide the "not allowed to publish modal"
             jQuery('.ppc-modal-prevent').attr('style', 'display:none');
             // scroll the "pre-publish checklists" metabox into view
-            document.querySelector('#ppc_custom_meta_box').scrollIntoView({
-                behavior: 'smooth',
-                block: "end",
-                inline: "nearest"
-            });
-            // Add class that gives the custom metabox a yellow background which fades
-            jQuery('#ppc_custom_meta_box').addClass('ppc-metabox-background');
-            setTimeout(function() {
-                jQuery('#ppc_custom_meta_box').removeClass('ppc-metabox-background');
-            }, 1000)
+            scrollToMetabox(metaboxID);
         });
     }
 );
+/* ~END TESTED */

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -136,8 +136,18 @@ jQuery(document).ready(
             }
         }
 
-        // Run on pageload, after interface has loaded (less than 500ms and the Publish/Update buttons aren't there)
-        setTimeout(ppc_checkbox_function, 1200);
+        /* ====== Publish / Send to draft ====== */
+        const getPostStatus = () => wp.data.select('core/editor').getEditedPostAttribute('status');
+        let postStatus = getPostStatus();
+
+        wp.data.subscribe(() => {
+            const newPostStatus = getPostStatus();
+            if(postStatus !== newPostStatus) {
+                // Run when post status changes
+                setTimeout(ppc_checkbox_function, 1000);
+            }
+            postStatus = newPostStatus;
+        });
 
         /* ====== Events ====== */
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -143,7 +143,7 @@ jQuery(document).ready(
         wp.data.subscribe(() => {
             const newPostStatus = getPostStatus();
             if(postStatus !== newPostStatus) {
-                // Run when post status changes
+                // Run when post status changes (also runs on pageloads (original post status is 'undefined'))
                 setTimeout(ppc_checkbox_function, 1000);
             }
             postStatus = newPostStatus;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,16 +1,19 @@
 jQuery(document).ready(    
     function($) {
 
-        // TODOs:
-        // - ✅ Open settings if closed
-        // - ✅ Detect when a checkbox is clicked
-        // - ✅ Detect when a condition is met
-        // - ❌ Detect when unpublished
-        // - Check when checkboxes are required or recommended
-
+        /**
+         * "ppc_error_level.option" is in the plugin settings
+         *
+         * - 1: Prevent User from Publishing Page/Post
+         * - 2: Warn User Before Publishing
+         * - 3: Do Nothing and Publish
+         */
 
         /* Assigning vars: Our vars */
-        const ppc_error_level = {option: 1}; // 1 is "required", 2 is "recommended"
+        const REQUIRED = {option: 1};
+        const RECOMMENDED = {option: 2};
+        let ppc_error_level = REQUIRED; // default to 'required'
+
         const metaboxID = '#pp_checklist_meta'
         const $itemsContainer = $('#pp-checklists-req-box')
         const $items = $itemsContainer.find('.pp-checklists-req')
@@ -22,13 +25,10 @@ jQuery(document).ready(
         //function to be executed when the itemlist changes.
         var ppc_checkbox_function = function() {
             // check if all the required && recommended checklists are checked
-
-            // TODO: this length is off, it happens too quickly
             numCheckedItems = $items.filter('.status-yes').length
-            console.log('numCheckedItems', numCheckedItems)
 
-            if (numItems === numCheckedItems) { // if all the checkboxes are checked (lets publish!!)
-                console.log('all items are checked')
+            // if all the checkboxes are checked (lets publish!!)
+            if (numItems === numCheckedItems) {
                 if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
                     jQuery('.edit-post-header__settings').children(jQuery('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
                     jQuery('.edit-post-header__settings').children(jQuery('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
@@ -39,8 +39,10 @@ jQuery(document).ready(
                 }
 
             // if not all the checkboxes are checked (lets not publish!!)
-            } else if (numItems !== numCheckedItems) { 
-                console.log('all items are NOT checked')
+            } else if (numItems !== numCheckedItems) {
+
+                // check number of required checkboxes still unchecked
+                ppc_error_level = $items.filter('.pp-checklists-block.status-no').length ? REQUIRED : RECOMMENDED;
 
                 // if NOT all the checkboxes are checked (don't publish!!)
                 if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
@@ -72,32 +74,17 @@ jQuery(document).ready(
             attributeFilter: ['class']}
         );
 
-        /**
-         * "ppc_error_level.option" is in the plugin settings
-         *
-         * - 1: Prevent User from Publishing Page/Post
-         * - 2: Warn User Before Publishing
-         * - 3: Do Nothing and Publish
-         */
-        //  Warn User Before Publishing
-        if (ppc_error_level.option == 2) {
-            // Show the "warning" modal
-            jQuery(document).on('click', "#ppc-update", function() {
+
+        $(document).on('click', "#ppc-update, #ppc-publish", function() {
+            if(ppc_error_level.option == REQUIRED.option) {
+                // Prevent User from Publishing Page/Post
+                $('.ppc-modal-prevent').attr('style', 'display:block');
+            }
+            else {
+                // Warn User Before Publishing
                 jQuery('.ppc-modal-warn').attr('style', 'display:block');
-            });
-            jQuery(document).on('click', "#ppc-publish", function() {
-                jQuery('.ppc-modal-warn').attr('style', 'display:block');
-            });
-        // Prevent User from Publishing Page/Post
-        } else if (ppc_error_level.option == 1) {
-            // Show the "prevent publishing" modal
-            jQuery(document).on('click', "#ppc-update", function() {
-                jQuery('.ppc-modal-prevent').attr('style', 'display:inline-block');
-            });
-            jQuery(document).on('click', "#ppc-publish", function() {
-                jQuery('.ppc-modal-prevent').attr('style', 'display:block');
-            });
-        }
+            }
+        })
 
         // Click "Publish anyway" on the "warning" modal
         jQuery(document).on('click', ".ppc-popup-options-publishanyway", function() {
@@ -183,6 +170,7 @@ jQuery(document).ready(
 
             // Hide the "warning" modal
             jQuery('.ppc-modal-warn').attr('style', 'display:none');
+
             // scroll the "pre-publish checklists" metabox into view
             scrollToMetabox(metaboxID);
         });
@@ -193,6 +181,7 @@ jQuery(document).ready(
 
             // Hide the "not allowed to publish modal"
             jQuery('.ppc-modal-prevent').attr('style', 'display:none');
+
             // scroll the "pre-publish checklists" metabox into view
             scrollToMetabox(metaboxID);
         });

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -19,48 +19,87 @@ jQuery(document).ready(
         const $items = $itemsContainer.find('.pp-checklists-req')
         const numItems = $items.length
 
-        // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
-        // .editor-post-publish-button          = "update" button for already-published posts
+        const isPublished = () => {
+            // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
+            // .editor-post-publish-button          = "update" button for already-published posts
+
+            return $('.editor-post-publish-button').length == 1 // if "Update" button exists, post is already published
+        }
+
+        const hideCustomButtons = () => {
+            $('.edit-post-header__settings').children($('#ppc-update, #ppc-publish').attr('style', 'display:none')); // Hide the custom "Update" and "Publish" buttons
+        }
+
+        showCustomPublishButton = () => {
+            $('#ppc-update').attr('style', 'display:none'); // Hide custom "Update" button
+            $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after($('#ppc-publish').attr('style', 'display:inline-flex')); // Show the custom "Publish" button
+
+            // if "Publish" button doesn't exist yet, add it
+            if ($('#ppc-publish').length == 0) {
+                $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
+            }
+        }
+
+        showCustomUpdateButton = () => {
+            $('#ppc-publish').attr('style', 'display:none'); // Hide custom "Publish" button
+            $('.edit-post-header__settings').find('.editor-post-publish-button').after($('#ppc-update').attr('style', 'display:inline-flex')); // Show the custom "Update" button
+
+            // if "Update" button doesn't exist yet, add it
+            if ($('#ppc-update').length == 0) {
+                $('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
+            }
+        }
+
+        const showPublishButton = () => {
+            $('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+        }
+
+        const hidePublishButton = () => {
+            $('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // Hide the regular "Publish" button
+        }
+
+        const showUpdateButton = () => {
+            $('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+        }
+
+        const hideUpdateButton = () => {
+            $('.editor-post-publish-button').attr('style', 'display:none'); // Show the regular "Publish" button
+        }
+
+        const showWarningModal = () => {
+            $('.ppc-modal-warn').attr('style', 'display:block');
+        }
+
+        const showPreventModal = () => {
+            $('.ppc-modal-prevent').attr('style', 'display:block');
+        }
+
+        const hideModals = () => {
+            $('.ppc-modal-prevent').add('.ppc-modal-warn').attr('style', 'display:none');
+        }
 
         //function to be executed when the itemlist changes.
         var ppc_checkbox_function = function() {
             // check if all the required && recommended checklists are checked
-            numCheckedItems = $items.filter('.status-yes').length
+            numItemsComplete = $items.filter('.status-yes').length
 
             // if all the checkboxes are checked (lets publish!!)
-            if (numItems === numCheckedItems) {
-                if ($('.editor-post-publish-panel__toggle').length == 1) {
-                    $('.edit-post-header__settings').children($('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
-                    $('.edit-post-header__settings').children($('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
-                    $('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
-                } else if ($('.editor-post-publish-button').length == 1) { // if "Update"
-                    $('.edit-post-header__settings').children(':eq(2)').after($('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Update" button
-                    $('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Update" button
-                }
+            if (numItems === numItemsComplete) {
+                hideCustomButtons();
+
+                isPublished() ? showUpdateButton() : showPublishButton()
 
             // if not all the checkboxes are checked (lets not publish!!)
-            } else if (numItems !== numCheckedItems) {
-
+            } else {
                 // check number of required checkboxes still unchecked
                 ppc_error_level = $items.filter('.pp-checklists-block.status-no').length ? REQUIRED : RECOMMENDED;
 
-                // if NOT all the checkboxes are checked (don't publish!!)
-                if ($('.editor-post-publish-panel__toggle').length == 1) {
-                    $('#ppc-update').attr('style', 'display:none'); // hide the custom "update" button
-                    $('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide the "publish" button
-                    $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after($('#ppc-publish').attr('style', 'display:inline-flex')); // (I think) show the custom "Publish" button
-                    // Add the (custom) publish button
-                    if ($('#ppc-publish').length == 0) {
-                        $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
-                    }
-                // I am pretty sure this is the difference between an already published post and a new post
-                } else if ($('.editor-post-publish-button').length == 1) {
-                    $('.editor-post-publish-button').attr('style', 'display:none');
-                    $('.edit-post-header__settings').find('.editor-post-publish-button').after($('#ppc-update').attr('style', 'display:inline-flex'));
-                    if ($('#ppc-update').length == 0) {
-                        // Add the (custom) "update" button
-                        $('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
-                    }
+                if (isPublished()) {
+                    hideUpdateButton();
+                    showCustomUpdateButton();
+                } else {
+                    hidePublishButton();
+                    showCustomPublishButton();
                 }
             }
         }
@@ -76,50 +115,35 @@ jQuery(document).ready(
 
 
         $(document).on('click', "#ppc-update, #ppc-publish", function() {
-            if(ppc_error_level.option == REQUIRED.option) {
-                // Prevent User from Publishing Page/Post
-                $('.ppc-modal-prevent').attr('style', 'display:block');
-            }
-            else {
-                // Warn User Before Publishing
-                $('.ppc-modal-warn').attr('style', 'display:block');
-            }
+            ppc_error_level.option == REQUIRED.option ?
+                showPreventModal() : // Prevent User from Publishing Page/Post
+                showWarningModal() // Warn User Before Publishing
         })
 
         // Click "Publish anyway" on the "warning" modal
         $(document).on('click', ".ppc-popup-options-publishanyway", function() {
-            // Hide the warning modal
-            $('.ppc-modal-warn').attr('style', 'display:none');
-            // If it's a new post
-            if ($('.editor-post-publish-panel__toggle').length == 1) {
-                // Hide custom "publish" button
-                $('#ppc-publish').attr('style', 'display:none');
-                // Hide custom "update" button
-                $('#ppc-update').attr('style', 'display:none');
-                // Show the real "publish" button
-                $('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex');
-                // Click the real "publish" button
-                $('.editor-post-publish-panel__toggle').trigger('click');
 
-                // check if "interface-interface-skeleton__actions" contains a "publish" button
-                const $publishButton = $('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
-                if($publishButton.length && $publishButton.text() === 'Publish') {
-                    // Click the "publish" button in the slideout panel
-                    $publishButton.trigger('click');
-                }
+            hideModals(); // Hide the warning modal
 
             // If it's an update to a post
-            } else if ($('.editor-post-publish-button').length == 1) {
-                // Hide custom "update" button
-                $('#ppc-update').attr('style', 'display:none');
-                // Show the real "Update" button
-                $('.editor-post-publish-button').attr('style', 'display:inline-flex');
-                // Click the real "Update" button
+            if (isPublished()) {
+                hideCustomButtons();
+                showUpdateButton(); // Show the real "Update" button
                 $('.editor-post-publish-button').trigger('click');
-                // Hide the real "Update" button
-                $('.editor-post-publish-button').attr('style', 'display:none');
-                // Show the custom "Update" button
-                $('#ppc-update').attr('style', 'display:inline-block');
+                hideUpdateButton(); // Hide the real "Update" button
+                showCustomUpdateButton(); // Show the custom "Update" button
+
+            // If it's being published
+            } else {
+                hideCustomButtons();
+                showPublishButton(); // Show the real "publish" button
+                $('.editor-post-publish-panel__toggle').trigger('click'); // Click the real "publish" button
+
+                // check if a slide-out panel with a publish button appears
+                const $publishButton = $('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
+                if($publishButton.length && $publishButton.text() === 'Publish') {
+                    $publishButton.trigger('click'); // Click the "publish" button in the slideout panel
+                }
             }
         });
         
@@ -164,26 +188,11 @@ jQuery(document).ready(
             }, 1000)
         }
 
-        // Click "Don't publish" on the "warning" modal
-        $(document).on('click', ".ppc-popup-option-dontpublish", function() {
+        // Click "Don't publish" on the "warning" modal, or click "Okay" on the "not allowed to publish" modal
+        $(document).on('click', ".ppc-popup-option-dontpublish, .ppc-popup-option-okay", function() {
             openPanel();
-
-            // Hide the "warning" modal
-            $('.ppc-modal-warn').attr('style', 'display:none');
-
-            // scroll the "pre-publish checklists" metabox into view
-            scrollToMetabox(metaboxID);
-        });
-
-        // Click "Okay" on the "not allowed to publish" modal
-        $(document).on('click', ".ppc-popup-option-okay", function() {
-            openPanel();
-
-            // Hide the "not allowed to publish modal"
-            $('.ppc-modal-prevent').attr('style', 'display:none');
-
-            // scroll the "pre-publish checklists" metabox into view
-            scrollToMetabox(metaboxID);
+            hideModals(); // Hide the "warning"/"prevent" modal
+            scrollToMetabox(metaboxID); // scroll the "pre-publish checklists" metabox into view
         });
     }
 );

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -5,7 +5,7 @@ jQuery(document).ready(
         // - ✅ Open settings if closed
         // - ✅ Detect when a checkbox is clicked
         // - ✅ Detect when a condition is met
-        // - Detect when unpublished
+        // - ❌ Detect when unpublished
         // - Check when checkboxes are required or recommended
 
 
@@ -66,23 +66,11 @@ jQuery(document).ready(
         setTimeout(ppc_checkbox_function, 1000);
 
         /* Observer that triggers whenever a checkbox's state changes */
-        const observer = new MutationObserver((e) => ppc_checkbox_function());
-        observer.observe($itemsContainer[0], {
+        const checkboxObserver = new MutationObserver((e) => ppc_checkbox_function());
+        checkboxObserver.observe($itemsContainer[0], {
             subtree: true,
             attributeFilter: ['class']}
         );
-
-        /* NOT WORKING */
-        // Click "switch to draft" button (unpublish a post)
-        jQuery(document).on('click change', '.editor-post-switch-to-draft', function() {
-            console.log('SWITCHED TO DRAFT')
-            // remove the custom "update" button, show the custom "publish" button
-            // jQuery('#ppc_update').attr('style', 'display:none');
-            // jQuery('#ppc_publish').attr('style', 'display:inline-block');
-            // ppc_checkbox_function();
-        });
-        /* END NOT WORKING */
-
 
         /**
          * "ppc_error_level.option" is in the plugin settings

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -78,7 +78,7 @@ jQuery(document).ready(
          */
          const openSettingsPanel = () => {
             // Open the "Settings" panel if it is closed
-            const $settingsButton = $('.edit-post-header__settings button[aria-label="Settings"]')
+            const $settingsButton = $('.edit-post-header__settings button:is([aria-label="Settings"], [aria-label="Réglages"])')
             if($settingsButton.attr('aria-expanded') === 'false') {
                 $settingsButton.trigger('click');
             }
@@ -176,7 +176,7 @@ jQuery(document).ready(
 
                 // check if a slide-out panel with a publish button appears
                 const $publishButton = $('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
-                if($publishButton.length && $publishButton.text() === 'Publish') {
+                if($publishButton.length) {
                     $publishButton.trigger('click'); // Click the "publish" button in the slideout panel
                 }
             }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,33 +1,22 @@
 jQuery(document).ready(
     function($) {
 
-        /**
-         * "ppc_error_level.option" is in the plugin settings
-         *
-         * - 1: Prevent User from Publishing Page/Post
-         * - 2: Warn User Before Publishing
-         * - 3: Do Nothing and Publish
-         */
-
-        /* Assigning vars: Our vars */
-        const REQUIRED = {option: 1};
-        const RECOMMENDED = {option: 2};
-        let ppc_error_level = REQUIRED; // default to 'required'
+        /* ====== Vars ====== */
+        const REQUIRED = 1;
+        const RECOMMENDED = 2;
+        let errorLevel = REQUIRED; // default to 'required'
 
         const metaboxID = '#pp_checklist_meta'
         const $itemsContainer = $('#pp-checklists-req-box')
         const $items = $itemsContainer.find('.pp-checklists-req')
-        const numItems = $items.length
+
+        /* ====== Utility functions: for updating components in the publishing interface ====== */
 
         const isPublished = () => {
-            // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
+            // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts
             // .editor-post-publish-button          = "update" button for already-published posts
 
             return $('.editor-post-publish-button').length == 1 // if "Update" button exists, post is already published
-        }
-
-        const hideCustomButtons = () => {
-            $('.edit-post-header__settings').children($('#ppc-update, #ppc-publish').attr('style', 'display:none')); // Hide the custom "Update" and "Publish" buttons
         }
 
         showCustomPublishButton = () => {
@@ -50,6 +39,10 @@ jQuery(document).ready(
             }
         }
 
+        const hideCustomButtons = () => {
+            $('.edit-post-header__settings').children($('#ppc-update, #ppc-publish').attr('style', 'display:none')); // Hide the custom "Update" and "Publish" buttons
+        }
+
         const showPublishButton = () => {
             $('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
         }
@@ -59,100 +52,31 @@ jQuery(document).ready(
         }
 
         const showUpdateButton = () => {
-            $('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+            $('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Update" button
         }
 
         const hideUpdateButton = () => {
-            $('.editor-post-publish-button').attr('style', 'display:none'); // Show the regular "Publish" button
+            $('.editor-post-publish-button').attr('style', 'display:none'); // Hide the regular "Update" button
         }
 
         const showWarningModal = () => {
-            $('.ppc-modal-warn').attr('style', 'display:block');
+            $('.ppc-modal-warn').attr('style', 'display:block'); // Modal warning you before publishing or updating
         }
 
         const showPreventModal = () => {
-            $('.ppc-modal-prevent').attr('style', 'display:block');
+            $('.ppc-modal-prevent').attr('style', 'display:block'); // Modal preventing you from publishing or updating
         }
 
         const hideModals = () => {
             $('.ppc-modal-prevent').add('.ppc-modal-warn').attr('style', 'display:none');
         }
 
-        //function to be executed when the itemlist changes.
-        var ppc_checkbox_function = function() {
-            // check if all the required && recommended checklists are checked
-            numItemsComplete = $items.filter('.status-yes').length
-
-            // if all the checkboxes are checked (lets publish!!)
-            if (numItems === numItemsComplete) {
-                hideCustomButtons();
-
-                isPublished() ? showUpdateButton() : showPublishButton()
-
-            // if not all the checkboxes are checked (lets not publish!!)
-            } else {
-                // check number of required checkboxes still unchecked
-                ppc_error_level = $items.filter('.pp-checklists-block.status-no').length ? REQUIRED : RECOMMENDED;
-
-                if (isPublished()) {
-                    hideUpdateButton();
-                    showCustomUpdateButton();
-                } else {
-                    hidePublishButton();
-                    showCustomPublishButton();
-                }
-            }
-        }
-
-        setTimeout(ppc_checkbox_function, 1000);
-
-        /* Observer that triggers whenever a checkbox's state changes */
-        const checkboxObserver = new MutationObserver((e) => ppc_checkbox_function());
-        checkboxObserver.observe($itemsContainer[0], {
-            subtree: true,
-            attributeFilter: ['class']}
-        );
-
-
-        $(document).on('click', "#ppc-update, #ppc-publish", function() {
-            ppc_error_level.option == REQUIRED.option ?
-                showPreventModal() : // Prevent User from Publishing Page/Post
-                showWarningModal() // Warn User Before Publishing
-        })
-
-        // Click "Publish anyway" on the "warning" modal
-        $(document).on('click', ".ppc-popup-options-publishanyway", function() {
-
-            hideModals(); // Hide the warning modal
-
-            // If it's an update to a post
-            if (isPublished()) {
-                hideCustomButtons();
-                showUpdateButton(); // Show the real "Update" button
-                $('.editor-post-publish-button').trigger('click');
-                hideUpdateButton(); // Hide the real "Update" button
-                showCustomUpdateButton(); // Show the custom "Update" button
-
-            // If it's being published
-            } else {
-                hideCustomButtons();
-                showPublishButton(); // Show the real "publish" button
-                $('.editor-post-publish-panel__toggle').trigger('click'); // Click the real "publish" button
-
-                // check if a slide-out panel with a publish button appears
-                const $publishButton = $('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
-                if($publishButton.length && $publishButton.text() === 'Publish') {
-                    $publishButton.trigger('click'); // Click the "publish" button in the slideout panel
-                }
-            }
-        });
-        
         /**
-         * Open the "settings" panel if it is closed
-         * Switch to the "Post" tab if we are on the "Block" tab
-         * Open the "Checklist" bix if it is collapsed
+         * - Open the "settings" panel if it is closed
+         * - Switch to the "Post" tab if we are on the "Block" tab
+         * - Open the "Checklist" box if it is collapsed
          */
-        const openPanel = () => {
+         const openSettingsPanel = () => {
             // Open the "Settings" panel if it is closed
             const $settingsButton = $('.edit-post-header__settings button[aria-label="Settings"]')
             if($settingsButton.attr('aria-expanded') === 'false') {
@@ -166,9 +90,9 @@ jQuery(document).ready(
                 $(metaboxID).attr('class', 'postbox');
             }
         }
-
+        
         /**
-         * Scroll to the metabox and apply temp background colour to draw attention
+         * Scroll to the checklists metabox and apply temp background colour to draw attention
          *
          * @param string _metaboxID The id attr of the "Checklists" metabox
          */
@@ -188,9 +112,80 @@ jQuery(document).ready(
             }, 1000)
         }
 
-        // Click "Don't publish" on the "warning" modal, or click "Okay" on the "not allowed to publish" modal
+        /* ====== Active functions: for syncing interface based on the "state" of requirements checklists ====== */
+
+        // Function to be executed when the itemlist changes.
+        var ppc_checkbox_function = function() {
+            // check if all the required && recommended checklists are checked
+            numItemsComplete = $items.filter('.status-yes').length
+
+            if ($items.length === numItemsComplete) { // if all checkboxes are complete, ready to publish or update
+                hideCustomButtons();
+                isPublished() ? showUpdateButton() : showPublishButton()
+            } else { // if not all checkboxes are complete, don't publish or update
+                // see if 'required' checkboxes are still unchecked
+                errorLevel = $items.filter('.pp-checklists-block.status-no').length ? REQUIRED : RECOMMENDED;
+
+                if (isPublished()) {
+                    hideUpdateButton();
+                    showCustomUpdateButton();
+                } else {
+                    hidePublishButton();
+                    showCustomPublishButton();
+                }
+            }
+        }
+
+        // Run on pageload, after interface has loaded (less than 500ms and the Publish/Update buttons aren't there)
+        setTimeout(ppc_checkbox_function, 1200);
+
+        /* ====== Events ====== */
+
+        /* Observer that triggers whenever a checkbox's state changes */
+        const checkboxObserver = new MutationObserver((e) => ppc_checkbox_function());
+        checkboxObserver.observe($itemsContainer[0], {
+            subtree: true,
+            attributeFilter: ['class']}
+        );
+
+        // Trigger whenever the custom "publish" or "update" buttons are clicked
+        $(document).on('click', "#ppc-update, #ppc-publish", function() {
+            errorLevel === REQUIRED ?
+                showPreventModal() : // Prevent User from Publishing Page/Post
+                showWarningModal() // Warn User Before Publishing
+        })
+
+        // Warning modal: click "Publish anyway"
+        $(document).on('click', ".ppc-popup-options-publishanyway", function() {
+
+            hideModals(); // Hide the warning modal
+
+            // If it's an update to a post
+            if (isPublished()) {
+                hideCustomButtons();
+                showUpdateButton(); // Show the "Update" button
+                $('.editor-post-publish-button').trigger('click'); // Click the "Update" button
+                hideUpdateButton(); // Hide the "Update" button
+                showCustomUpdateButton(); // Show the custom "Update" button
+
+            // If it's being published
+            } else {
+                hideCustomButtons();
+                showPublishButton(); // Show the real "publish" button
+                $('.editor-post-publish-panel__toggle').trigger('click'); // Click the real "publish" button
+
+                // check if a slide-out panel with a publish button appears
+                const $publishButton = $('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
+                if($publishButton.length && $publishButton.text() === 'Publish') {
+                    $publishButton.trigger('click'); // Click the "publish" button in the slideout panel
+                }
+            }
+        });
+
+        // Warning modal: click "Don't publish"
+        // Prevent modal: click "Okay"
         $(document).on('click', ".ppc-popup-option-dontpublish, .ppc-popup-option-okay", function() {
-            openPanel();
+            openSettingsPanel();
             hideModals(); // Hide the "warning"/"prevent" modal
             scrollToMetabox(metaboxID); // scroll the "pre-publish checklists" metabox into view
         });

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,39 +1,24 @@
 jQuery(document).ready(    
     function($) {
 
-        /* Assigning vars: Their vars (get rid of these) */
-        var ppc_checkboxes = jQuery('.ppc_checkboxes[type="checkbox"]');
-        var ppc_checkboxes_length = jQuery('.ppc_checkboxes[type="checkbox"]').length;
-        var countCheckedppc_checkboxes = ppc_checkboxes.filter(':checked').length;
 
-        /* ~TESTED */
 
         /* Assigning vars: Our vars */
-        const ppc_error_level = {option: 2}; // 1 is "required", 2 is "recommended"
+        const ppc_error_level = {option: 1}; // 1 is "required", 2 is "recommended"
         const $items = $('.pp-checklists-req')
         const numItems = $items.length
-        const $requiredItems = $items.filter('.pp-checklists-block')
-        const numRequiredItems = $requiredItems.length
-        const $recommendedItems = $items.filter('.pp-checklists-warning')
-        const numRecommendedItems = $recommendedItems.length
         const metaboxID = '#pp_checklist_meta'
-
-        console.log('items', $items)
-        console.log('numItems', numItems)
 
         // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
         // .editor-post-publish-button          = "update" button for already-published posts
 
         //function to be executed when the itemlist changes.
-        
         var ppc_checkbox_function = function() {
             // check if all the required && recommended checklists are checked
-            console.log('ppc_checkbox_function called')
+
             // TODO: this length is off, it happens too quickly
             numCheckedItems = $items.filter('.status-yes').length
             console.log('numCheckedItems', numCheckedItems)
-
-            /* ~END TESTED */
 
             if (numItems === numCheckedItems) { // if all the checkboxes are checked (lets publish!!)
                 console.log('all items are checked')
@@ -41,19 +26,17 @@ jQuery(document).ready(
                     jQuery('.edit-post-header__settings').children(jQuery('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
                     jQuery('.edit-post-header__settings').children(jQuery('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
                     jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
-                } else if (jQuery('.editor-post-publish-button').length == 1) {
-                    jQuery('.edit-post-header__settings').children(':eq(2)').after(jQuery('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Publish" button
-                    jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+                } else if (jQuery('.editor-post-publish-button').length == 1) { // if "Update"
+                    jQuery('.edit-post-header__settings').children(':eq(2)').after(jQuery('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Update" button
+                    jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Update" button
                 }
-            /* ~TESTED */
+
             // if not all the checkboxes are checked (lets not publish!!)
             } else if (numItems !== numCheckedItems) { 
                 console.log('all items are NOT checked')
 
                 // if NOT all the checkboxes are checked (don't publish!!)
                 if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
-                    console.log('toggle length == 1')
-
                     jQuery('#ppc-update').attr('style', 'display:none'); // hide the custom "update" button
                     jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide the "publish" button
                     jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after(jQuery('#ppc-publish').attr('style', 'display:inline-flex')); // (I think) show the custom "Publish" button
@@ -72,7 +55,6 @@ jQuery(document).ready(
                 }
             }
         }
-
 
         setTimeout(ppc_checkbox_function, 1000);
         /* ~END TESTED */

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -60,11 +60,11 @@ jQuery(document).ready(
         }
 
         const showWarningModal = () => {
-            $('.ppc-modal-warn').attr('style', 'display:block'); // Modal warning you before publishing or updating
+            $('.ppc-modal-warn').attr('style', 'display:block').find('*[tabindex]').first().focus(); // Modal warning you before publishing or updating
         }
 
         const showPreventModal = () => {
-            $('.ppc-modal-prevent').attr('style', 'display:block'); // Modal preventing you from publishing or updating
+            $('.ppc-modal-prevent').attr('style', 'display:block').find('*[tabindex]').first().focus(); // Modal preventing you from publishing or updating
         }
 
         const hideModals = () => {
@@ -191,6 +191,13 @@ jQuery(document).ready(
                 }
             }
         });
+
+        $(document).on('click', '.ppc-modal-warn', function(e) {
+            // only if they click the grey background (outside) of the modal
+            if(e.currentTarget === e.target) {
+                hideModals(); // Hide the "warning"/"prevent" modal
+            }
+        })
 
         // Warning modal: click "Don't publish"
         // Prevent modal: click "Okay"

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -9,7 +9,7 @@ jQuery(document).ready(
         /* ~TESTED */
 
         /* Assigning vars: Our vars */
-        const ppc_error_level = {option: 1}; // 1 is "required", 2 is "recommended"
+        const ppc_error_level = {option: 2}; // 1 is "required", 2 is "recommended"
         const $items = $('.pp-checklists-req')
         const numItems = $items.length
         const $requiredItems = $items.filter('.pp-checklists-block')
@@ -45,11 +45,12 @@ jQuery(document).ready(
                     jQuery('.edit-post-header__settings').children(':eq(2)').after(jQuery('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Publish" button
                     jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
                 }
+            /* ~TESTED */
             // if not all the checkboxes are checked (lets not publish!!)
             } else if (numItems !== numCheckedItems) { 
                 console.log('all items are NOT checked')
 
-                // if not all the checkboxes are checked (lets not publish!!)
+                // if NOT all the checkboxes are checked (don't publish!!)
                 if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
                     console.log('toggle length == 1')
 
@@ -62,7 +63,6 @@ jQuery(document).ready(
                     }
                 // I am pretty sure this is the difference between an already published post and a new post
                 } else if (jQuery('.editor-post-publish-button').length == 1) {
-                    /* ~TESTED */
                     jQuery('.editor-post-publish-button').attr('style', 'display:none');
                     jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after(jQuery('#ppc-update').attr('style', 'display:inline-flex'));
                     if (jQuery('#ppc-update').length == 0) {
@@ -77,60 +77,32 @@ jQuery(document).ready(
         setTimeout(ppc_checkbox_function, 1000);
         /* ~END TESTED */
 
+        /* NOT WORKING */
         // Click "switch to draft" button (unpublish a post)
         jQuery(document).on('click', '.editor-post-switch-to-draft', function() {
+            console.log('CLICK')
             // remove the custom "update" button, show the custom "publish" button
             jQuery('#ppc_update').attr('style', 'display:none');
             jQuery('#ppc_publish').attr('style', 'display:inline-block');
+            ppc_checkbox_function();
         });
 
+        /* ~TESTED */
 
-        // not sure what this is
-        if (jQuery('#publish').length !== 1) {
-            setTimeout(
-                function() {
-                    if (ppc_checkboxes_length != countCheckedppc_checkboxes) {
-                        // new article
-                        if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
-                            jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide "publish" the button
-                        } else if (jQuery('.editor-post-publish-button').length == 1) {
-                            jQuery('.editor-post-publish-button').attr('style', 'display:none'); // hide the "update" button
-                        }
-                        if (jQuery('.edit-post-header__settings').find('.editor-post-save-draft').length != 0) { // if "save draft"
-                            // add a custom "publish" button
-                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
-                        } else if (jQuery('.edit-post-header__settings').find('.editor-post-switch-to-draft').length == 1) { // if "switch to draft"
-                            // add a custom "update" button
-                            jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
-                        } else if (jQuery('.edit-post-header__settings').find('.editor-post-switch-to-draft').length == 0) {  // if no "switch to draft"
-                            // add a custom "publish" button
-                            jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
-                        }
-                    }
-                }, 10
-            );
-
-            /**
-             * "ppc_error_level" is in the plugin settings
-             * 
-             * - 1: Prevent User from Publishing Page/Post
-             * - 2: Warn User Before Publishing
-             * - 3: Do Nothing and Publish
-             */ 
-            if (ppc_error_level.option == 1 || ppc_error_level.option == 2) {
-                // run "ppc_checkbox_function" when the checkboxes are updated 
-                ppc_checkboxes.change(ppc_checkbox_function);
-            }
-        }
+        /**
+         * "ppc_error_level.option" is in the plugin settings
+         *
+         * - 1: Prevent User from Publishing Page/Post
+         * - 2: Warn User Before Publishing
+         * - 3: Do Nothing and Publish
+         */
 
         //  Warn User Before Publishing
         if (ppc_error_level.option == 2) {
             // Show the "warning" modal
-            /* ~TESTED */
             jQuery(document).on('click', "#ppc-update", function() {
                 jQuery('.ppc-modal-warn').attr('style', 'display:block');
             });
-            /* ~END TESTED */
             jQuery(document).on('click', "#ppc-publish", function() {
                 jQuery('.ppc-modal-warn').attr('style', 'display:block');
             });
@@ -144,6 +116,7 @@ jQuery(document).ready(
                 jQuery('.ppc-modal-prevent').attr('style', 'display:block');
             });
         }
+
         // Click "Publish anyway" on the "warning" modal
         jQuery(document).on('click', ".ppc-popup-options-publishanyway", function() {
             // Hide the warning modal
@@ -157,7 +130,15 @@ jQuery(document).ready(
                 // Show the real "publish" button
                 jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex');
                 // Click the real "publish" button
-                jQuery('.editor-post-publish-panel__toggle').trigger('click', 'publish');
+                jQuery('.editor-post-publish-panel__toggle').trigger('click');
+
+                // check if "interface-interface-skeleton__actions" contains a "publish" button
+                const $publishButton = jQuery('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
+                if($publishButton.length && $publishButton.text() === 'Publish') {
+                    // Click the "publish" button in the slideout panel
+                    $publishButton.trigger('click');
+                }
+
             // If it's an update to a post
             } else if (jQuery('.editor-post-publish-button').length == 1) {
                 // Hide custom "update" button
@@ -165,20 +146,14 @@ jQuery(document).ready(
                 // Show the real "Update" button
                 jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex');
                 // Click the real "Update" button
-                jQuery('.editor-post-publish-button').trigger('click', 'update');
+                jQuery('.editor-post-publish-button').trigger('click');
                 // Hide the real "Update" button
                 jQuery('.editor-post-publish-button').attr('style', 'display:none');
                 // Show the custom "Update" button
                 jQuery('#ppc-update').attr('style', 'display:inline-block');
-            } else {
-                // Hide the modal, and click the publish button
-                ppc_publish_flag = 1;
-                jQuery('.ppc-modal-warn').attr('style', 'display:none');
-                jQuery('#publish').trigger('click', 'publish');
             }
         });
         
-        /* ~TESTED */
         const scrollToMetabox = (_metaboxID) => {
             document.querySelector(_metaboxID).scrollIntoView({
                 behavior: 'smooth',

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,4 +1,4 @@
-jQuery(document).ready(    
+jQuery(document).ready(
     function($) {
 
         /**
@@ -29,13 +29,13 @@ jQuery(document).ready(
 
             // if all the checkboxes are checked (lets publish!!)
             if (numItems === numCheckedItems) {
-                if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
-                    jQuery('.edit-post-header__settings').children(jQuery('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
-                    jQuery('.edit-post-header__settings').children(jQuery('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
-                    jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
-                } else if (jQuery('.editor-post-publish-button').length == 1) { // if "Update"
-                    jQuery('.edit-post-header__settings').children(':eq(2)').after(jQuery('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Update" button
-                    jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Update" button
+                if ($('.editor-post-publish-panel__toggle').length == 1) {
+                    $('.edit-post-header__settings').children($('#ppc-update').attr('style', 'display:none')); // Hide the custom "Update" button
+                    $('.edit-post-header__settings').children($('#ppc-publish').attr('style', 'display:none')); // Hide the custom "Publish" button
+                    $('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex'); // Show the regular "Publish" button
+                } else if ($('.editor-post-publish-button').length == 1) { // if "Update"
+                    $('.edit-post-header__settings').children(':eq(2)').after($('#ppc-update').attr('style', 'display:none')); // (I think) Hide the custom "Update" button
+                    $('.editor-post-publish-button').attr('style', 'display:inline-flex'); // Show the regular "Update" button
                 }
 
             // if not all the checkboxes are checked (lets not publish!!)
@@ -45,21 +45,21 @@ jQuery(document).ready(
                 ppc_error_level = $items.filter('.pp-checklists-block.status-no').length ? REQUIRED : RECOMMENDED;
 
                 // if NOT all the checkboxes are checked (don't publish!!)
-                if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
-                    jQuery('#ppc-update').attr('style', 'display:none'); // hide the custom "update" button
-                    jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide the "publish" button
-                    jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after(jQuery('#ppc-publish').attr('style', 'display:inline-flex')); // (I think) show the custom "Publish" button
+                if ($('.editor-post-publish-panel__toggle').length == 1) {
+                    $('#ppc-update').attr('style', 'display:none'); // hide the custom "update" button
+                    $('.editor-post-publish-panel__toggle').attr('style', 'display:none'); // hide the "publish" button
+                    $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after($('#ppc-publish').attr('style', 'display:inline-flex')); // (I think) show the custom "Publish" button
                     // Add the (custom) publish button
-                    if (jQuery('#ppc-publish').length == 0) {
-                        jQuery('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
+                    if ($('#ppc-publish').length == 0) {
+                        $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
                     }
                 // I am pretty sure this is the difference between an already published post and a new post
-                } else if (jQuery('.editor-post-publish-button').length == 1) {
-                    jQuery('.editor-post-publish-button').attr('style', 'display:none');
-                    jQuery('.edit-post-header__settings').find('.editor-post-publish-button').after(jQuery('#ppc-update').attr('style', 'display:inline-flex'));
-                    if (jQuery('#ppc-update').length == 0) {
+                } else if ($('.editor-post-publish-button').length == 1) {
+                    $('.editor-post-publish-button').attr('style', 'display:none');
+                    $('.edit-post-header__settings').find('.editor-post-publish-button').after($('#ppc-update').attr('style', 'display:inline-flex'));
+                    if ($('#ppc-update').length == 0) {
                         // Add the (custom) "update" button
-                        jQuery('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
+                        $('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
                     }
                 }
             }
@@ -82,44 +82,44 @@ jQuery(document).ready(
             }
             else {
                 // Warn User Before Publishing
-                jQuery('.ppc-modal-warn').attr('style', 'display:block');
+                $('.ppc-modal-warn').attr('style', 'display:block');
             }
         })
 
         // Click "Publish anyway" on the "warning" modal
-        jQuery(document).on('click', ".ppc-popup-options-publishanyway", function() {
+        $(document).on('click', ".ppc-popup-options-publishanyway", function() {
             // Hide the warning modal
-            jQuery('.ppc-modal-warn').attr('style', 'display:none');
+            $('.ppc-modal-warn').attr('style', 'display:none');
             // If it's a new post
-            if (jQuery('.editor-post-publish-panel__toggle').length == 1) {
+            if ($('.editor-post-publish-panel__toggle').length == 1) {
                 // Hide custom "publish" button
-                jQuery('#ppc-publish').attr('style', 'display:none');
+                $('#ppc-publish').attr('style', 'display:none');
                 // Hide custom "update" button
-                jQuery('#ppc-update').attr('style', 'display:none');
+                $('#ppc-update').attr('style', 'display:none');
                 // Show the real "publish" button
-                jQuery('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex');
+                $('.editor-post-publish-panel__toggle').attr('style', 'display:inline-flex');
                 // Click the real "publish" button
-                jQuery('.editor-post-publish-panel__toggle').trigger('click');
+                $('.editor-post-publish-panel__toggle').trigger('click');
 
                 // check if "interface-interface-skeleton__actions" contains a "publish" button
-                const $publishButton = jQuery('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
+                const $publishButton = $('.interface-interface-skeleton__actions').find('.editor-post-publish-panel .editor-post-publish-button');
                 if($publishButton.length && $publishButton.text() === 'Publish') {
                     // Click the "publish" button in the slideout panel
                     $publishButton.trigger('click');
                 }
 
             // If it's an update to a post
-            } else if (jQuery('.editor-post-publish-button').length == 1) {
+            } else if ($('.editor-post-publish-button').length == 1) {
                 // Hide custom "update" button
-                jQuery('#ppc-update').attr('style', 'display:none');
+                $('#ppc-update').attr('style', 'display:none');
                 // Show the real "Update" button
-                jQuery('.editor-post-publish-button').attr('style', 'display:inline-flex');
+                $('.editor-post-publish-button').attr('style', 'display:inline-flex');
                 // Click the real "Update" button
-                jQuery('.editor-post-publish-button').trigger('click');
+                $('.editor-post-publish-button').trigger('click');
                 // Hide the real "Update" button
-                jQuery('.editor-post-publish-button').attr('style', 'display:none');
+                $('.editor-post-publish-button').attr('style', 'display:none');
                 // Show the custom "Update" button
-                jQuery('#ppc-update').attr('style', 'display:inline-block');
+                $('#ppc-update').attr('style', 'display:inline-block');
             }
         });
         
@@ -165,22 +165,22 @@ jQuery(document).ready(
         }
 
         // Click "Don't publish" on the "warning" modal
-        jQuery(document).on('click', ".ppc-popup-option-dontpublish", function() {
+        $(document).on('click', ".ppc-popup-option-dontpublish", function() {
             openPanel();
 
             // Hide the "warning" modal
-            jQuery('.ppc-modal-warn').attr('style', 'display:none');
+            $('.ppc-modal-warn').attr('style', 'display:none');
 
             // scroll the "pre-publish checklists" metabox into view
             scrollToMetabox(metaboxID);
         });
 
         // Click "Okay" on the "not allowed to publish" modal
-        jQuery(document).on('click', ".ppc-popup-option-okay", function() {
+        $(document).on('click', ".ppc-popup-option-okay", function() {
             openPanel();
 
             // Hide the "not allowed to publish modal"
-            jQuery('.ppc-modal-prevent').attr('style', 'display:none');
+            $('.ppc-modal-prevent').attr('style', 'display:none');
 
             // scroll the "pre-publish checklists" metabox into view
             scrollToMetabox(metaboxID);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -3,17 +3,18 @@ jQuery(document).ready(
 
         // TODOs:
         // - ✅ Open settings if closed
-        // - Detect when a checkbox is clicked
-        // - Detect when a condition is met
+        // - ✅ Detect when a checkbox is clicked
+        // - ✅ Detect when a condition is met
         // - Detect when unpublished
         // - Check when checkboxes are required or recommended
 
 
         /* Assigning vars: Our vars */
         const ppc_error_level = {option: 1}; // 1 is "required", 2 is "recommended"
-        const $items = $('.pp-checklists-req')
-        const numItems = $items.length
         const metaboxID = '#pp_checklist_meta'
+        const $itemsContainer = $('#pp-checklists-req-box')
+        const $items = $itemsContainer.find('.pp-checklists-req')
+        const numItems = $items.length
 
         // .editor-post-publish-panel__toggle   = "publish" button for unpublished posts 
         // .editor-post-publish-button          = "update" button for already-published posts
@@ -63,6 +64,13 @@ jQuery(document).ready(
         }
 
         setTimeout(ppc_checkbox_function, 1000);
+
+        /* Observer that triggers whenever a checkbox's state changes */
+        const observer = new MutationObserver((e) => ppc_checkbox_function());
+        observer.observe($itemsContainer[0], {
+            subtree: true,
+            attributeFilter: ['class']}
+        );
 
         /* NOT WORKING */
         // Click "switch to draft" button (unpublish a post)

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -1,6 +1,12 @@
 jQuery(document).ready(    
     function($) {
 
+        // TODOs:
+        // - ✅ Open settings if closed
+        // - Detect when a checkbox is clicked
+        // - Detect when a condition is met
+        // - Detect when unpublished
+        // - Check when checkboxes are required or recommended
 
 
         /* Assigning vars: Our vars */
@@ -57,19 +63,18 @@ jQuery(document).ready(
         }
 
         setTimeout(ppc_checkbox_function, 1000);
-        /* ~END TESTED */
 
         /* NOT WORKING */
         // Click "switch to draft" button (unpublish a post)
-        jQuery(document).on('click', '.editor-post-switch-to-draft', function() {
-            console.log('CLICK')
+        jQuery(document).on('click change', '.editor-post-switch-to-draft', function() {
+            console.log('SWITCHED TO DRAFT')
             // remove the custom "update" button, show the custom "publish" button
-            jQuery('#ppc_update').attr('style', 'display:none');
-            jQuery('#ppc_publish').attr('style', 'display:inline-block');
-            ppc_checkbox_function();
+            // jQuery('#ppc_update').attr('style', 'display:none');
+            // jQuery('#ppc_publish').attr('style', 'display:inline-block');
+            // ppc_checkbox_function();
         });
+        /* END NOT WORKING */
 
-        /* ~TESTED */
 
         /**
          * "ppc_error_level.option" is in the plugin settings
@@ -78,7 +83,6 @@ jQuery(document).ready(
          * - 2: Warn User Before Publishing
          * - 3: Do Nothing and Publish
          */
-
         //  Warn User Before Publishing
         if (ppc_error_level.option == 2) {
             // Show the "warning" modal
@@ -136,6 +140,31 @@ jQuery(document).ready(
             }
         });
         
+        /**
+         * Open the "settings" panel if it is closed
+         * Switch to the "Post" tab if we are on the "Block" tab
+         * Open the "Checklist" bix if it is collapsed
+         */
+        const openPanel = () => {
+            // Open the "Settings" panel if it is closed
+            const $settingsButton = $('.edit-post-header__settings button[aria-label="Settings"]')
+            if($settingsButton.attr('aria-expanded') === 'false') {
+                $settingsButton.trigger('click');
+            }
+
+            // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
+            $('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
+            if ($(metaboxID).attr("class") === 'postbox closed') {
+                // Open the "pre-publish checklists" metabox
+                $(metaboxID).attr('class', 'postbox');
+            }
+        }
+
+        /**
+         * Scroll to the metabox and apply temp background colour to draw attention
+         *
+         * @param string _metaboxID The id attr of the "Checklists" metabox
+         */
         const scrollToMetabox = (_metaboxID) => {
             document.querySelector(_metaboxID).scrollIntoView({
                 behavior: 'smooth',
@@ -154,12 +183,8 @@ jQuery(document).ready(
 
         // Click "Don't publish" on the "warning" modal
         jQuery(document).on('click', ".ppc-popup-option-dontpublish", function() {
-            // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
-            jQuery('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
-            if (jQuery(metaboxID).attr("class") === 'postbox closed') {
-                // Open the "pre-publish checklists" metabox
-                jQuery(metaboxID).attr('class', 'postbox');
-            }
+            openPanel();
+
             // Hide the "warning" modal
             jQuery('.ppc-modal-warn').attr('style', 'display:none');
             // scroll the "pre-publish checklists" metabox into view
@@ -168,12 +193,8 @@ jQuery(document).ready(
 
         // Click "Okay" on the "not allowed to publish" modal
         jQuery(document).on('click', ".ppc-popup-option-okay", function() {
-            // click the "Post" tab in the gutenberg side panel (as opposed to the "block" tab)
-            jQuery('.edit-post-sidebar__panel-tab').first().trigger('click', 'publish');
-            if (jQuery(metaboxID).attr("class") === 'postbox closed') {
-                // Open the "pre-publish checklists" metabox
-                jQuery(metaboxID).attr('class', 'postbox');
-            }
+            openPanel();
+
             // Hide the "not allowed to publish modal"
             jQuery('.ppc-modal-prevent').attr('style', 'display:none');
             // scroll the "pre-publish checklists" metabox into view
@@ -181,4 +202,3 @@ jQuery(document).ready(
         });
     }
 );
-/* ~END TESTED */


### PR DESCRIPTION
# Summary | Résumé

This PR adds a bunch of jQuery which adds modals to our checklist feature. Essentially, if you try to publish or update a post without doing all the checks, you get a modal which prevents you from publishing (if required checks are not met) or warns you away from publishing (if only recommended checks are met).

It introduces (basically) a 4-outcome flowchart:

Try to publish/update:

1. All checks met: Publish/update like normal
2. All "required" checks met: Warning modal, but then Publish/update anyway
3. All "required" checks met: Warning modal, decide not to Publish/update, focus the checklist
4. Not all "required" checks met: Prevent publishing modal, focus the checklist

## gif

![Screen Recording 2022-04-20 at 18 27 32](https://user-images.githubusercontent.com/2454380/164293676-7c8d2099-36b1-4f6c-a9c7-f97763d1cc82.gif)

## Notes:

- Most of the original code comes from another plugin, the other file is here: https://github.com/brainstormforce/pre-publish-checklist/blob/master/assets/js/ppc-checkbox.js
- Essentially what is happening is that two hidden modals are added to editing pages, and then the "publish/update" buttons are replaced with custom publish.../update... buttons. Clicking the custom buttons pops up the modals. One modal prevents publishing (if required checks are not met) and one modal 'warns' the user before publishing (if "recommended" checks are not met). Once all checks are met, the regular WP Update/Publish buttons are used and the modals never come up.
- The `ppc_checkbox_function` function does most of the work of making sure the interface is in sync with the data. It runs whenever the checklist items are changed (manually or automatically) and when the post/page status (draft/published) changes.
- The JS file relies on specific classnames for the WordPress Publish/Update buttons, the Modals, and the custom buttons. If those change (which isn't too likely, but not impossible), then the JS is going to break.
- The original English in modals isn't changed in this PR, we can do that in a future PR.
   - The text of the custom publish/update buttons in the JS file also needs to be translated
- I raised an issue in the PublishPress plugin for this functionality, so it may eventually show up: https://github.com/publishpress/PublishPress-Checklists/issues/353
