### PR TITLE
Fix login link on 404 page

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
@@ -18,6 +18,8 @@ class Login
         add_action('lostpassword_post', [$this, 'redirectToSuccessPageIfNoUser'], 10, 2);
 
         add_action('admin_page_access_denied', [$this, 'redirectToNewestBlog'], 98);
+
+        add_filter('login_url', [$this, 'loginUrl'], 15, 3);
     }
 
     public function redirectToNewestBlog(): void
@@ -171,5 +173,40 @@ class Login
         if (! $user_data) {
             return wp_safe_redirect('wp-login.php?checkemail=confirm');
         }
+    }
+
+    /**
+     *
+     * This hook overrides the login_url hook from WPS Hide Login plugin. For some reason,
+     * the plugin version specifically returns '#' on the 404 page. This override will
+     * return `login` for localhost sites, and `sign-in-se-connecter` on the server.
+     *
+     * @param $login_url
+     * @param $redirect
+     * @param $force_reauth
+     *
+     * @return string
+     */
+    public function loginUrl($login_url, $redirect, $force_reauth)
+    {
+        if (is_404()) {
+            return get_site_url() . '/' . get_option('whl_page', 'login');
+        }
+
+        if ($force_reauth === false) {
+            return $login_url;
+        }
+
+        if (empty($redirect)) {
+            return $login_url;
+        }
+
+        $redirect = explode('?', $redirect);
+
+        if ($redirect[0] === admin_url('options.php')) {
+            $login_url = admin_url();
+        }
+
+        return $login_url;
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Login.php
@@ -179,7 +179,7 @@ class Login
      *
      * This hook overrides the login_url hook from WPS Hide Login plugin. For some reason,
      * the plugin version specifically returns '#' on the 404 page. This override will
-     * return `login` for localhost sites, and `sign-in-se-connecter` on the server.
+     * return the configured path or the default `/login`.
      *
      * @param $login_url
      * @param $redirect


### PR DESCRIPTION
# Summary | Résumé

See cds-snc/gc-articles-issues#321

Fixes an issue where the Login link in the header of a 404 page would simply link to `#`.

The root cause was this bit of code in the WPS Hide Login plugin:

```
if ( is_404() ) {
	return '#';
}
```

Assuming the intention here is to not accidentally leak the "hidden" login url from the 404 page. We have decided to include these Sign in links deliberately, and so they should work as intended.

The plugin sets the login_url through a WP filter. This PR overrides that filter with our own which contains most of the same code, replacing the `is_404` bit with our own logic.

## To test
- Setup one or more sites on your localhost
- Note that the default url for WPS Hide Login is `/login` ... you can change this in settings
- Set a login URL for each site you are testing (they can all be the same)
- Logout and visit a page that would trigger a 404, ie `/xxx` or `/my-subsite/xxx`
- Try the Sign in link in the header - it should take you to the appropriate sign in link