### PR TITLE
Return nav menus independently of each other via the API

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -17,6 +17,9 @@ class Menus
         add_action('admin_menu', [$this, 'addMenusLinkToAdmin'], 11);
         // BlockGC Admins and GC Editors from seeing "themes" or "customize" pages
         add_action('admin_init', [$this, 'blockAppearancePages']);
+
+        // WPML filter causing nav menu to always be returned in same language
+        add_filter('wpml_disable_term_adjust_id', [$this, 'disableAutomaticTranslationForNavMenus'], 10, 2);
     }
 
     public function removeMenuPages(): void
@@ -162,5 +165,16 @@ class Menus
         } catch (Exception $e) {
             // no-op
         }
+    }
+
+    public function disableAutomaticTranslationForNavMenus($icl_adjust_id_url_filter_off, $term)
+    {
+        // If using the API
+        // AND the "taxonomy" is equal to "nav_menu"
+        if (defined('REST_REQUEST') && property_exists($term, 'taxonomy') && $term->taxonomy === 'nav_menu') {
+            return true;
+        }
+
+        // return nothing otherwise
     }
 }


### PR DESCRIPTION
# Summary | Résumé

Adds a filter that make sure nav menus are always returned independently when being called via the API. Not specific to any theme, and doesn't need WPML to be installed (if it is not installed, nothing will happen).

## Details 

There is a 'helpful' WPML function that will try and always return the nav_menu in the current language of the site. This leads to the same menu being returned twice when you ask for "all menus" via the API, which is NOT what we want.

Thought of adding this only to the Redirector theme, but since the API returns menus the same way in both themes, I can't think of a case when we would want the current behaviour. Better to just change the API response in all cases.

Resolves this ticket: https://github.com/cds-snc/gc-articles-issues/issues/333

