### PR TITLE
Add "Last modified" date to all posts and pages

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -431,3 +431,17 @@ function get_top_nav(): string
 
     return '';
 }
+
+function cds_last_modified_date()
+{
+    ?>
+    <dl id="wb-dtmd">
+        <dt>Date modified:</dt>
+        <dd>
+            <time property="dateModified" datetime="<?php the_modified_time('Y-m-d'); ?>">
+                <?php the_modified_time('Y-m-d'); ?>
+            </time>
+        </dd>
+    </dl>
+    <?php
+}

--- a/wordpress/wp-content/themes/cds-default/page.php
+++ b/wordpress/wp-content/themes/cds-default/page.php
@@ -47,6 +47,7 @@ get_header();
             </div><!--end of .wp-block-columns -->
         <?php } ?>
 
+    <?php cds_last_modified_date(); ?>
     </main><!-- #main -->
 
 <?php

--- a/wordpress/wp-content/themes/cds-default/single.php
+++ b/wordpress/wp-content/themes/cds-default/single.php
@@ -32,8 +32,9 @@ get_header();
             );
             */
         } // End of the loop.
-        ?>
 
+        cds_last_modified_date();
+        ?>
     </main><!-- #main -->
 
 <?php

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -513,3 +513,8 @@ nav.nav--about li a:focus {
     margin-bottom:20px;
     line-height: 1.7em;
 }
+
+/* Date modified */
+#wb-dtmd {
+    font-size: 16px;
+}


### PR DESCRIPTION
# Summary | Résumé

We saw one of our sites creating this manually. This is a required Canada.ca element, so we can just include it for all posts and pages. Adding this to the CDS Default theme. Don't need it for the CDS Redirector theme because that is our "headless CMS" use case, so they wouldn't use the default templates in that case.

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/346

Source:
- https://design.canada.ca/common-design-patterns/date-modified.html

## Screenshot

<img width="1512" alt="Screen Shot 2022-05-13 at 15 33 45" src="https://user-images.githubusercontent.com/2454380/168306565-c2ecad9a-b68a-413e-81ce-d8db3e1e1edf.png">
