### PR TITLE
Keep answers in the contact form + Add URL to responses

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -130,26 +130,31 @@ class ContactForm
                             'goal',
                             'Ask a question.',
                             __('Ask a question.', 'cds-snc'),
+                            val: $all_values['goal']
                         );
                         Utils::radioField(
                             'goal',
                             'Get technical support.',
                             __('Get technical support.', 'cds-snc'),
+                            val: $all_values['goal']
                         );
                         Utils::radioField(
                             'goal',
                             'Give feedback.',
                             __('Give feedback.', 'cds-snc'),
+                            val: $all_values['goal']
                         );
                         Utils::radioField(
                             'goal',
                             'Schedule a demo to learn more about GC Articles.',
                             __('Schedule a demo to learn more about GC Articles.', 'cds-snc'),
+                            val: $all_values['goal']
                         );
                         Utils::radioField(
                             'goal',
                             'Other',
                             __('Other', 'cds-snc'),
+                            val: $all_values['goal']
                         );
                     ?>
                     </div>
@@ -171,33 +176,38 @@ class ContactForm
                             name: 'usage[]',
                             id: 'Blog.',
                             value: __('Blog.', 'cds-snc'),
+                            vals: $all_values['usage']
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Newsletter archive with emailing to a subscriber list.',
                             value: __('Newsletter archive with emailing to a subscriber list.', 'cds-snc'),
+                            vals: $all_values['usage']
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Website.',
                             value: __('Website.', 'cds-snc'),
+                            vals: $all_values['usage']
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Internal website.',
                             value: __('Internal website.', 'cds-snc'),
+                            vals: $all_values['usage']
                         );
                         Utils::checkboxField(
                             name: 'usage[]',
                             id: 'Something else.',
                             value: __('Something else.', 'cds-snc'),
+                            vals: $all_values['usage'],
                             ariaControls: 'optional-usage'
                         );
                     ?>
                     </div>
                     
                     <div id="optional-usage">
-                        <?php Utils::textField(id: 'optional-usage-value', label: __('Other usage', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-usage-value', label: __('Other usage', 'cds-snc'), value: $all_values['optional-usage-value']); ?>
                     </div>
                 </div>
                 <!-- end usage -->
@@ -217,32 +227,37 @@ class ContactForm
                             name: 'target[]',
                             id: 'People who use your programs and services.',
                             value: __('People who use your programs and services.', 'cds-snc'),
+                            vals: $all_values['target']
                         );
                         Utils::checkboxField(
                             name: 'target[]',
                             id: 'General public.',
                             value: __('General public.', 'cds-snc'),
+                            vals: $all_values['target']
                         );
                         Utils::checkboxField(
                             name: 'target[]',
                             id: 'Subscribers.',
                             value: __('Subscribers.', 'cds-snc'),
+                            vals: $all_values['target']
                         );
                         Utils::checkboxField(
                             name: 'target[]',
                             id: 'Internal employees and/or community volunteers.',
                             value: __('Internal employees and/or community volunteers.', 'cds-snc'),
+                            vals: $all_values['target']
                         );
                         Utils::checkboxField(
                             name: 'target[]',
                             id: 'Other people.',
                             value: __('Other people.', 'cds-snc'),
+                            vals: $all_values['target'],
                             ariaControls: 'optional-target'
                         );
                     ?>
                     </div>
                     <div id="optional-target">
-                        <?php Utils::textField(id: 'optional-target-value', label: __('Other target audience', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-target-value', label: __('Other target audience', 'cds-snc'), value: $all_values['optional-target-value']); ?>
                     </div>
                 </div>
                 <!-- target -->
@@ -256,7 +271,7 @@ class ContactForm
                     required
                     placeholder=""
                     name="message"
-                ></textarea>
+                ><?php echo $all_values['message']; ?></textarea>
 
                 <?php Utils::submitButton(__('Next', 'cds-snc')); ?>
             </form>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -68,6 +68,9 @@ class ContactForm
                 }
             }
 
+                // Add current URL and path to request
+                echo '<input type="hidden" name="url" value="' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '" />';
+
                 wp_nonce_field(
                     'cds_form_nonce_action',
                     'cds-form-nonce',

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
@@ -110,6 +110,14 @@ class Setup
         $message .= "\n\n" . 'Message:' . "\n";
         $message .= sanitize_text_field($_POST['message']);
 
+        // Add the submitted URL to the message text
+        if (isset($_POST['url']) && $_POST['url'] !== '') {
+            $message .=
+            "\n\n" .
+            'URL: ' .
+            sanitize_text_field($_POST['url']);
+        }
+
         $messenger = new Messenger();
         $response = $messenger->createTicket($goal, $fullname, $email, $message);
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -208,7 +208,7 @@ class RequestSiteForm
                         ?>
                     </div>
                     <div id="optional-usage" aria-hidden="false">
-                        <?php Utils::textField(id: 'optional-usage-value', label: __('Other usage', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-usage-value', label: __('Other usage', 'cds-snc'), value: $all_values['optional-usage-value']); ?>
                     </div>
                 </div>
                 <!-- end usage -->
@@ -258,7 +258,7 @@ class RequestSiteForm
                     ?>
                     </div>
                     <div id="optional-target" aria-hidden="false">
-                        <?php Utils::textField(id: 'optional-target-value', label: __('Other target audience', 'cds-snc')); ?>
+                        <?php Utils::textField(id: 'optional-target-value', label: __('Other target audience', 'cds-snc'), value: $all_values['optional-target-value']); ?>
                     </div>
                 </div>
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -79,6 +79,9 @@ class RequestSiteForm
                     }
                 }
 
+                    // Add current URL and path to request
+                    echo '<input type="hidden" name="url" value="' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '" />';
+
                     Utils::textField(id: 'fullname', label: __('Full name', 'cds-snc'));
                     Utils::textField(
                         id: 'email',

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
@@ -84,6 +84,14 @@ class Setup
             }
         }
 
+        // Add the submitted URL to the message text
+        if (isset($_POST['url']) && $_POST['url'] !== '') {
+            $message .=
+            "\n\n" .
+            'URL: ' .
+            sanitize_text_field($_POST['url']);
+        }
+
         $site = $_POST['site'] ?? __('No name specified', 'cds-snc');
         $goal = __('Request a site:', 'cds-snc') . ' ' . $this->removeslashes($site);
         $fullname = $_POST['fullname'];

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Utils.php
@@ -63,8 +63,10 @@ class Utils
         echo $field;
     }
 
-    public static function radioField(string $name, string $id, string $value, ?bool $echo = true)
+    public static function radioField(string $name, string $id, string $value, string $val = null, ?bool $echo = true)
     {
+        $checked = $id === $val;
+
         ob_start();
         ?>
         <div class="gc-input-radio">
@@ -73,6 +75,9 @@ class Utils
                 name="<?php echo $name; ?>"
                 id="<?php echo sanitize_title($id); ?>"
                 value="<?php echo $id; ?>"
+                <?php if ($checked) {
+                    echo 'checked';
+                } ?>
                 class="gc-radio__input"
                 required
             />
@@ -96,7 +101,7 @@ class Utils
     {
         // set to empty array if a non-array is passed in
         $vals = is_array($vals) ? $vals : [];
-        $checked = in_array($value, $vals);
+        $checked = in_array($id, $vals);
 
         ob_start();
         ?>

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/tests/UtilsTest.php
@@ -69,6 +69,16 @@ test('asserts radioField returns a radio input with expected values', function (
     expect($field)->toContain('<span class="radio-label-text">myValue</span>');
 });
 
+test('asserts radioField returns a "checked" radio input if "id" array contains value', function () {
+    $field = Utils::radioField('myName', 'myId', 'myValue', echo: false);
+    $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
+
+    // note that "id" arg is used for value (because we don't want to be translated)
+    expect($field)->toContain('<input type="radio" name="myName" id="myId" value="myId" class="gc-radio__input" required />');
+    expect($field)->toContain('<label for="myId"');
+    expect($field)->toContain('<span class="radio-label-text">myValue</span>');
+});
+
 test('asserts checkboxField returns a checkbox input with expected values', function () {
     $field = Utils::checkboxField('myName', 'myId', 'myValue', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
@@ -79,8 +89,8 @@ test('asserts checkboxField returns a checkbox input with expected values', func
     expect($field)->toContain('<span class="checkbox-label-text">myValue</span>');
 });
 
-test('asserts checkboxField returns a "checked" checkbox input if "values" array contains value', function () {
-    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myValue'], echo: false);
+test('asserts checkboxField returns a "checked" checkbox input if "id" array contains value', function () {
+    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myId'], echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('checked');
@@ -94,7 +104,7 @@ test('asserts checkboxField returns a not "checked" checkbox input if "values" a
 });
 
 test('asserts checkboxField returns an "aria-controls" and "expanded" checkbox input', function () {
-    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myValue'], ariaControls: 'aria-controls', echo: false);
+    $field = Utils::checkboxField('myName', 'myId', 'myValue', vals: ['myId'], ariaControls: 'aria-controls', echo: false);
     $field = preg_replace('/\s+/', ' ', $field); // remove all whitespace
 
     expect($field)->toContain('aria-controls="aria-controls" aria-expanded="1"');


### PR DESCRIPTION
# Summary | Résumé

This pull request preserves already-answered questions when someone is returned to the contact form because of a validation error, and it adds the current page URL to form submissions.

## Notes

If you don't fill out a checkbox field for one of the questions on the contact form, you will be sent back to the current page with an error message about the question you forgot to answer. However, it would also forget all of the other answers you had.

Fixed both forms so that answers are preserved:
- If validation fails
- In French and English
- for optional fields as well

Also, I noticed that when you submit a French form response, you don't get any indication that it was a french response, except the free text fields probably have french text. So we're adding the URL into the form responses. This means:
- We can see at a glance whether it's an english or french response
- We can see where responses are coming from (Staging or prod)



