### PR TITLE
Wire up REST endpoints

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/phpunit.xml.dist
+++ b/wordpress/wp-content/plugins/gc-lists/phpunit.xml.dist
@@ -15,4 +15,9 @@
 			<directory prefix="Test" suffix=".php">./tests/Unit</directory>
 		</testsuite>
 	</testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -202,7 +202,7 @@ class Messages extends BaseEndpoint
     }
 
     /**
-     * Create a Message
+     * Create a Message template
      *
      * @param  WP_REST_Request  $request
      *
@@ -216,10 +216,10 @@ class Messages extends BaseEndpoint
             'subject' => $request['subject'],
             'body' => $request['body'],
             'message_type' => $request['message_type']
-        ]);
+        ])->fresh();
 
         // @TODO: Probably need to catch exceptions from Model::create()
-        $response = new WP_REST_Response($message->toJson());
+        $response = new WP_REST_Response($message);
 
         $response->set_status(200);
 
@@ -244,7 +244,7 @@ class Messages extends BaseEndpoint
             'body' => $request['body']
         ]);
 
-        $response = new WP_REST_Response($message->toJson());
+        $response = new WP_REST_Response($message);
 
         $response->set_status(200);
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -78,11 +78,14 @@ class Messages extends BaseEndpoint
     /**
      * Get all Message templates
      *
+     * @param  WP_REST_Request  $request
      * @return WP_REST_Response
      */
-    public function all(): WP_REST_Response
+    public function all(WP_REST_Request $request): WP_REST_Response
     {
-        $results = Message::all();
+        $options = $this->getOptions($request);
+
+        $results = Message::templates($options);
 
         $response = new WP_REST_Response($results);
 
@@ -94,11 +97,14 @@ class Messages extends BaseEndpoint
     /**
      * Get sent Messages
      *
+     * @param  WP_REST_Request  $request
      * @return WP_REST_Response
      */
-    public function sent(): WP_REST_Response
+    public function sent(WP_REST_Request $request): WP_REST_Response
     {
-        $results = Message::whereNotNull('original_message_id');
+        $options = $this->getOptions($request);
+
+        $results = Message::sentMessages($options);
 
         $response = new WP_REST_Response($results);
 
@@ -192,5 +198,23 @@ class Messages extends BaseEndpoint
         $response->set_status(200);
 
         return $response;
+    }
+
+    /**
+     * Build up an array of valid $options from request params
+     *
+     * @param  WP_REST_Request  $request
+     * @return array
+     */
+    protected function getOptions(WP_REST_Request $request): array
+    {
+        $options = [];
+        $params  = $request->get_params();
+
+        if (isset($params['limit'])) {
+            $options['limit'] = (int)$params['limit'] ?: 5;
+        }
+
+        return $options;
     }
 }

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -129,7 +129,7 @@ class Messages extends BaseEndpoint
     }
 
     /**
-     * Get a Message
+     * Get a Message (defaults to latest add ?original to get original)
      *
      * @param  WP_REST_Request  $request
      *
@@ -149,6 +149,7 @@ class Messages extends BaseEndpoint
             return rest_ensure_response($response);
         }
 
+        // Whether we have a version or the original, return the latest version
         $message = Message::find($request['id'])->original()->latest();
 
         $response = new WP_REST_Response($message);

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GCLists\Api;
 
 use GCLists\Database\Models\Message;
-use Illuminate\Support\Collection;
 use WP_REST_Response;
 use WP_REST_Request;
 
@@ -45,6 +44,22 @@ class Messages extends BaseEndpoint
         register_rest_route($this->namespace, '/messages/(?P<id>[\d]+)', [
             'methods'             => 'GET',
             'callback'            => [$this, 'get'],
+            'permission_callback' => function () {
+                return $this->hasPermission();
+            }
+        ]);
+
+        register_rest_route($this->namespace, '/messages/(?P<id>[\d]+)/versions', [
+            'methods'             => 'GET',
+            'callback'            => [$this, 'getVersions'],
+            'permission_callback' => function () {
+                return $this->hasPermission();
+            }
+        ]);
+
+        register_rest_route($this->namespace, '/messages/(?P<id>[\d]+)/sent', [
+            'methods'             => 'GET',
+            'callback'            => [$this, 'getSentVersions'],
             'permission_callback' => function () {
                 return $this->hasPermission();
             }
@@ -122,9 +137,51 @@ class Messages extends BaseEndpoint
      */
     public function get(WP_REST_Request $request): WP_REST_Response
     {
-        $results = Message::find($request['id']);
+        $message = Message::find($request['id']);
 
-        $response = new WP_REST_Response($results);
+        $response = new WP_REST_Response($message);
+
+        $response->set_status(200);
+
+        return rest_ensure_response($response);
+    }
+
+    /**
+     * Get versions of a Message template
+     *
+     * @param  WP_REST_Request  $request
+     *
+     * @return WP_REST_Response
+     */
+    public function getVersions(WP_REST_Request $request): WP_REST_Response
+    {
+        $options = $this->getOptions($request);
+
+        $message = Message::find($request['id']);
+        $versions = $message->versions($options);
+
+        $response = new WP_REST_Response($versions);
+
+        $response->set_status(200);
+
+        return rest_ensure_response($response);
+    }
+
+    /**
+     * Get sent versions of a Message template
+     *
+     * @param  WP_REST_Request  $request
+     *
+     * @return WP_REST_Response
+     */
+    public function getSentVersions(WP_REST_Request $request): WP_REST_Response
+    {
+        $options = $this->getOptions($request);
+
+        $message = Message::find($request['id']);
+        $versions = $message->sent($options);
+
+        $response = new WP_REST_Response($versions);
 
         $response->set_status(200);
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -91,7 +91,7 @@ class Messages extends BaseEndpoint
 
         $response->set_status(200);
 
-        return $response;
+        return rest_ensure_response($response);
     }
 
     /**
@@ -110,7 +110,7 @@ class Messages extends BaseEndpoint
 
         $response->set_status(200);
 
-        return $response;
+        return rest_ensure_response($response);
     }
 
     /**
@@ -122,13 +122,13 @@ class Messages extends BaseEndpoint
      */
     public function get(WP_REST_Request $request): WP_REST_Response
     {
-        $results = Message::find($request['id'])->toJson();
+        $results = Message::find($request['id']);
 
         $response = new WP_REST_Response($results);
 
         $response->set_status(200);
 
-        return $response;
+        return rest_ensure_response($response);
     }
 
     /**
@@ -153,7 +153,7 @@ class Messages extends BaseEndpoint
 
         $response->set_status(200);
 
-        return $response;
+        return rest_ensure_response($response);
     }
 
     /**
@@ -178,7 +178,7 @@ class Messages extends BaseEndpoint
 
         $response->set_status(200);
 
-        return $response;
+        return rest_ensure_response($response);
     }
 
     /**
@@ -197,7 +197,7 @@ class Messages extends BaseEndpoint
 
         $response->set_status(200);
 
-        return $response;
+        return rest_ensure_response($response);
     }
 
     /**

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -137,7 +137,19 @@ class Messages extends BaseEndpoint
      */
     public function get(WP_REST_Request $request): WP_REST_Response
     {
-        $message = Message::find($request['id']);
+        $params  = $request->get_params();
+
+        if (isset($params['original'])) {
+            $message = Message::find($request['id'])->original();
+
+            $response = new WP_REST_Response($message);
+
+            $response->set_status(200);
+
+            return rest_ensure_response($response);
+        }
+
+        $message = Message::find($request['id'])->original()->latest();
 
         $response = new WP_REST_Response($message);
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
@@ -38,23 +38,31 @@ class Message extends Model
     /**
      * Get sent versions of the current Message
      *
+     * @param  array  $options
      * @return Collection
      */
-    public function sent(): Collection
+    public function sent(array $options = []): Collection
     {
-        return $this->versions()->filter(function ($item) {
+        $sent = $this->versions()->filter(function ($item) {
             return (bool)$item->attributes["sent_at"];
         });
+
+        if (isset($options['limit'])) {
+            return $sent->take($options['limit']);
+        }
+
+        return $sent;
     }
 
     /**
      * Get all versions of the current Message
      *
+     * @param  array  $options
      * @return Collection|null
      */
-    public function versions(): ?Collection
+    public function versions(array $options = []): ?Collection
     {
-        return static::whereEquals(['original_message_id' => $this->getAttribute('id')]);
+        return static::whereEquals(['original_message_id' => $this->getAttribute('id')], $options);
     }
 
     /**

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
@@ -80,7 +80,9 @@ class Message extends Model
      */
     public function latest(): static
     {
-        if ($versions = $this->versions()) {
+        $versions = $this->versions();
+
+        if ($versions->count()) {
             return $versions->last();
         }
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -231,7 +231,7 @@ class Model implements JsonSerializable
         global $wpdb;
         $wpdb->suppress_errors(true);
 
-        $time = Carbon::now()->timestamp;
+        $time = Carbon::now()->toDateTimeString();
         $this->updateUpdatedTimestamp($time);
 
         $updated = $wpdb->update($this->tableName, $this->getAttributes(), [
@@ -255,7 +255,7 @@ class Model implements JsonSerializable
         global $wpdb;
         $wpdb->suppress_errors(true);
 
-        $time = Carbon::now()->timestamp;
+        $time = Carbon::now()->toDateTimeString();
         $this->updateCreatedTimestamp($time);
         $this->updateUpdatedTimestamp($time);
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -306,22 +306,6 @@ class Model implements JsonSerializable
     }
 
     /**
-     * How to serialize the model
-     *
-     * @return array
-     */
-    public function __serialize(): array
-    {
-        // @TODO: this should probably use $model->visible
-        $model = [];
-        foreach ($this->getAttributes() as $attribute => $value) {
-            $model[$attribute] = $value;
-        }
-
-        return $model;
-    }
-
-    /**
      * Delete the model from the database
      *
      * @return mixed

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -447,7 +447,7 @@ class Model implements JsonSerializable
         $data = $wpdb->get_results($query);
 
         if (!$data) {
-            return null;
+            return collect();
         }
 
         return collect(self::loadModelsFromDbResults($data));
@@ -477,7 +477,7 @@ class Model implements JsonSerializable
         $data = $wpdb->get_results($query);
 
         if (!$data) {
-            return null;
+            return collect();
         }
 
         return collect(self::loadModelsFromDbResults($data));
@@ -512,7 +512,7 @@ class Model implements JsonSerializable
         $data = $wpdb->get_results($query);
 
         if (!$data) {
-            return null;
+            return collect();
         }
 
         return collect(self::loadModelsFromDbResults($data));
@@ -547,7 +547,7 @@ class Model implements JsonSerializable
         $data = $wpdb->get_results($query);
 
         if (!$data) {
-            return null;
+            return collect();
         }
 
         return collect(self::loadModelsFromDbResults($data));

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -172,7 +172,7 @@ class Model implements JsonSerializable
      * @param  array  $attributes
      * @return array
      */
-    protected function getFillableFromArray(array $attributes): array
+    public function getFillableFromArray(array $attributes): array
     {
         if (count($this->fillable)) {
             return array_intersect_key($attributes, array_flip($this->fillable));

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -14,7 +14,7 @@ beforeEach(function() {
 	do_action( 'rest_api_init' );
 });
 
-test('Get all messages', function() {
+test('Get all Message templates', function() {
 	$this->factory->message->create_many(5);
 
 	$request  = new WP_REST_Request( 'GET', '/gc-lists/messages' );
@@ -24,9 +24,57 @@ test('Get all messages', function() {
 	$this->assertJson($response->get_data());
 	$this->assertCount(5, json_decode($response->get_data()));
 
+    // Assertions about the array of Messages
+    $messages = json_decode($response->get_data());
+    $this->assertIsArray($messages);
+
+    // Assertions about a message
+    $message = collect($messages)->random();
+    $this->assertIsObject($message);
+    $this->assertObjectHasAttribute('id', $message);
+    $this->assertObjectHasAttribute('name', $message);
+    $this->assertObjectHasAttribute('subject', $message);
+    $this->assertObjectHasAttribute('body', $message);
+    $this->assertObjectHasAttribute('message_type', $message);
+    $this->assertObjectHasAttribute('sent_at', $message);
+    $this->assertObjectHasAttribute('sent_to_list_name', $message);
+    $this->assertObjectHasAttribute('sent_by_email', $message);
+    $this->assertObjectHasAttribute('original_message_id', $message);
+    $this->assertObjectHasAttribute('version_id', $message);
+    $this->assertObjectHasAttribute('created_at', $message);
+    $this->assertObjectHasAttribute('updated_at', $message);
+});
+
+test('Get all templates with limit', function() {
+    $this->factory->message->create_many(20);
+
+    $request  = new WP_REST_Request( 'GET', '/gc-lists/messages' );
+    $request->set_query_params([
+        'limit' => 5,
+    ]);
+    $response = $this->server->dispatch( $request );
+
+    $this->assertEquals( 200, $response->get_status() );
+    $this->assertJson($response->get_data());
+    $this->assertCount(5, json_decode($response->get_data()));
+});
+
+test('Get all templates with invalid limit returns default 5', function() {
+    $this->factory->message->create_many(20);
+
+    $request  = new WP_REST_Request( 'GET', '/gc-lists/messages' );
+    $request->set_query_params([
+        'limit' => 'xxx',
+    ]);
+    $response = $this->server->dispatch( $request );
+
+    $this->assertEquals( 200, $response->get_status() );
+    $this->assertJson($response->get_data());
+    $this->assertCount(5, json_decode($response->get_data()));
 });
 
 test('Get sent messages', function() {
+    // Create some templates and versions
 	$template = $this->factory->message->create_and_get();
 
 	$this->factory->message->create_many(5, [
@@ -34,13 +82,20 @@ test('Get sent messages', function() {
         'sent_at' => Carbon::now()->timestamp
 	]);
 
+    $template2 = $this->factory->message->create_and_get();
+
+    $this->factory->message->create_many(8, [
+        'original_message_id' => $template2->id,
+        'sent_at' => Carbon::now()->timestamp
+    ]);
+
 	$request  = new WP_REST_Request( 'GET', '/gc-lists/messages/sent' );
 	$response = $this->server->dispatch( $request );
 
 	$this->assertEquals( 200, $response->get_status() );
 	$this->assertJson($response->get_data());
-	$this->assertCount(5, json_decode($response->get_data()));
-});
+	$this->assertCount(13, json_decode($response->get_data()));
+})->group('test');
 
 test('Get one message', function() {
 	$message = $this->factory->message->create_and_get([

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -178,6 +178,24 @@ test('Get versions of a message', function() {
         ->toHaveKeys($this->messageAttributes);
 });
 
+test('No versions available', function() {
+    $message_id = $this->factory->message->create([
+        'name' => 'This is the message name'
+    ]);
+
+    $request = new WP_REST_Request('GET', "/gc-lists/messages/{$message_id}/versions");
+    $response = $this->server->dispatch($request);
+
+    $this->assertEquals(200, $response->get_status());
+
+    $body = $response->get_data()->toJson();
+
+    expect($body)
+        ->json()
+        ->toBeArray()
+        ->toBeEmpty();
+});
+
 test('Get sent versions of a message', function() {
     $message_id = $this->factory->message->create([
         'name' => 'This is the message name'
@@ -212,6 +230,28 @@ test('Get sent versions of a message', function() {
         ->toHaveKeys($this->messageAttributes)
         ->toHaveKey('original_message_id', $message_id)
         ->toHaveKey('sent_at', $timestamp);
+});
+
+test('No sent versions available', function() {
+    $message_id = $this->factory->message->create([
+        'name' => 'This is the message name'
+    ]);
+
+    $this->factory->message->create_many(5, [
+        'original_message_id' => $message_id
+    ]);
+
+    $request = new WP_REST_Request('GET', "/gc-lists/messages/{$message_id}/sent");
+    $response = $this->server->dispatch($request);
+
+    $this->assertEquals(200, $response->get_status());
+
+    $body = $response->get_data()->toJson();
+
+    expect($body)
+        ->json()
+        ->toBeArray()
+        ->toBeEmpty();
 });
 
 test('Create a message', function() {

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -315,10 +315,12 @@ test('Create a message', function() {
 	$response = $this->server->dispatch( $request );
 
 	$this->assertEquals(200, $response->get_status());
-	$this->assertJson($response->get_data());
 
-	$message = json_decode($response->get_data());
-	$this->assertEquals('Name of the message', $message->name);
+	$body = $response->get_data()->toJson();
+
+	expect($body)
+        ->json()
+        ->toHaveKey('name', 'Name of the message');
 });
 
 test('Update a message', function() {
@@ -339,10 +341,12 @@ test('Update a message', function() {
 	$response = $this->server->dispatch( $request );
 
 	$this->assertEquals( 200, $response->get_status() );
-	$this->assertJson($response->get_data());
 
-	$message = json_decode($response->get_data());
-	$this->assertEquals('Name of the message', $message->name);
+	$body = $response->get_data()->toJson();
+
+	expect($body)
+        ->json()
+        ->toHaveKey('name', 'Name of the message');
 });
 
 test('Delete a message', function() {

--- a/wordpress/wp-content/plugins/gc-lists/tests/Unit/Database/Models/TestModel.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Unit/Database/Models/TestModel.php
@@ -1,6 +1,8 @@
 <?php
 
 use GCLists\Database\Models\Model;
+use GCLists\Exceptions\InvalidAttributeException;
+use GCLists\Exceptions\JsonEncodingException;
 
 test('toArray', function() {
     $model = new ModelStub;
@@ -13,6 +15,14 @@ test('toArray', function() {
     $this->assertSame('Foo', $array['title']);
     $this->assertSame('Bar', $array['message']);
 });
+
+test('toJson fails on unencodeable data', function() {
+    $model = new ModelStub;
+    $model->foo = "b\xF8r";
+
+    $this->expectException(JsonEncodingException::class);
+    $model->toJson();
+})->group('model');
 
 test('Attribute manipulation', function() {
     $model = new ModelStub;
@@ -29,6 +39,43 @@ test('Attribute manipulation', function() {
         'message'  => 'Baz'
     ], $model->getAttributes());
 });
+
+test('Fill with attributes', function() {
+    $model = new ModelStub;
+    $model->fill([
+        'title' => 'This is a name',
+        'message' => 'This is a message'
+    ]);
+
+    $this->assertIsObject($model);
+    $this->assertTrue($model instanceof ModelStub);
+})->group('model');
+
+test('Fill with invalid attribute', function() {
+    $model = new ModelStub;
+
+    $this->expectException(InvalidAttributeException::class);
+    $model->fill([
+        'title' => 'This is a name',
+        'message' => 'This is a message',
+        'notvalid' => 'This is not a fillable attribute'
+    ]);
+})->group('model');
+
+test('Serialize model toJson', function() {
+    $model = new ModelStub;
+
+    $model->fill([
+        'title' => 'This is a name',
+        'message' => 'This is a message'
+    ]);
+
+    $json = $model->toJson();
+    expect($json)
+        ->toBeJson()
+        ->json()
+        ->toHaveKeys(['title', 'message']);
+})->group('model');
 
 
 /**

--- a/wordpress/wp-content/plugins/gc-lists/tests/Unit/Database/Models/TestModel.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Unit/Database/Models/TestModel.php
@@ -22,7 +22,7 @@ test('toJson fails on unencodeable data', function() {
 
     $this->expectException(JsonEncodingException::class);
     $model->toJson();
-})->group('model');
+});
 
 test('Attribute manipulation', function() {
     $model = new ModelStub;
@@ -49,7 +49,7 @@ test('Fill with attributes', function() {
 
     $this->assertIsObject($model);
     $this->assertTrue($model instanceof ModelStub);
-})->group('model');
+});
 
 test('Fill with invalid attribute', function() {
     $model = new ModelStub;
@@ -60,7 +60,7 @@ test('Fill with invalid attribute', function() {
         'message' => 'This is a message',
         'notvalid' => 'This is not a fillable attribute'
     ]);
-})->group('model');
+});
 
 test('Serialize model toJson', function() {
     $model = new ModelStub;
@@ -75,8 +75,31 @@ test('Serialize model toJson', function() {
         ->toBeJson()
         ->json()
         ->toHaveKeys(['title', 'message']);
-})->group('model');
+});
 
+test('getFillableFromArray', function() {
+    $model = new ModelStub;
+    $array = $model->getFillableFromArray([
+        'title' => 'Foo',
+        'message' => 'Bar',
+        'notvalid' => 'Baz',
+    ]);
+
+    expect($array)
+        ->toBeArray()
+        ->toHaveKeys(['title', 'message'])
+        ->not()->toHaveKey('notvalid');
+});
+
+test('getAttribute', function() {
+    $model = new ModelStub([
+        'title' => 'Foo',
+        'message' => 'Bar',
+    ]);
+
+    $this->assertEquals('Foo', $model->getAttribute('title'));
+    $this->assertEquals('Bar', $model->getAttribute('message'));
+});
 
 /**
  * Model stub for testing the base Model


### PR DESCRIPTION
# Summary | Résumé

Adds REST endpoints for:
- Get message versions
  `GET /messages/[id]/versions?limit=5`

- Get sent versions of a message
  `GET /messages/[id]/sent?limit=5`

Also includes:
- More base Model unit tests
- Return empty collections when no results from Model queries
- Some refactoring to use Pest expectations in API tests
- phpunit config for code coverage
- `GET /messages/[id]` should always return the latest version of a message
- Add a query param to `GET /messages/[id]?original` to return the original version