### PR TITLE
Intranet improvements

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor-and-public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor-and-public.css
@@ -88,6 +88,12 @@ body:not(.wp-admin) table tbody tr td,
   margin: 10px 0 20px 0;
 }
 
+/* has-background divs: usually people use these as little panels */
+.has-background {
+  padding: 11.5px 11.5px 6.25px 11.5px; /* 11.25 is the bottom margin of our paragraphs */
+  border-radius: 2px;
+}
+
 /* Details */
 /* Remove bottom margin on open details elements and open alerts */
 section[class^="wp-block"] details[open],

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -79,6 +79,11 @@ header .gcweb-menu {
   height: auto;
 }
 
+/* Search bar */
+header #wb-srch .submit {
+  top: 16px;
+}
+
 /* Hide search bar */
 .hide-search-bar header .brand {
   margin-bottom: 20px;


### PR DESCRIPTION
# Summary | Résumé

This PR adds a couple of small CSS fixes to improve the CDS intranet site that we now have up and running.

1. Fix the search button in the search bar: align it so that it sits inside the search input
2. Add padding to divs with an explicit background colour: they are using it like a panel and currently it looks terrible with no padding

## Screenshots

### Fix for search button 

| before | after |
|--------|-------|
|  Search button not aligned with the search input      |   Now it is    |
|  <img width="1190" alt="Screen Shot 2022-04-28 at 16 27 50" src="https://user-images.githubusercontent.com/2454380/165791763-a5ec4d4e-4603-4644-bad8-7dd8ee53f945.png">    |   <img width="1190" alt="Screen Shot 2022-04-28 at 16 27 43" src="https://user-images.githubusercontent.com/2454380/165791754-d2d2a4cc-c5cc-49e8-83a9-b964825823c4.png">  |

### More padding for panels

| before | after |
|--------|-------|
|  Text is crowded in div with background colour     |   Now it has more padding  |
|  <img width="1363" alt="Screen Shot 2022-04-28 at 16 39 24" src="https://user-images.githubusercontent.com/2454380/165791774-9f975bb4-3cf4-41df-b5da-2426b2c52ccb.png">    |  <img width="1363" alt="Screen Shot 2022-04-28 at 16 39 20" src="https://user-images.githubusercontent.com/2454380/165791767-4b0dd992-4481-4465-a934-3ea519351be1.png">  |


