### PR TITLE
Allow GC Admins, Editors, and Writers to embed iFrames

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Profile.php
@@ -15,6 +15,9 @@ class Profile
         add_action('wpml_user_profile_options', [$this, 'wpmlOptions']);
         add_action('additional_capabilities_display', [$this, 'yoastOptions']);
 
+        add_action('edit_user_profile', [$this, 'displayUnfilteredHTMLMeta']);
+        add_action('edit_user_profile_update', [$this,'updateUnfilteredHTMLMeta']);
+
         if (is_admin()) {
             remove_action('admin_color_scheme_picker', 'admin_color_scheme_picker');
             remove_action('personal_options', 'wpml_show_user_options');
@@ -155,5 +158,54 @@ class Profile
         echo '<input type="hidden" id="icl_admin_language_for_edit" name="icl_admin_language_for_edit" value="0">';
         echo '<input type="hidden" id="icl_show_hidden_languages" name="icl_show_hidden_languages" value="1">';
         echo '<input type="hidden" id="icl_user_admin_language" name="icl_user_admin_language" value="en">';
+    }
+
+    public function displayUnfilteredHTMLMeta($user)
+    {
+        if (!is_super_admin()) {
+            return;
+        }
+
+        printf('<h3>%s</h3>', __('Unsafe HTML permissions', 'cds-snc'));
+        print "<table class='form-table'>";
+
+        print '<tr>';
+        $allow_unfiltered_html = user_can($user, "allow_unfiltered_html");
+
+        if ($allow_unfiltered_html) {
+            $checked = 'checked';
+        } else {
+            $checked = '';
+        }
+
+        printf(
+            "<th><label for='allow_unfiltered_html'>%s</label></th>",
+            __('Unsafe HTML', 'cds-snc'),
+        );
+        printf(
+            "<td><input value='true' type='checkbox' name='allow_unfiltered_html' id='allow_unfiltered_html' %s /> %s</td>",
+            $checked,
+            __('Allow iFrames', 'cds-snc'),
+        );
+
+        print '</tr>';
+        print '</table>';
+    }
+
+    public function updateUnfilteredHTMLMeta($userId)
+    {
+        if (!is_super_admin()) {
+            return;
+        }
+
+        $user = get_user_by('id', $userId);
+        // these have to both be set for the 'unfiltered html' permission to work
+        $user->remove_cap('unfiltered_html');
+        $user->remove_cap('allow_unfiltered_html');
+
+        if (isset($_POST['allow_unfiltered_html']) && $_POST['allow_unfiltered_html'] === "true") {
+            $user->add_cap('unfiltered_html');
+            $user->add_cap('allow_unfiltered_html');
+        }
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -35,14 +35,11 @@ class Roles
 
     public function addUnfilteredHTMLRole($caps, $cap, $user_id)
     {
-        if (
-            'unfiltered_html' === $cap && (
-                user_can($user_id, 'administrator') ||
-                user_can($user_id, 'gceditor') ||
-                user_can($user_id, 'gcwriter')
-            )
-        ) {
-            $caps = array('unfiltered_html');
+        if ('unfiltered_html' === $cap) {
+            // Checking for "unfiltered_html" here causes an infinite loop
+            if (is_super_admin() || user_can($user_id, "allow_unfiltered_html")) {
+                $caps = array('unfiltered_html');
+            }
         }
         return $caps;
     }
@@ -98,7 +95,8 @@ class Roles
                 'delete_published_pages' => 1,
                 'upload_files' => 1,
                 'edit_theme_options' => 1, // allows editing the "menu" options
-                'unfiltered_html' => 1
+                'unfiltered_html' => 0,
+                'allow_unfiltered_html' => 0
             ],
             'editor' => [
                 'moderate_comments' => 1,
@@ -186,7 +184,8 @@ class Roles
                 'delete_published_pages' => 1,
                 'upload_files' => 1,
                 'edit_theme_options' => 1, // allows editing the "menu" options
-                'unfiltered_html' => 1
+                'unfiltered_html' => 0,
+                'allow_unfiltered_html' => 0
             ],
             'gcwriter' => [
                 'read' => 1,
@@ -215,7 +214,8 @@ class Roles
                 'delete_published_pages' => 0,
                 'upload_files' => 0,
                 'edit_theme_options' => 0, // allows editing the "menu" options
-                'unfiltered_html' => 1
+                'unfiltered_html' => 0,
+                'allow_unfiltered_html' => 0
             ],
             'display_name' => [
                 'administrator' => 'GC Admin',

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -28,6 +28,17 @@ class Roles
         });
 
         add_action('wpseo_activate', [$this, 'removeSEORoles'], 99);
+
+        // Add "unfiltered_html" role to GC Admins
+        add_filter('map_meta_cap', [$this, 'addUnfilteredHTMLRole'], 1, 3);
+    }
+
+    function addUnfilteredHTMLRole($caps, $cap, $user_id)
+    {
+        if ('unfiltered_html' === $cap && user_can($user_id, 'administrator')) {
+            $caps = array('unfiltered_html');
+        }
+        return $caps;
     }
 
     public function removeSEORoles()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -33,9 +33,15 @@ class Roles
         add_filter('map_meta_cap', [$this, 'addUnfilteredHTMLRole'], 1, 3);
     }
 
-    function addUnfilteredHTMLRole($caps, $cap, $user_id)
+    public function addUnfilteredHTMLRole($caps, $cap, $user_id)
     {
-        if ('unfiltered_html' === $cap && user_can($user_id, 'administrator')) {
+        if (
+            'unfiltered_html' === $cap && (
+                    user_can($user_id, 'administrator') ||
+                    user_can($user_id, 'gceditor') ||
+                    user_can($user_id, 'gcwriter')
+                )
+        ) {
             $caps = array('unfiltered_html');
         }
         return $caps;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,7 +8,7 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.1.7', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.1.8', function () {
             if (is_blog_installed()) {
                 $wp_roles = wp_roles();
                 $allRoles = array_keys($wp_roles->roles); // array_keys returns only the slug
@@ -29,7 +29,7 @@ class Roles
 
         add_action('wpseo_activate', [$this, 'removeSEORoles'], 99);
 
-        // Add "unfiltered_html" role to GC Admins
+        // Add "unfiltered_html" role to GC Admins, GC Editors, GC Writers
         add_filter('map_meta_cap', [$this, 'addUnfilteredHTMLRole'], 1, 3);
     }
 
@@ -37,10 +37,10 @@ class Roles
     {
         if (
             'unfiltered_html' === $cap && (
-                    user_can($user_id, 'administrator') ||
-                    user_can($user_id, 'gceditor') ||
-                    user_can($user_id, 'gcwriter')
-                )
+                user_can($user_id, 'administrator') ||
+                user_can($user_id, 'gceditor') ||
+                user_can($user_id, 'gcwriter')
+            )
         ) {
             $caps = array('unfiltered_html');
         }
@@ -97,7 +97,8 @@ class Roles
                 'delete_others_pages' => 1,
                 'delete_published_pages' => 1,
                 'upload_files' => 1,
-                'edit_theme_options' => 1 // allows editing the "menu" options
+                'edit_theme_options' => 1, // allows editing the "menu" options
+                'unfiltered_html' => 1
             ],
             'editor' => [
                 'moderate_comments' => 1,
@@ -184,7 +185,8 @@ class Roles
                 'delete_others_pages' => 1,
                 'delete_published_pages' => 1,
                 'upload_files' => 1,
-                'edit_theme_options' => 1 // allows editing the "menu" options
+                'edit_theme_options' => 1, // allows editing the "menu" options
+                'unfiltered_html' => 1
             ],
             'gcwriter' => [
                 'read' => 1,
@@ -212,7 +214,8 @@ class Roles
                 'delete_others_pages' => 0,
                 'delete_published_pages' => 0,
                 'upload_files' => 0,
-                'edit_theme_options' => 0 // allows editing the "menu" options
+                'edit_theme_options' => 0, // allows editing the "menu" options
+                'unfiltered_html' => 1
             ],
             'display_name' => [
                 'administrator' => 'GC Admin',

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/ListManagerUserProfile.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/ListManagerUserProfile.php
@@ -15,8 +15,6 @@ class ListManagerUserProfile
         $instance = new self();
 
         add_action('edit_user_profile', [$instance, 'displayListManagerMeta']);
-
-        add_action('personal_options_update', [$instance, 'updateListManagerMeta']);
         add_action('edit_user_profile_update', [$instance,'updateListManagerMeta']);
     }
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `unfiltered_html` capability to users who have been approved by a superadmin. Here's what the screenshot looks like:

<img width="381" alt="Screen Shot 2022-05-11 at 18 57 31" src="https://user-images.githubusercontent.com/2454380/167915547-19588f24-c428-48c4-8cba-158a3fda8be6.png">

Unlike our other capabilities, which we can just add to roles during the setup and they will just work, `unfiltered_html` is treated differently.

> User roles other than Super Admin cannot be assigned the `unfiltered_html` capability in WordPress Multisite. You can set it, but then WordPress disables the capability after the fact.

Because of this, we have to add 2 capabilities here:
- add the 'unfiltered_html' capability to select users
- add a custom `allow_unfiltered_html` permission, which we check in the 'map_meta_cap' filter.

Adding `unfiltered_html` to the roles array on its own does not work, but this does.

Resolves this issue: https://github.com/cds-snc/gc-articles-issues/issues/338

Sources:
- https://smartslider.helpscoutdocs.com/article/1983-how-to-give-access-to-smart-slider-for-non-admin-users#multisite
- https://hegeman.me/kb/wordpress-multisite-add-unfiltered-html-capability-to-role/