### PR TITLE
Build out Create/Update endpoints and send() instance method

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/composer.json
+++ b/wordpress/wp-content/plugins/gc-lists/composer.json
@@ -11,7 +11,8 @@
         "phpunit/phpunit": "^9.5",
         "yoast/phpunit-polyfills": "^1.0",
         "yoast/wp-test-utils": "^1.0",
-        "pestphp/pest": "^1.21"
+        "pestphp/pest": "^1.21",
+        "pestphp/pest-plugin-faker": "^1.0"
     },
     "autoload": {
       "psr-4": {

--- a/wordpress/wp-content/plugins/gc-lists/composer.lock
+++ b/wordpress/wp-content/plugins/gc-lists/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e8116b14d46476161a34bda692fd42c",
+    "content-hash": "5db0138695f75b5ddf5c0dd693a187f6",
     "packages": [
         {
             "name": "illuminate/collections",
-            "version": "v9.12.2",
+            "version": "v9.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "32badf046bfc187afacbee37b9820c5e200285d0"
+                "reference": "7d7617afdca6f15c881856c679da4e76820e7674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/32badf046bfc187afacbee37b9820c5e200285d0",
-                "reference": "32badf046bfc187afacbee37b9820c5e200285d0",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/7d7617afdca6f15c881856c679da4e76820e7674",
+                "reference": "7d7617afdca6f15c881856c679da4e76820e7674",
                 "shasum": ""
             },
             "require": {
@@ -59,11 +59,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-02T14:05:19+00:00"
+            "time": "2022-05-16T15:20:45+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.12.2",
+            "version": "v9.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -109,7 +109,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.12.2",
+            "version": "v9.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -157,7 +157,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.12.2",
+            "version": "v9.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -985,6 +985,73 @@
             "time": "2020-10-16T08:27:54+00:00"
         },
         {
+            "name": "fakerphp/faker",
+            "version": "v1.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "symfony/phpunit-bridge": "^4.4 || ^5.2"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v1.19-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.19.0"
+            },
+            "time": "2022-02-02T17:38:57+00:00"
+        },
+        {
             "name": "filp/whoops",
             "version": "2.14.5",
             "source": {
@@ -1382,16 +1449,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v1.21.2",
+            "version": "v1.21.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "63f009fadf9b37f611fda43928d03336475d5d9f"
+                "reference": "66f69617f1e01032e009f783136f129de3476689"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/63f009fadf9b37f611fda43928d03336475d5d9f",
-                "reference": "63f009fadf9b37f611fda43928d03336475d5d9f",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/66f69617f1e01032e009f783136f129de3476689",
+                "reference": "66f69617f1e01032e009f783136f129de3476689",
                 "shasum": ""
             },
             "require": {
@@ -1413,7 +1480,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-1.x": "1.x-dev"
                 },
                 "pest": {
                     "plugins": [
@@ -1459,7 +1526,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v1.21.2"
+                "source": "https://github.com/pestphp/pest/tree/v1.21.3"
             },
             "funding": [
                 {
@@ -1491,7 +1558,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-03-05T19:34:40+00:00"
+            "time": "2022-05-12T19:10:25+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -1564,6 +1631,76 @@
                 }
             ],
             "time": "2021-01-03T15:53:42+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-faker",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-faker.git",
+                "reference": "9d93419f1f47ffd856ee544317b2f9144a129044"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-faker/zipball/9d93419f1f47ffd856ee544317b2f9144a129044",
+                "reference": "9d93419f1f47ffd856ee544317b2f9144a129044",
+                "shasum": ""
+            },
+            "require": {
+                "fakerphp/faker": "^1.9.1",
+                "pestphp/pest": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest-dev-tools": "dev-master"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Faker.php"
+                ],
+                "psr-4": {
+                    "Pest\\Faker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Faker Plugin",
+            "keywords": [
+                "faker",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-faker/tree/v1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-01-03T15:42:35+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3479,6 +3616,73 @@
                 }
             ],
             "time": "2022-04-20T15:01:42+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -75,24 +75,33 @@ class Messages extends BaseEndpoint
                 'name' => [
                     'required' => true,
                     'type' => 'string',
-                    'description' => 'Name of the Message'
+                    'description' => 'Name of the Message',
+                    'sanitize_callback' => function ($value, $request, $param) {
+                        return sanitize_text_field($value);
+                    }
                 ],
                 'subject' => [
                     'required' => true,
                     'type' => 'string',
-                    'description' => 'Subject of the Message'
+                    'description' => 'Subject of the Message',
+                    'sanitize_callback' => function ($value, $request, $param) {
+                        return sanitize_text_field($value);
+                    }
                 ],
                 'body' => [
                     'required' => true,
                     'type' => 'string',
-                    'description' => 'Body of the Message'
+                    'description' => 'Body of the Message',
+                    'sanitize_callback' => function ($value, $request, $param) {
+                        return sanitize_textarea_field($value);
+                    }
                 ],
                 'message_type' => [
                     'required' => true,
                     'type' => 'string',
                     'description' => 'Type of message',
-                    'validate_callback' => function ($param, $request, $key) {
-                        return in_array($param, ['email', 'phone']);
+                    'validate_callback' => function ($value, $request, $param) {
+                        return in_array($value, ['email', 'phone']);
                     }
                 ]
             ]

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -70,7 +70,32 @@ class Messages extends BaseEndpoint
             'callback'            => [$this, 'create'],
             'permission_callback' => function () {
                 return $this->hasPermission();
-            }
+            },
+            'args' => [
+                'name' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Name of the Message'
+                ],
+                'subject' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Subject of the Message'
+                ],
+                'body' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Body of the Message'
+                ],
+                'message_type' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Type of message',
+                    'validate_callback' => function ($param, $request, $key) {
+                        return in_array($param, ['email', 'phone']);
+                    }
+                ]
+            ]
         ]);
 
         register_rest_route($this->namespace, '/messages/(?P<id>[\d]+)', [

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -112,7 +112,33 @@ class Messages extends BaseEndpoint
             'callback'            => [$this, 'update'],
             'permission_callback' => function () {
                 return $this->hasPermission();
-            }
+            },
+            'args' => [
+                'name' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Name of the Message',
+                    'sanitize_callback' => function ($value, $request, $param) {
+                        return sanitize_text_field($value);
+                    }
+                ],
+                'subject' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Subject of the Message',
+                    'sanitize_callback' => function ($value, $request, $param) {
+                        return sanitize_text_field($value);
+                    }
+                ],
+                'body' => [
+                    'required' => true,
+                    'type' => 'string',
+                    'description' => 'Body of the Message',
+                    'sanitize_callback' => function ($value, $request, $param) {
+                        return sanitize_textarea_field($value);
+                    }
+                ]
+            ]
         ]);
 
         register_rest_route($this->namespace, '/messages/(?P<id>[\d]+)', [
@@ -244,7 +270,6 @@ class Messages extends BaseEndpoint
      */
     public function create(WP_REST_Request $request): WP_REST_Response
     {
-        // @TODO: data validation and santitization
         $message = Message::create([
             'name' => $request['name'],
             'subject' => $request['subject'],
@@ -269,16 +294,17 @@ class Messages extends BaseEndpoint
      */
     public function update(WP_REST_Request $request): WP_REST_Response
     {
-        // @TODO: data validation and santitization
         $message = Message::find($request['id']);
 
-        $message->update([
+        $message->fill([
             'name' => $request['name'],
             'subject' => $request['subject'],
             'body' => $request['body']
         ]);
 
-        $response = new WP_REST_Response($message);
+        $message->saveVersion();
+
+        $response = new WP_REST_Response($message->latest());
 
         $response->set_status(200);
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Factories/MessageFactory.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Factories/MessageFactory.php
@@ -2,6 +2,8 @@
 
 namespace GCLists\Database\Factories;
 
+use Carbon\Carbon;
+
 class MessageFactory extends \WP_UnitTest_Factory_For_Thing
 {
     protected $tableName;
@@ -19,7 +21,9 @@ class MessageFactory extends \WP_UnitTest_Factory_For_Thing
             'name' => 'This is a message',
             'subject' => 'Subject of the message',
             'body' => 'This is the body of the message it can be very long',
-            'message_type' => 'email'
+            'message_type' => 'email',
+            'updated_at' => Carbon::now()->toDateTimeString(),
+            'created_at' => Carbon::now()->toDateTimeString(),
         );
     }
 

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
@@ -30,9 +30,32 @@ class Message extends Model
         'message_type',
     ];
 
-    public function send()
+    /**
+     * Mark a message as sent
+     *
+     * @param  string  $sent_to_list_id
+     * @param  string  $sent_to_list_name
+     * @param  int  $sent_by_id
+     * @param  string  $sent_by_email
+     *
+     * @return $this
+     */
+    public function send(string $sent_to_list_id, string $sent_to_list_name, int $sent_by_id, string $sent_by_email): static
     {
-        //
+        $timestamp = $this->freshTimestamp();
+
+        $this->updateUpdatedTimestamp($timestamp);
+
+        $this->forceFill([
+            'sent_at' => $this->freshTimestamp(),
+            'sent_to_list_id' => $sent_to_list_id,
+            'sent_to_list_name' => $sent_to_list_name,
+            'sent_by_id' => $sent_by_id,
+            'sent_by_email' => $sent_by_email
+        ]);
+
+        // @TODO: need to wire this up to the actual send
+        return $this->saveVersion();
     }
 
     /**
@@ -124,7 +147,12 @@ class Message extends Model
         // new model instance for the version
         $version = new static();
 
-        $version->forceFill(array_merge($original->getFillableFromArray($this->getAttributes()), [
+        $attributes = $this->getAttributes();
+
+        // Don't copy the id obvi
+        unset($attributes['id']);
+
+        $version->forceFill(array_merge($attributes, [
             'original_message_id' => $original->getAttribute('id'),
             'version_id' => $latest_version,
         ]));

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -39,7 +39,7 @@ class Model implements JsonSerializable
      *
      * @var string
      */
-    protected string $tableName;
+    public string $tableName;
 
     /**
      * The model's attributes

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -320,7 +320,7 @@ class Model implements JsonSerializable
     }
 
     /**
-     * Update
+     * Update the model's updated_at timestamp
      */
     protected function touch(): static
     {
@@ -332,16 +332,24 @@ class Model implements JsonSerializable
     /**
      * Delete the model from the database
      *
-     * @return mixed
+     * @return bool
      */
-    public function delete(): mixed
+    public function delete(): bool
     {
+        if (!$this->exists) {
+            return false;
+        }
+
         global $wpdb;
 
-        return $wpdb->delete(
+        $wpdb->delete(
             $this->tableName,
             ['id' => $this->attributes["id"]]
         );
+
+        $this->exists = false;
+
+        return true;
     }
 
     /**

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -231,7 +231,7 @@ class Model implements JsonSerializable
         global $wpdb;
         $wpdb->suppress_errors(true);
 
-        $time = Carbon::now()->toDateTimeString();
+        $time = $this->freshTimestamp();
         $this->updateUpdatedTimestamp($time);
 
         $updated = $wpdb->update($this->tableName, $this->getAttributes(), [
@@ -255,7 +255,7 @@ class Model implements JsonSerializable
         global $wpdb;
         $wpdb->suppress_errors(true);
 
-        $time = Carbon::now()->toDateTimeString();
+        $time = $this->freshTimestamp();
         $this->updateCreatedTimestamp($time);
         $this->updateUpdatedTimestamp($time);
 
@@ -289,20 +289,44 @@ class Model implements JsonSerializable
      * Update the created_at timestamp on the model
      *
      * @param $time
+     * @return Model
      */
-    protected function updateCreatedTimestamp($time)
+    protected function updateCreatedTimestamp($time): static
     {
         $this->created_at = $time;
+        return $this;
     }
 
     /**
      * Update the updated_at timestamp on the model
      *
      * @param $time
+     * @return Model
      */
-    protected function updateUpdatedTimestamp($time)
+    protected function updateUpdatedTimestamp($time): static
     {
         $this->updated_at = $time;
+        return $this;
+    }
+
+    /**
+     * Get a fresh timestamp
+     *
+     * @return string
+     */
+    protected function freshTimestamp()
+    {
+        return Carbon::now()->toDateTimeString();
+    }
+
+    /**
+     * Update
+     */
+    protected function touch(): static
+    {
+        $this->updateUpdatedTimestamp($this->freshTimestamp());
+
+        return $this->save();
     }
 
     /**

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -323,6 +323,49 @@ test('Create a message', function() {
         ->toHaveKey('name', 'Name of the message');
 });
 
+test('Create a message with Validation errors', function() {
+    $request  = new WP_REST_Request( 'POST', '/gc-lists/messages' );
+    $request->set_query_params([
+        'subject' => 'Subject of the message',
+        'message_type' => 'email'
+    ]);
+
+    $response = $this->server->dispatch( $request );
+
+    $body = $response->get_data();
+
+    $this->assertEquals(400, $response->get_status());
+
+    // missing name, body
+    expect($body)
+        ->toBeArray()
+        ->toHaveKey('code', 'rest_missing_callback_param')
+        ->toHaveKey('data.status', 400)
+        ->toHaveKey('data.params', ['name', 'body']);
+
+
+    // Again with no missing params but invalid message_type
+    $request->set_query_params([
+        'name' => 'Name of the message',
+        'subject' => 'Subject of the message',
+        'body' => 'Body of the message',
+        'message_type' => 'xx'
+    ]);
+
+    $response = $this->server->dispatch( $request );
+
+    $body = $response->get_data();
+
+    $this->assertEquals(400, $response->get_status());
+
+    // missing name, body
+    expect($body)
+        ->toBeArray()
+        ->toHaveKey('code', 'rest_invalid_param')
+        ->toHaveKey('data.status', 400)
+        ->toHaveKey('data.params.message_type');
+})->group('validation');
+
 test('Update a message', function() {
 	$message = $this->factory->message->create_and_get([
 		'name' => 'This is the message name'

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -366,19 +366,17 @@ test('Create a message with Validation errors', function() {
         ->toHaveKey('data.params.message_type');
 });
 
-test('Update a message', function() {
+test('Update a message creates a new version', function() {
 	$message = $this->factory->message->create_and_get([
-		'name' => 'This is the message name'
+		'name' => 'This is the original message name'
 	]);
-
-	$this->assertEquals('This is the message name', $message->name);
 
 	$request  = new WP_REST_Request( 'PUT', "/gc-lists/messages/{$message->id}" );
 	$request->set_query_params([
 		'id' => $message->id,
-		'name' => 'Name of the message',
-		'subject' => 'Subject of the message',
-		'body' => 'Body of the message',
+		'name' => 'Name of the new version of the message',
+		'subject' => 'Subject of the new message',
+		'body' => 'Body of the new message',
 	]);
 
 	$response = $this->server->dispatch( $request );
@@ -389,8 +387,11 @@ test('Update a message', function() {
 
 	expect($body)
         ->json()
-        ->toHaveKey('name', 'Name of the message');
-});
+        ->toHaveKey('name', 'Name of the new version of the message')
+        ->toHaveKey('subject', 'Subject of the new message')
+        ->toHaveKey('body', 'Body of the new message')
+        ->toHaveKey('original_message_id', $message->id);
+})->group('update');
 
 test('Delete a message', function() {
 	$message_ids = $this->factory->message->create_many(5);

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -391,7 +391,7 @@ test('Update a message creates a new version', function() {
         ->toHaveKey('subject', 'Subject of the new message')
         ->toHaveKey('body', 'Body of the new message')
         ->toHaveKey('original_message_id', $message->id);
-})->group('update');
+});
 
 test('Delete a message', function() {
 	$message_ids = $this->factory->message->create_many(5);

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Api/TestMessages.php
@@ -364,7 +364,7 @@ test('Create a message with Validation errors', function() {
         ->toHaveKey('code', 'rest_invalid_param')
         ->toHaveKey('data.status', 400)
         ->toHaveKey('data.params.message_type');
-})->group('validation');
+});
 
 test('Update a message', function() {
 	$message = $this->factory->message->create_and_get([

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
@@ -464,6 +464,21 @@ test('Save a new version from a version should create a revision of the original
     $this->assertCount(6, $original->versions());
 });
 
+test('Saving a version with invalid attribute should throw exception', function() {
+    $message_id = $this->factory->message->create([
+        'name' => 'Original name',
+        'body' => 'Original body',
+    ]);
+
+    $original = Message::find($message_id);
+
+    $original->name = 'New name';
+    $original->foo = 'Bar';
+
+    $this->expectException(QueryException::class);
+    $original->saveVersion();
+});
+
 test('Retrieve all Message templates', function() {
     $this->factory->message->create_many(20);
 

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
@@ -388,6 +388,28 @@ test('Save a new version of a message', function() {
     $this->assertSame('This is a another new body', $version->body);
 });
 
+test('Saving a version touches the original updated_at timestamp', function() {
+    Carbon::setTestNow(Carbon::now());
+
+    $message_id = $this->factory->message->create([
+        'name' => 'Original name',
+        'body' => 'Original body',
+    ]);
+    $original = Message::find($message_id);
+    $original_updated = $original->updated_at;
+
+    // Let's go to the future!
+    Carbon::setTestNow(Carbon::now()->addMinutes(5));
+
+    $original = $original->fill([
+        'name' => 'This is a new name',
+        'body' => 'This is a new body'
+    ])->saveVersion();
+
+    $this->assertNotEquals($original_updated, $original->updated_at);
+    $this->assertGreaterThan($original_updated, $original->updated_at);
+});
+
 test('Save a new version from a version should create a revision of the original', function() {
     $message_id = $this->factory->message->create([
         'name' => 'Original name',

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
@@ -115,18 +115,30 @@ test('Find a model', function() {
 });
 
 test('Delete a model', function() {
-    $message_ids = $this->factory->message->create_many(5);
+    $message_ids = collect($this->factory->message->create_many(5));
 
     $count = $this->wpdb->get_var("SELECT COUNT(*) FROM {$this->tableName}");
     $this->assertEquals(5, $count);
 
-    $message = Message::find($message_ids[1]);
+    $message = Message::find($message_ids->random());
     $this->assertTrue($message instanceof Message);
 
-    $message->delete();
+    $this->assertTrue($message->delete());
+
+    $this->assertFalse($message->exists);
 
     $count = $this->wpdb->get_var("SELECT COUNT(*) FROM {$this->tableName}");
     $this->assertEquals(4, $count);
+});
+
+test('Deleting a non-existent model returns false', function() {
+    $message = new Message([
+        'name' => 'Foo',
+        'subject' => 'Bar',
+        'body' => 'Baz'
+    ]);
+
+    $this->assertFalse($message->delete());
 });
 
 test('Retrieve all models', function() {


### PR DESCRIPTION
# Summary | Résumé

- Adds validation rules to Create and Update endpoints
- Adds data sanitization to Create and Update endpoints
- Update a message creates a new Version
- Creating a new version touches the updated_at timestamp of the original
- Delete message cleanup/tests
- Mark an instance of a message as sent with the send() method