### PR TITLE
Bugfix: missed quotes around json template value

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -157,7 +157,7 @@
       },
       {
         "name": "ZENDESK_API_URL",
-        "valueFrom": "${ZENDESK_API_URL}""
+        "valueFrom": "${ZENDESK_API_URL}"
       }
     ]
   }

--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -157,7 +157,7 @@
       },
       {
         "name": "ZENDESK_API_URL",
-        "valueFrom": ${ZENDESK_API_URL}
+        "valueFrom": "${ZENDESK_API_URL}""
       }
     ]
   }


### PR DESCRIPTION
# Summary | Résumé

Missed quotes around a value in the container-definitions template
