### PR TITLE
Add Zendesk API Url to environment

### DIFF
--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -66,18 +66,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       # Load-balancer & database dependency
       - name: Terragrunt plan ecs
@@ -106,7 +96,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: setup terraform tools
+      - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
       - name: Terragrunt apply ecs

--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -106,18 +106,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: Terragrunt apply ecs
         working-directory: infrastructure/terragrunt/env/prod/ecs

--- a/.github/workflows/deploy-staging-container.yml
+++ b/.github/workflows/deploy-staging-container.yml
@@ -97,18 +97,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: Terragrunt apply ecs
         working-directory: infrastructure/terragrunt/env/staging/ecs

--- a/.github/workflows/deploy-staging-container.yml
+++ b/.github/workflows/deploy-staging-container.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/deploy-staging-container.yml
+++ b/.github/workflows/deploy-staging-container.yml
@@ -62,18 +62,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: Terragrunt plan ecs
         uses: cds-snc/terraform-plan@v1
@@ -97,7 +87,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: setup terraform tools
+      - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
       - name: Terragrunt apply ecs

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           ref: ${{ env.TARGET_VERSION }}
 
-      - name: setup terraform tools
+      - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -61,18 +61,8 @@ jobs:
         with:
           ref: ${{ env.TARGET_VERSION }}
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3
         id: filter

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -62,7 +62,7 @@ jobs:
           ref: ${{ env.TARGET_VERSION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -40,6 +40,7 @@ env:
   TF_VAR_wordpress_nonce_salt: ${{ secrets.PRODUCTION_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.PRODUCTION_JWT_AUTH_SECRET_KEY }}
   TF_VAR_wpml_site_key: ${{ secrets.PRODUCTION_WPML_SITE_KEY }}
+  TF_VAR_zendesk_api_url: ${{ secrets.ZENDESK_API_URL }}
 
 jobs:
   environments-manifest:

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -43,6 +43,7 @@ env:
   TF_VAR_wordpress_nonce_salt: ${{ secrets.STAGING_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.STAGING_JWT_AUTH_SECRET_KEY }}
   TF_VAR_wpml_site_key: ${{ secrets.STAGING_WPML_SITE_KEY }}
+  TF_VAR_zendesk_api_url: ${{ secrets.ZENDESK_API_URL }}
 
 jobs:
   terragrunt-apply-staging:

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -57,18 +57,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3
         id: filter

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: setup terraform tools
+      - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           ref: ${{ env.TARGET_VERSION }}
 
-      - name: setup terraform tools
+      - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -61,27 +61,8 @@ jobs:
         with:
           ref: ${{ env.TARGET_VERSION }}
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
-      - name: Install Conftest
-        run: |
-          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
-          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
-          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
-          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
-          && mv conftest /usr/local/bin \
-          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3
         id: filter

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -62,7 +62,7 @@ jobs:
           ref: ${{ env.TARGET_VERSION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -40,6 +40,7 @@ env:
   TF_VAR_wordpress_nonce_salt: ${{ secrets.PRODUCTION_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.PRODUCTION_JWT_AUTH_SECRET_KEY }}
   TF_VAR_wpml_site_key: ${{ secrets.PRODUCTION_WPML_SITE_KEY }}
+  TF_VAR_zendesk_api_url: ${{ secrets.ZENDESK_API_URL }}
 
 jobs:
   environments-manifest:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -51,18 +51,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3
         id: filter

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.0
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -41,6 +41,7 @@ env:
   TF_VAR_wordpress_nonce_salt: ${{ secrets.STAGING_WORDPRESS_NONCE_SALT }}
   TF_VAR_jwt_auth_secret_key: ${{ secrets.STAGING_JWT_AUTH_SECRET_KEY }}
   TF_VAR_wpml_site_key: ${{ secrets.STAGING_WPML_SITE_KEY }}
+  TF_VAR_zendesk_api_url: ${{ secrets.ZENDESK_API_URL }}
 
 jobs:
   terragrunt-plan-staging:

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: setup terraform tools
+      - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
       - uses: cds-snc/paths-filter@v2.10.3

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -34,6 +34,7 @@ The following Terraform variables are required:
 * `default_notify_api_key`: Default Notify API key used before a site has one configured
 * `slack_webhook_url`: Slack incoming webhook to post SNS notifications to
 * `wpml_site_key`: Site Key from WPML
+* `zendesk_api_url`: URL for zendesk api
 
 WordPress [generated secret keys](https://api.wordpress.org/secret-key/1.1/salt/):
 * `wordpress_auth_key`

--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -154,6 +154,10 @@
       {
         "name": "WORDPRESS_NONCE_SALT",
         "valueFrom": "${WORDPRESS_NONCE_SALT}"
+      },
+      {
+        "name": "ZENDESK_API_URL",
+        "valueFrom": ${ZENDESK_API_URL}
       }
     ]
   }

--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -73,6 +73,7 @@ data "template_file" "wordpress_container_definition" {
     WORDPRESS_NONCE_SALT         = aws_secretsmanager_secret_version.wordpress_nonce_salt.arn
     JWT_AUTH_SECRET_KEY          = aws_secretsmanager_secret_version.jwt_auth_secret_key.arn
     WPML_SITE_KEY                = aws_secretsmanager_secret_version.wpml_site_key.arn
+    ZENDESK_API_URL              = aws_secretsmanager_secret_version.zendesk_api_url.arn
 
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.wordpress_ecs_logs.name
     AWS_LOGS_REGION        = var.region

--- a/infrastructure/terragrunt/aws/ecs/iam.tf
+++ b/infrastructure/terragrunt/aws/ecs/iam.tf
@@ -95,7 +95,8 @@ data "aws_iam_policy_document" "wordpress_ecs_task_get_secret_value" {
       aws_secretsmanager_secret_version.wordpress_logged_in_salt.arn,
       aws_secretsmanager_secret_version.wordpress_nonce_salt.arn,
       aws_secretsmanager_secret_version.jwt_auth_secret_key.arn,
-      aws_secretsmanager_secret_version.wpml_site_key.arn
+      aws_secretsmanager_secret_version.wpml_site_key.arn,
+      aws_secretsmanager_secret_version.zendesk_api_url.arn
     ]
   }
 }

--- a/infrastructure/terragrunt/aws/ecs/inputs.tf
+++ b/infrastructure/terragrunt/aws/ecs/inputs.tf
@@ -116,6 +116,11 @@ variable "jwt_auth_secret_key" {
   type        = string
 }
 
+variable "zendesk_api_url" {
+  description = "URL for the zendesk API"
+  type        = string
+}
+
 variable "memory" {
   type = string
 }

--- a/infrastructure/terragrunt/aws/ecs/secrets.tf
+++ b/infrastructure/terragrunt/aws/ecs/secrets.tf
@@ -49,6 +49,15 @@ resource "aws_secretsmanager_secret_version" "wpml_site_key" {
   secret_string = var.wpml_site_key
 }
 
+resource "aws_secretsmanager_secret" "zendesk_api_url" {
+  name = "zendesk_api_url_${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "zendesk_api_url" {
+  secret_id     = aws_secretsmanager_secret.zendesk_api_url.id
+  secret_string = var.zendesk_api_url
+}
+
 resource "aws_secretsmanager_secret" "s3_uploads_bucket" {
   name = "s3_uploads_bucket_${random_string.random.result}"
 }


### PR DESCRIPTION
# Summary | Résumé

Adds the Zendesk API Url to the environment for use by the Request a Site form.

Also includes a change to using cds-snc/terraform-tools-setup replacing a bunch of the old setup actions.
