### PR TITLE
Add Table of contents pattern

### DIFF
--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -220,6 +220,11 @@ if (! function_exists('cds_register_block_patterns')) :
                 'categories'    => array( 'homepage' ),
                 'content'       => cds_get_block_pattern_markup('homepage/landing'),
             ),
+            'cds/toc' => array(
+                'title'         => esc_html__('Table of contents', 'cds-snc'),
+                'categories'    => array( 'homepage' ),
+                'content'       => cds_get_block_pattern_markup('homepage/toc'),
+            ),
         ));
 
         // Register block patterns.

--- a/wordpress/wp-content/themes/cds-default/inc/block-patterns/homepage/toc.php
+++ b/wordpress/wp-content/themes/cds-default/inc/block-patterns/homepage/toc.php
@@ -1,0 +1,3 @@
+<!-- wp:list {"className":"toc"} -->
+<ul class="toc"><li><a href="http://canada.ca">What this service offers</a></li><li><a href="http://canada.ca">Who is eligible</a></li><li><a href="http://canada.ca">What do you need before you start</a></li><li><a href="http://canada.ca">How to apply</a></li><li><a href="http://canada.ca">After you apply</a></li></ul>
+<!-- /wp:list -->

--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -1,15 +1,44 @@
-(function($) {
+function createToc() {
+
+  if (!document.querySelector(".toc")) {
+    return;
+  }
+
+  function wrap(el, wrapper, classList) {
+    el.parentNode.insertBefore(wrapper, el);
+    wrapper.appendChild(el);
+    wrapper.classList.add(...classList)
+  }
+
+  try {
+    const ulStyles = ["lst-spcd", "col-md-12"];
+    document.querySelectorAll('.toc').forEach(x => x.classList.add(...ulStyles));
+
+    const liStyles = ["col-md-4", "col-sm-6"];
+    document.querySelectorAll('.toc li').forEach(x => x.classList.add(...liStyles));
+
+    const aStyles = ["list-group-item"];
+    document.querySelectorAll('.toc li a').forEach(x => x.classList.add(...aStyles));
+
+    wrap(document.querySelector('.toc'), document.createElement('div'), ["row", "toc-row-wrapper"]);
+    wrap(document.querySelector('.toc-row-wrapper'), document.createElement('div'), ["gc-stp-stp"]);
+  } catch (e) {
+    // no-op
+  }
+}
+
+(function ($) {
 
   const $menuToggle = $('button.navbar-toggler');
   const $itemWithSubmenu = $('.menu-item-has-children');
 
-  $menuToggle.on('click', function(e) {
+  $menuToggle.on('click', function (e) {
     // toggle "aria-expanded"
     const expanded = e.target.getAttribute('aria-expanded') === 'false' ? true : false;
     $menuToggle.attr("aria-expanded", expanded);
 
     // set the submenu to "expanded" if the mobile nav is opened
-    if(expanded === true) {
+    if (expanded === true) {
       $itemWithSubmenu.attr('aria-expanded', true);
     }
 
@@ -19,16 +48,18 @@
   })
 
   $itemWithSubmenu.on(
-    'focusin mouseover', function(e) {
+    'focusin mouseover', function (e) {
       // if target is within submenu, "aria-expanded" is true
       if ($.contains($itemWithSubmenu[0], e.target)) {
         $itemWithSubmenu.attr('aria-expanded', true);
       }
-    }).on('focusout mouseout', function(e) {
+    }).on('focusout mouseout', function (e) {
       // if the focused element is outside of submenu, "aria-expanded" is false
       if (!$.contains($itemWithSubmenu[0], document.activeElement)) {
         $itemWithSubmenu.attr('aria-expanded', false);
       }
     })
+
+  createToc();
 
 })(jQuery);


### PR DESCRIPTION
Adds a Table of contents pattern as requested in https://github.com/cds-snc/gc-articles-issues/issues/327 .

This is more of a proof of concept vs finished code but I think it's worth adding.

Noting there's no interface to add a class to one of the `<a>` tags for the active state but there might be at some point see

https://github.com/WordPress/gutenberg/issues/23011

With active class applied to the  `<a>`  using the code editor
<img width="1247" alt="Screen Shot 2022-04-22 at 10 10 42 AM" src="https://user-images.githubusercontent.com/62242/164731475-366874c2-650b-4c81-95e9-947e62230fda.png">


