### PR TITLE
Ready the checklists modals for translations

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -117,20 +117,20 @@ class Setup
         ?>
         <div class="ppc-modal-warn" >
             <div id="ppc_notifications" class="ppc-popup-warn" tabindex="-1">
-                <h2><?php _e('Pre-Publish Checklist', 'cds-snc'); ?></h2>
-                <p class="ppc-popup-description"><?php _e('Your Pre-Publish Checklist is incomplete. What would you like to do?', 'cds-snc'); ?></p>
+                <h2><?php _e('Are you sure you want to publish?', 'cds-snc'); ?></h2>
+                <p class="ppc-popup-description"><?php _e('There are still recommended items remaining on your checklist. What would you like to do?', 'cds-snc'); ?></p>
                 <div class="ppc-button-wrapper">
-                    <button class="ppc-popup-option-dontpublish"><?php _e("Don't Publish", 'cds-snc'); ?></button>
-                    <button class="ppc-popup-options-publishanyway"><?php _e('Publish Anyway', 'cds-snc'); ?></button>
+                    <button class="ppc-popup-option-dontpublish"><?php _e('Don’t publish', 'cds-snc'); ?></button>
+                    <button class="ppc-popup-options-publishanyway"><?php _e('Publish anyway', 'cds-snc'); ?></button>
                 </div>
             </div>
         </div>
         <div class="ppc-modal-prevent">
             <div id="ppc_notifications" class="ppc-popup-prevent" tabindex="-1">
-                <h2><?php _e('Pre-Publish Checklist', 'cds-snc'); ?></h2>
-                <p class="ppc-popup-description"> <?php _e('Please check all the checklist items before publishing.', 'cds-snc'); ?></p>
+                <h2><?php _e('Publishing not allowed', 'cds-snc'); ?></h2>
+                <p class="ppc-popup-description"> <?php _e('Please complete all the required checklist items before publishing.', 'cds-snc'); ?></p>
                 <div class="ppc-prevent-button-wrapper">
-                    <button class="ppc-popup-option-okay"><?php _e('Okay, Take Me to the List!', 'cds-snc'); ?></button>
+                    <button class="ppc-popup-option-okay"><?php _e('Okay, take me to the list.', 'cds-snc'); ?></button>
                 </div>
             </div>
         </div>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -117,22 +117,26 @@ class Setup
         ?>
         <div class="ppc-modal-warn" >
             <div id="ppc_notifications" class="ppc-popup-warn" tabindex="-1">
-                <h2><?php esc_html_e('Pre-Publish Checklist', 'pre-publish-checklist'); ?></h2>
-                <p class="ppc-popup-description"><?php esc_html_e('Your Pre-Publish Checklist is incomplete. What would you like to do?', 'pre-publish-checklist'); ?></p>
+                <h2><?php _e('Pre-Publish Checklist', 'cds-snc'); ?></h2>
+                <p class="ppc-popup-description"><?php _e('Your Pre-Publish Checklist is incomplete. What would you like to do?', 'cds-snc'); ?></p>
                 <div class="ppc-button-wrapper">
-                    <button class="ppc-popup-option-dontpublish"><?php esc_html_e("Don't Publish", 'pre-publish-checklist'); ?></button>
-                    <button class="ppc-popup-options-publishanyway"><?php esc_html_e('Publish Anyway', 'pre-publish-checklist'); ?></button>
+                    <button class="ppc-popup-option-dontpublish"><?php _e("Don't Publish", 'cds-snc'); ?></button>
+                    <button class="ppc-popup-options-publishanyway"><?php _e('Publish Anyway', 'cds-snc'); ?></button>
                 </div>
             </div>
         </div>
         <div class="ppc-modal-prevent">
             <div id="ppc_notifications" class="ppc-popup-prevent" tabindex="-1">
-                <h2><?php esc_html_e('Pre-Publish Checklist', 'pre-publish-checklist'); ?></h2>
-                <p class="ppc-popup-description"> <?php esc_html_e('Please check all the checklist items before publishing.', 'pre-publish-checklist'); ?></p>
+                <h2><?php _e('Pre-Publish Checklist', 'cds-snc'); ?></h2>
+                <p class="ppc-popup-description"> <?php _e('Please check all the checklist items before publishing.', 'cds-snc'); ?></p>
                 <div class="ppc-prevent-button-wrapper">
-                    <button class="ppc-popup-option-okay"><?php esc_html_e('Okay, Take Me to the List!', 'pre-publish-checklist'); ?></button>
+                    <button class="ppc-popup-option-okay"><?php _e('Okay, Take Me to the List!', 'cds-snc'); ?></button>
                 </div>
             </div>
+        </div>
+        <div class="ppc-button-container">
+            <button type="button" class="components-button is-button is-primary ppc-publish" id="ppc-publish"><?php _e('Publish…', 'cds-snc'); ?></button>
+            <button type="button" class="components-button is-button is-primary ppc-publish" id="ppc-update"><?php _e('Update…', 'cds-snc'); ?></button>
         </div>
         <?php
     }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/css/styles.css
@@ -8,7 +8,7 @@
   display: none;
 }
 
-/* All the CSS needed for the modal */
+/* CSS needed for the custom buttons and modal */
 #ppc-update, #ppc-publish {
   padding: 0 12px 2px;
   height: 33px;
@@ -108,4 +108,8 @@
 
 .ppc-popup-description {
   padding: 0px 20px 0px 20px;
+}
+
+.ppc-button-container {
+  display: none;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -23,9 +23,10 @@ jQuery(document).ready(
             $('#ppc-update').attr('style', 'display:none'); // Hide custom "Update" button
             $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after($('#ppc-publish').attr('style', 'display:inline-flex')); // Show the custom "Publish" button
 
-            // if "Publish" button doesn't exist yet, add it
-            if ($('#ppc-publish').length == 0) {
-                $('.edit-post-header__settings').find('.editor-post-publish-panel__toggle').after('<button type="button" class="components-button is-button is-primary ppc-publish" id="ppc-publish">Publish…</button>');
+            // if custom "Publish" button doesn't exist inside of wp-content, detatch it from elsewhere and append it after "Publish" button
+            if ($('#wp-content #ppc-publish').length == 0) {
+                $button = $(document).find('#ppc-publish').remove()
+                $button.insertAfter($('.edit-post-header__settings').find('.editor-post-publish-panel__toggle'));
             }
         }
 
@@ -35,7 +36,8 @@ jQuery(document).ready(
 
             // if "Update" button doesn't exist yet, add it
             if ($('#ppc-update').length == 0) {
-                $('.edit-post-header__settings').children(':eq(2)').after('<button type="button" class="components-button  is-button is-primary ppc-publish" id="ppc-update">Update…</button>');
+                $button = $(document).find('#ppc-update').remove()
+                $button.insertAfter($('.edit-post-header__settings').children(':eq(2)'))
             }
         }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -194,7 +194,7 @@ jQuery(document).ready(
             }
         });
 
-        $(document).on('click', '.ppc-modal-warn', function(e) {
+        $(document).on('click', '.ppc-modal-warn, .ppc-modal-prevent', function(e) {
             // only if they click the grey background (outside) of the modal
             if(e.currentTarget === e.target) {
                 hideModals(); // Hide the "warning"/"prevent" modal


### PR DESCRIPTION
# Summary | Résumé

This PR changes the text and the text-domain for the modals, and also moves the HTML for the custom button into the PHP layer (so that we can translate it). This content shouldn't be considered "final", but more like 'good enough for now' content.

There's also a bugfix in here: if you click the grey background while the "prevent" modal is open, the modal closes.

## Screenshots

|               | before | after |
|---------------|--------|-------|
| warning modal |   <img width="400" alt="Screen Shot 2022-04-21 at 18 21 29" src="https://user-images.githubusercontent.com/2454380/164516820-f67c16c2-bbce-4811-96ec-82c5c5b9cdf9.png">   |  <img width="400" alt="Screen Shot 2022-04-21 at 18 28 57" src="https://user-images.githubusercontent.com/2454380/164517275-84d50d2e-068a-4bcd-8e31-daf7f9365f7e.png">    |
| prevent modal |   <img width="400" alt="Screen Shot 2022-04-21 at 18 21 12" src="https://user-images.githubusercontent.com/2454380/164516813-4c75b85d-491a-4e9d-a919-e777e5d2c4e0.png">   |  <img width="400" alt="Screen Shot 2022-04-21 at 18 17 52" src="https://user-images.githubusercontent.com/2454380/164516802-c7dbb46c-c066-45d9-ab8e-d8bf1476a65d.png">    |

