### PR TITLE
Add use service -- hook for List Manager

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/Back.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/Back.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { Link } from "react-router-dom";
-import { useParams } from "react-router-dom";
 import { __ } from "@wordpress/i18n";
+import { useService } from '../util/useService';
 
 export const Back = () => {
-    const params = useParams();
-    const serviceId = params?.serviceId;
+    const { serviceId } = useService();
     return <Link className="button action" to={{ pathname: `/service/${serviceId}` }}>{__('Go back', 'cds-snc')}</Link>
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/CreateList.tsx
@@ -6,14 +6,13 @@ import { Navigate } from "react-router-dom";
 import { List } from "../types";
 import { useList } from "../store/ListContext";
 import { ListForm } from "./ListForm";
-import { useParams } from "react-router-dom";
+import { useService } from '../util/useService';
 
 export const CreateList = () => {
     const { request, cache, response } = useFetch({ data: [] })
     const [data, setData] = useState({ id: null })
     const { dispatch } = useList();
-    const params = useParams();
-    const serviceId = params?.serviceId;
+    const { serviceId } = useService();
 
     const createList = useCallback(async (formData: List) => {
         await request.post('/list', formData)
@@ -28,15 +27,15 @@ export const CreateList = () => {
     }, [response, request, cache, dispatch]);
 
     const onSubmit: SubmitHandler<List> = data => createList(data);
-    const formData = { 
-        service_id: serviceId, 
+    const formData = {
+        service_id: serviceId,
         language: "en",
         subscribe_redirect_url: "https://articles.alpha.canada.ca/thanks-for-subscribing-merci-pour-votre-labonnement",
         unsubscribe_redirect_url: "https://articles.alpha.canada.ca/unsubscribed-from-mailing-list-labonnement-supprime",
         confirm_redirect_url: "https://articles.alpha.canada.ca/confirmation"
     }
 
-    
+
 
     return data.id ? <Navigate to={`/service/${serviceId}`} replace={true} /> : <ListForm formData={formData} serverErrors={[]} handler={onSubmit} />
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListForm.tsx
@@ -18,8 +18,7 @@ const Asterisk = () => {
 }
 
 export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handler: (list: List) => void, formData: {} | List, serverErrors: FieldError[] }) => {
-    const { state } = useList();
-    const { user } = state;
+    const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
 
     useEffect(() => {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListViewTable.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/ListViewTable.tsx
@@ -10,7 +10,7 @@ import { Spinner } from './Spinner';
 import { DeleteActionLink } from './DeleteActionLink';
 import { ResetActionLink } from './ResetActionLink';
 import { useListFetch } from '../store/UseListFetch';
-import { useParams } from "react-router-dom";
+import { useService } from '../util/useService';
 import { capitalize, getListType } from "../util";
 
 const HeaderStyles = styled.div`
@@ -74,12 +74,9 @@ const updateLink = (serviceId: string | undefined, listId: string) => {
 }
 
 export const ListViewTable = () => {
-    const { state } = useList();
-    const { lists, user } = state;
+    const { state: { lists, user } } = useList();
     const { status } = useListFetch();
-    const params = useParams();
-    const serviceId = params?.serviceId;
-
+    const { serviceId } = useService();
     const columns = React.useMemo(
         () => [
             {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/Messages.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/Messages.tsx
@@ -22,11 +22,11 @@ const Toast = Swal.mixin({
 
 
 export const Messages = () => {
-    const { state } = useList();
+    const { state: { messages } } = useList();
 
-    if (state.messages && state.messages.length >= 1) {
+    if (messages && messages.length >= 1) {
 
-        state.messages.map((item: Message) => {
+        messages.map((item: Message) => {
             if (item.type === "add" || item.type === "delete" || item.type === "reset") {
 
                 Toast.fire({

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/SendTemplate.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/SendTemplate.tsx
@@ -27,8 +27,7 @@ const ListSelect = ({ lists, handleChange }: { handleChange: (val: string) => vo
 export const SendTemplate = () => {
     const { status } = useListFetch();
     const [listId, setListId] = useState<String>("");
-    const { state } = useList();
-    const { lists } = state;
+    const { state: { lists } } = useList();
     const sendTemplate = useSendTemplate(listId);
 
     if (status === "loading") {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/Service.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/Service.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { ListViewTable } from "./ListViewTable";
 import { Messages } from "./Messages";
 import { useList } from "../store/ListContext";
-import { useParams } from "react-router-dom";
+import { useService } from '../util/useService';
 import { Error } from "./Error";
 
 export const Service = () => {
     const { state: { serviceData } } = useList();
-    const params = useParams();
-    const serviceId = params?.serviceId;
+    const { serviceId } = useService();
 
     if (!serviceData) {
         return <Error />;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/UpdateList.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/UpdateList.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { useState, useCallback } from 'react'
 import useFetch from 'use-http';
-import { useParams } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
 import { Navigate } from "react-router-dom";
 import { useList } from "../store/ListContext";
 import { ListForm } from "./ListForm";
 import { useListFetch } from '../store/UseListFetch';
+import { useService } from '../util/useService';
 import { ErrorResponse, ServerErrors, FieldError, List, ListId } from "../types";
 
 const parseError = async (response: Response) => {
@@ -25,13 +25,9 @@ export const UpdateList = () => {
   const { request, cache, response } = useFetch({ data: [] });
   const [responseData, setResponseData] = useState<ListId>({ id: null });
   const [errors, setErrors] = useState<ServerErrors>([]);
-  const { state } = useList();
-
+  const { state: { lists } } = useList();
+  const { serviceId, listId } = useService()
   useListFetch();
-
-  const params = useParams();
-  const serviceId = params?.serviceId;
-  const listId = params?.listId;
 
   const onSubmit: SubmitHandler<List> = data => updateList(listId, data);
 
@@ -52,7 +48,7 @@ export const UpdateList = () => {
 
   }, [response, request, cache]);
 
-  const list = state.lists.filter((list: any) => {
+  const list = lists.filter((list: any) => {
     return list.id === listId
   })[0];
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/UploadList.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/components/UploadList.tsx
@@ -2,20 +2,18 @@ import * as React from 'react';
 import { useState } from 'react'
 import { Importer, ImporterField } from "react-csv-importer";
 import useFetch from 'use-http';
-import { useParams, Navigate } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { ListType } from "../types"
 import { Back } from "./Back";
 import { capitalize } from "../util";
+import { useService } from '../util/useService';
 
 // theme CSS for React CSV Importer
 import "react-csv-importer/dist/index.css";
 
 export const UploadList = () => {
     const [finished, setFinished] = useState<boolean>(false)
-    const params = useParams();
-    const serviceId = params?.serviceId;
-    const listId = params?.listId;
-    const type = params?.type;
+    const { serviceId, listId, type } = useService();
     let uploadType = '';
 
     switch (type) {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/UseListFetch.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/store/UseListFetch.tsx
@@ -1,17 +1,14 @@
 import { useEffect, useState } from 'react';
 import useFetch from 'use-http';
-import { useParams } from "react-router-dom";
 import { useList } from "../store/ListContext";
 import { sendListData } from "./SaveListData"
 import { getListType } from "../util";
 import { List, ListType } from '../types';
+import { useService } from '../util/useService';
 
 export const useListFetch = () => {
-    const { dispatch, state } = useList();
-    const { user } = state;
-    const params = useParams();
-    const serviceId = params?.serviceId;
-
+    const { dispatch, state: { user } } = useList();
+    const { serviceId } = useService();
     const [status, setStatus] = useState('idle');
     const { request, response } = useFetch({ data: [] })
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/util/useService.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/ListManager/app/src/util/useService.tsx
@@ -1,0 +1,9 @@
+import { useParams } from "react-router-dom";
+
+export const useService = () => {
+    const params = useParams();
+    const serviceId = params?.serviceId;
+    const listId = params?.listId;
+    const type = params?.type;
+    return { serviceId, listId, type };
+}


### PR DESCRIPTION
- Adds a useService hook to cleanup duplicated code to pull the service ID and other query params
- This also cleans up some variables using destructuring assignment