### PR TITLE
Create a 2-page contact form

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -123,6 +123,12 @@ form * {
   margin-top: .75em;
 }
 
+form div[role="group"][id]:focus {
+  outline: 2px solid blue;
+  outline-offset: 5px;
+  border-radius: 2px;
+}
+
 form .focus-group {
   margin-bottom: 1em;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -23,29 +23,104 @@ class ContactForm
         global $wp;
         ob_start();
         ?>
-        <!--
-            fullname
-        -->
         <div class="gc-form-wrapper">
-            <form id="cds-form" method="POST" action="/wp-json/contact/v1/process">
-                
-                <?php
-                    wp_nonce_field(
-                        'cds_form_nonce_action',
-                        'cds-form-nonce',
-                    );
+        <?php
 
-                    Utils::textField(id: 'fullname', label: __('Full name', 'cds-snc'));
-                    Utils::textField(id: 'email', label: __('Email', 'cds-snc'));
-                    Utils::textField(id: 'department', label: __('Department', 'cds-snc'));
+            $required_keys = ['goal', 'usage', 'target', 'message'];
+            $all_keys = array_merge($required_keys, ['optional-usage-value', 'optional-target-value']);
+            $all_values = [];
+            $empty_values = [];
+
+            // create array of keys and values
+        foreach ($all_keys as $_key) {
+            $all_values[$_key] = is_array($_POST[$_key] ?? '') ? $_POST[$_key] : stripslashes($_POST[$_key] ?? '');
+        }
+
+            // find all empty values
+        foreach ($all_values as $_key => $_value) {
+            // if it's a required key AND it's empty
+            if (in_array($_key, $required_keys) && $_value === '') {
+                array_push($empty_values, $_key);
+            }
+        }
+
+            // if all required fields are empty, it's a new form. If some are but not others, it's an error
+            $is_error = count($empty_values) !== count($required_keys);
+
+        if (
+                count($empty_values) === 0
+        ) {  // no empty 'required' keys exist, use second part of form
+            ?>
+
+            <form id="cds-form" method="POST" action="/wp-json/contact/v1/process">
+
+            <?php
+
+                // add hidden fields for previous answers
+            foreach ($all_values as $_key => $_value) {
+                // if is array, iterate through each array value
+                if (is_array($_value)) {
+                    foreach ($_value as $_v) {
+                        echo '<input type="hidden" name="' . sanitize_text_field($_key) . '[]" value="' . sanitize_text_field($_v) . '" />';
+                    }
+                } else {
+                    echo '<input type="hidden" name="' . sanitize_text_field($_key) . '" value="' . sanitize_text_field($_value) . '" />';
+                }
+            }
+
+                wp_nonce_field(
+                    'cds_form_nonce_action',
+                    'cds-form-nonce',
+                );
+
+                echo '<p>';
+                echo _e('(Step 2 of 2)', 'cds-snc');
+                echo '</p>';
+
+                Utils::textField(id: 'fullname', label: __('Full name', 'cds-snc'));
+                Utils::textField(id: 'email', label: __('Email', 'cds-snc'));
+                Utils::textField(id: 'department', label: __('Department', 'cds-snc'));
+
+                // start: send me a copy
+                echo '<div>';
+                Utils::checkboxField(
+                    'cc',
+                    'Send a copy to your email.',
+                    __('Send a copy to your email.', 'cds-snc'),
+                );
+                echo '</div>';
+                // end: send me a copy
+
+                Utils::submitButton(__('Submit', 'cds-snc'));
+            ?>
+            </form>
+
+        <?php } else {  // if no "site", beginning of the form
+                $current_url = home_url(add_query_arg([], $wp->request)); ?>
+
+                <?php
+                if ($is_error) {
+                    Utils::errorMessage($empty_values);
+                }
                 ?>
+
+            <form id="cds-form-step-1" method="POST" action="<?php echo $current_url; ?>">
             
+                <p>
+                    <?php echo _e('(Step 1 of 2)', 'cds-snc'); ?>
+                </p>
+
+                <?php wp_nonce_field(
+                    'cds_form_nonce_action',
+                    'cds-form-nonce',
+                ); ?>
+
                 <!-- goal of your message -->
-                <div role="group" aria-labelledby="goal_types">
+                <div role="group" aria-labelledby="goal_types" id="goal">
                     <label class="gc-label" for="goal" id="goal_types">
                         <?php _e('Goal of your message', 'cds-snc'); ?>
                     </label>
-                    <div id="usage-desc" class="gc-description" data-testid="description">
+                    <div id="goal-desc" class="gc-description" data-testid="description">
                         <?php _e('Your answer helps us make sure your message gets to the right people.', 'cds-snc');?>
                     </div>
 
@@ -77,11 +152,12 @@ class ContactForm
                             __('Other', 'cds-snc'),
                         );
                     ?>
+                    </div>
                 </div>
                 <!-- end goal of your message -->
 
                 <!-- usage -->
-                <div role="group" aria-labelledby="usage_types">
+                <div role="group" aria-labelledby="usage_types" id="usage">
                     <label class="gc-label" for="usage" id="usage_types">
                         <?php _e('What are you thinking about using GC Articles for? (optional)', 'cds-snc'); ?>
                     </label>
@@ -121,17 +197,17 @@ class ContactForm
                     </div>
                     
                     <div id="optional-usage">
-                        <?php Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-usage-value', label: __('Other usage', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- end usage -->
 
                 <!-- target -->
-                <div role="group" aria-labelledby="target_types">
+                <div role="group" aria-labelledby="target_types" id="target">
                     <label class="gc-label" for="target" id="target_types">
                         <?php _e('Who are the target audiences you’re thinking about? (optional)', 'cds-snc'); ?>
                     </label>
-                    <div id="usage-desc" class="gc-description" data-testid="description">
+                    <div id="target-desc" class="gc-description" data-testid="description">
                         <?php _e('We use this information to improve GC Articles.', 'cds-snc');?>
                     </div>
                     
@@ -166,7 +242,7 @@ class ContactForm
                     ?>
                     </div>
                     <div id="optional-target">
-                        <?php Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-target-value', label: __('Other target audience', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- target -->
@@ -182,19 +258,10 @@ class ContactForm
                     name="message"
                 ></textarea>
 
-
-                <!-- send me a copy -->
-                <div>
-                    <?php Utils::checkboxField(
-                        'cc',
-                        'Send a copy to your email.',
-                        __('Send a copy to your email.', 'cds-snc'),
-                    ); ?>
-                </div>
-                <!-- send me a copy -->
-
-                <?php Utils::submitButton(__('Submit', 'cds-snc')); ?>
+                <?php Utils::submitButton(__('Next', 'cds-snc')); ?>
             </form>
+
+        <?php }  // end of the big if ?>
         </div>
         <?php
         $form = ob_get_contents();

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
@@ -35,10 +35,11 @@ class Setup
             return ['error' => true, "error_message" => $nonceErrorMessage];
         }
 
-        $required_keys = ['fullname', 'email', 'department', 'goal', 'message'];
+        $keys_page_1 = ['goal', 'usage', 'optional-usage-value', 'target', 'optional-target-value', 'message'];
+        $keys_page_2 = ['fullname', 'email', 'department'];
         $empty_keys = [];
 
-        foreach ($required_keys as $_key) {
+        foreach ($keys_page_2 as $_key) {
             if (!isset($_POST[$_key]) || $_POST[$_key] === '') {
                 array_push($empty_keys, $_key);
             }
@@ -69,7 +70,7 @@ class Setup
         $message .= $goal . "\n\n";
 
         $message .= 'Department:' . "\n";
-        $message .= $department . "\n";
+        $message .= $department . "\n\n";
 
         if (isset($_POST['usage'])) {
             $message .=
@@ -80,11 +81,11 @@ class Setup
             }
         }
 
-        if (isset($_POST['usage-optional']) && $_POST['usage-optional'] !== '') {
+        if (isset($_POST['optional-usage-value']) && $_POST['optional-usage-value'] !== '') {
             $message .=
                 "\n" .
                 '(Other) ' .
-                sanitize_text_field($_POST['usage-optional']) .
+                sanitize_text_field($_POST['optional-usage-value']) .
                 "\n";
         }
 
@@ -98,11 +99,11 @@ class Setup
             }
         }
 
-        if (isset($_POST['target-optional']) && $_POST['target-optional'] !== '') {
+        if (isset($_POST['optional-target-value']) && $_POST['optional-target-value'] !== '') {
             $message .=
                 "\n" .
                 '(Other) ' .
-                sanitize_text_field($_POST['target-optional']) .
+                sanitize_text_field($_POST['optional-target-value']) .
                 "\n";
         }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -18,19 +18,6 @@ class RequestSiteForm
         add_shortcode('request-site-form', [$this, 'render']);
     }
 
-    public function errorMessage(array $error_ids): string
-    {
-        $errorEl = '<div id="request-error" class="gc-alert gc-alert--error gc-alert--validation" data-testid="alert" tabindex="0" role="alert">';
-        $errorEl .= '<div class="gc-alert__body">';
-        $errorEl .= '<h2 class="gc-h3">' . __('Please complete the required field(s) to continue', 'cds-snc') . '</h2>';
-        $errorEl .= '<ol class="gc-ordered-list">';
-        foreach ($error_ids as $id) {
-            $errorEl .= '<li><a href="#' . $id . '" class="gc-error-link">' . $id . '</a></li>';
-        }
-        $errorEl .= '</ol></div></div>';
-        return $errorEl;
-    }
-
     public function render($atts, $content = null): string
     {
         global $wp;
@@ -41,7 +28,7 @@ class RequestSiteForm
             <?php
 
             $required_keys = ['site', 'usage', 'target', 'timeline'];
-            $all_keys = array_merge($required_keys, ['usage-optional', 'target-optional']);
+            $all_keys = array_merge($required_keys, ['optional-usage-value', 'optional-target-value']);
             $all_values = [];
             $empty_values = [];
 
@@ -136,7 +123,7 @@ class RequestSiteForm
 
                 <?php
                 if ($is_error) {
-                    echo $this->errorMessage($empty_values);
+                    Utils::errorMessage($empty_values);
                 }
                 ?>
             <form id="cds-form-step-1" method="POST" action="<?php echo $current_url; ?>">
@@ -177,7 +164,7 @@ class RequestSiteForm
                 <!-- end site -->
 
                 <!-- usage -->
-                <div role="group" aria-labelledby="usage_types">
+                <div role="group" aria-labelledby="usage_types" id="usage">
                     <label class="gc-label" for="usage" id="usage_types">
                         <?php _e('What will you use your site for?', 'cds-snc'); ?>
                     </label>
@@ -221,13 +208,13 @@ class RequestSiteForm
                         ?>
                     </div>
                     <div id="optional-usage" aria-hidden="false">
-                        <?php Utils::textField(id: 'usage-optional', label: __('Other usage', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-usage-value', label: __('Other usage', 'cds-snc')); ?>
                     </div>
                 </div>
                 <!-- end usage -->
 
                 <!-- target -->
-                <div role="group" aria-labelledby="target_types">
+                <div role="group" aria-labelledby="target_types" id="target">
                     <label class="gc-label" for="target" id="target_types">
                         <?php _e('Who are the target audiences for your site?', 'cds-snc'); ?>
                     </label>
@@ -271,7 +258,7 @@ class RequestSiteForm
                     ?>
                     </div>
                     <div id="optional-target" aria-hidden="false">
-                        <?php Utils::textField(id: 'target-optional', label: __('Other target audience', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-target-value', label: __('Other target audience', 'cds-snc')); ?>
                     </div>
                 </div>
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
@@ -48,7 +48,7 @@ class Setup
             return ['error' => true, "error_message" => $nonceErrorMessage];
         }
 
-        $keys_page_1 = ['site', 'usage', 'usage-optional', 'target', 'target-optional', 'timeline'];
+        $keys_page_1 = ['site', 'usage', 'optional-usage-value', 'target', 'optional-target-value', 'timeline'];
         $keys_page_2 = ['fullname', 'email', 'role', 'department'];
         $empty_keys = [];
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
@@ -26,7 +26,7 @@ class Utils
     public static function textField(string $id, string $label, ?string $description = null, ?string $value = '', ?string $placeholder = null, ?bool $echo = true)
     {
         $isEmail = $id === 'email';
-        $isRequired = !str_ends_with($id, "optional");
+        $isRequired = !str_starts_with($id, "optional");
         ob_start();
         ?>
         <div class="focus-group">
@@ -147,5 +147,22 @@ class Utils
             return $field;
         }
         echo $field;
+    }
+
+    public static function errorMessage(array $error_ids, ?bool $echo = true)
+    {
+        $errorEl = '<div id="request-error" class="gc-alert gc-alert--error gc-alert--validation" data-testid="alert" tabindex="0" role="alert">';
+        $errorEl .= '<div class="gc-alert__body">';
+        $errorEl .= '<h2 class="gc-h3">' . __('Please complete the required field(s) to continue', 'cds-snc') . '</h2>';
+        $errorEl .= '<ol class="gc-ordered-list">';
+        foreach ($error_ids as $id) {
+            $errorEl .= '<li><a href="#' . $id . '" class="gc-error-link">' . $id . '</a></li>';
+        }
+        $errorEl .= '</ol></div></div>';
+
+        if (!$echo) {
+            return $errorEl;
+        }
+        echo $errorEl;
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
@@ -22,12 +22,12 @@ test('asserts textField returns a text input with expected values', function () 
     expect($field)->toContain('<input type="text" id="myId" name="myId" value="" required class="gc-input-text" />');
 });
 
-test('asserts textField returns a text input that is not required when id ends with "optional"', function () {
-    $field = Utils::textField('myId-optional', 'Enter your middle name', echo: false);
+test('asserts textField returns a text input that is not required when id starts with "optional"', function () {
+    $field = Utils::textField('optional-myID', 'Enter your middle name', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
-    expect($field)->toContain('<label class="gc-label" for="myId-optional" id="myId-optional-label">Enter your middle name</label>');
-    expect($field)->toContain('<input type="text" id="myId-optional" name="myId-optional" value="" class="gc-input-text" />');
+    expect($field)->toContain('<label class="gc-label" for="optional-myID" id="optional-myID-label">Enter your middle name</label>');
+    expect($field)->toContain('<input type="text" id="optional-myID" name="optional-myID" value="" class="gc-input-text" />');
 });
 
 test('asserts textField returns an email input when id is "email"', function () {


### PR DESCRIPTION
# Summary | Résumé

Since we started to get spammed on the Contact form, we are splitting it into 2 pages. The result will be that's easy for humans to fill out but hard for bots.

The majority of this code is brought over from the "Request a site" form, which is already broken into 2 pages.

It's not the most beautiful code in the world but it's been working okay for what we need it for.

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/364

## Notes

- Updated the "group" divs with an id so that clicking the error messages takes you to that question
- Updated the ids of the optional fields because it seemed too confusing to have a div wrapping the optional fields with an id of `optional-usage` and the field itself with an id of `usage-optional`
- Fixed a pretty minor axe problem where some of the description ids on the contact form were duplicated

## Screenshots


| before | after (page 1) | after (page 2) |
|--------|----------------|----------------|
|  all fields on one page      |     page 1: what is your message?           |      page 2: who are you?          |
|   ![localhost_contact-form_ (1)](https://user-images.githubusercontent.com/2454380/168653096-a861070b-4ed7-4283-9ff7-11c9cd5b3c9c.png)   |     ![localhost_contact-form_](https://user-images.githubusercontent.com/2454380/168653114-e93c3cfe-f140-4c86-a3d5-2fff837a686f.png)        |     ![localhost_contact-form](https://user-images.githubusercontent.com/2454380/168653102-8355c047-21e3-4668-bcc7-88324aac5469.png)           |

