### PR TITLE
A11y menu

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -401,7 +401,7 @@ function get_top_nav(): string
         $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#' . $menuID . '" aria-controls="' . $menuID . '" aria-expanded="false">Menu</button></div>', $headerMenu);
 
         // Insert a button to open/close submenus
-        $headerMenu = str_replace('<ul class="sub-menu">', '<button aria-expanded="false"><span class="sr-only">Open</span></button><ul class="sub-menu">', $headerMenu);
+        $headerMenu = str_replace('<ul class="sub-menu">', '<button aria-expanded="false" class="sub-menu--button"><span class="sr-only">Open</span></button><ul class="sub-menu">', $headerMenu);
 
         try {
             $topMenu = __('Top menu', 'cds-snc');
@@ -415,16 +415,14 @@ function get_top_nav(): string
             $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
 
             // Insert aria-label for submenu
-            // $submenuNode = $dom->find('.sub-menu')[0];
-            // if ($submenuNode) {
-            //     $submenuNode->setAttribute('aria-label', $submenu);
-            // }
-
-            // Insert aria-expanded for link with submenu
-            // $menuItemNode = $dom->find('.menu-item-has-children')[0];
-            // if ($menuItemNode) {
-            //     $menuItemNode->setAttribute('aria-expanded', "false");
-            // }
+            $submenuNodes = $dom->find('.sub-menu');
+            $submenuCount = 0;
+            foreach ($submenuNodes as $node) {
+                $submenuID = 'sub-menu-' . ++$submenuCount;
+                $node->setAttribute('aria-label', $submenu);
+                $node->setAttribute('id', $submenuID);
+                $node->getParent()->find('.sub-menu--button')->setAttribute('aria-controls', $submenuID);
+            }
 
             return $dom->outerHTML;
         } catch (Exception) {

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -401,7 +401,7 @@ function get_top_nav(): string
         $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#' . $menuID . '" aria-controls="' . $menuID . '" aria-expanded="false">Menu</button></div>', $headerMenu);
 
         // Insert a button to open/close submenus
-        $headerMenu = str_replace('<ul class="sub-menu">', '<button aria-expanded="false" class="sub-menu--button"><span class="sr-only">Open</span></button><ul class="sub-menu">', $headerMenu);
+        $headerMenu = str_replace('<ul class="sub-menu">', '<button aria-expanded="false" class="sub-menu--button"><span class="sr-only">' .  __('Toggle submenu', 'cds-snc') . '</span></button><ul class="sub-menu">', $headerMenu);
 
         try {
             $topMenu = __('Top menu', 'cds-snc');
@@ -421,7 +421,12 @@ function get_top_nav(): string
                 $submenuID = 'sub-menu-' . ++$submenuCount;
                 $node->setAttribute('aria-label', $submenu);
                 $node->setAttribute('id', $submenuID);
-                $node->getParent()->find('.sub-menu--button')->setAttribute('aria-controls', $submenuID);
+
+                $button = $node->getParent()->find('.sub-menu--button');
+                $button->setAttribute('aria-controls', $submenuID);
+
+                $linkText = $node->getParent()->find('a')[0]->text;
+                $button->find('span')->firstChild()->setText(__('Toggle submenu for ', 'cds-snc') . $linkText);
             }
 
             return $dom->outerHTML;

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -400,6 +400,9 @@ function get_top_nav(): string
         // It seems like we can't append an element using the PHP HTML Parser https://stackoverflow.com/q/51466367
         $headerMenu = str_replace('<nav class="nav--primary__container">', '<nav class="nav--primary__container"><div class="container"><button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#' . $menuID . '" aria-controls="' . $menuID . '" aria-expanded="false">Menu</button></div>', $headerMenu);
 
+        // Insert a button to open/close submenus
+        $headerMenu = str_replace('<ul class="sub-menu">', '<button aria-expanded="false"><span class="sr-only">Open</span></button><ul class="sub-menu">', $headerMenu);
+
         try {
             $topMenu = __('Top menu', 'cds-snc');
             $submenu = __('submenu', 'cds-snc');
@@ -412,16 +415,16 @@ function get_top_nav(): string
             $dom->find('.nav--primary__container')->setAttribute('aria-label', $topMenu);
 
             // Insert aria-label for submenu
-            $submenuNode = $dom->find('.sub-menu')[0];
-            if ($submenuNode) {
-                $submenuNode->setAttribute('aria-label', $submenu);
-            }
+            // $submenuNode = $dom->find('.sub-menu')[0];
+            // if ($submenuNode) {
+            //     $submenuNode->setAttribute('aria-label', $submenu);
+            // }
 
             // Insert aria-expanded for link with submenu
-            $menuItemNode = $dom->find('.menu-item-has-children')[0];
-            if ($menuItemNode) {
-                $menuItemNode->setAttribute('aria-expanded', "false");
-            }
+            // $menuItemNode = $dom->find('.menu-item-has-children')[0];
+            // if ($menuItemNode) {
+            //     $menuItemNode->setAttribute('aria-expanded', "false");
+            // }
 
             return $dom->outerHTML;
         } catch (Exception) {

--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -83,7 +83,6 @@ function createToc() {
     $itemWithSubmenu.find('ul.sub-menu').addClass('open');
     $itemWithSubmenu.find('> a').attr("aria-expanded", 'true');
     $itemWithSubmenu.find('> button').attr("aria-expanded", 'true');
-    $itemWithSubmenu.find('> button span').text('Close submenu');
 
     if(isMouseEnter) {
       $itemWithSubmenu.find('ul.sub-menu').addClass('mouseenter');
@@ -94,7 +93,6 @@ function createToc() {
     $itemWithSubmenu.find('ul.sub-menu').removeClass('open').removeClass('mouseenter');
     $itemWithSubmenu.find('> a').attr("aria-expanded", 'false');
     $itemWithSubmenu.find('> button').attr("aria-expanded", 'false');
-    $itemWithSubmenu.find('> button span').text('Open submenu');
   }
 
   createToc();

--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -28,11 +28,11 @@ function createToc() {
 }
 
 (function ($) {
-
   const $menuToggle = $('button.navbar-toggler');
-  //const $itemWithSubmenu = $('.menu-item-has-children');
   const $submenuButton = $('.menu-item-has-children button');
+  let closeMenuTimeout;
 
+  // this is for the mobile nav
   $menuToggle.on('click', function (e) {
     // toggle "aria-expanded"
     const expanded = e.target.getAttribute('aria-expanded') === 'false' ? true : false;
@@ -40,7 +40,7 @@ function createToc() {
 
     // set the submenu to "expanded" if the mobile nav is opened
     if (expanded === true) {
-      $itemWithSubmenu.attr('aria-expanded', true);
+      $('.menu-item-has-children').attr('aria-expanded', true);
     }
 
     // toggle menu class
@@ -48,38 +48,54 @@ function createToc() {
     $menu.toggleClass('show');
   })
 
-  $submenuButton.on('click', function (e) {
+  // open or close the menu
+  $submenuButton.on('click mouseenter', function(e) {
     $itemWithSubmenu = $(e.target).parent();
     isOpen = $itemWithSubmenu.find('ul.sub-menu').hasClass('open');
+    isMouseEnter = e.type === 'mouseenter'
+    clearTimeout(closeMenuTimeout)
 
     if(isOpen) {
-      $itemWithSubmenu.find('ul.sub-menu').removeClass('open');
-      $itemWithSubmenu.find('> a').attr("aria-expanded", 'false');
-      $itemWithSubmenu.find('> button').attr("aria-expanded", 'false');
-      $itemWithSubmenu.find('> button span').text('Open');
+      if (e.type === 'click') {
+        closeMenu($itemWithSubmenu)
+      }
+      
     } else {
-      $itemWithSubmenu.find('ul.sub-menu').addClass('open');
-      $itemWithSubmenu.find('> a').attr("aria-expanded", 'true');
-      $itemWithSubmenu.find('> button').attr("aria-expanded", 'true');
-      $itemWithSubmenu.find('> button span').text('Close');
+      // close other submenus
+      closeMenu($('li.menu-item-has-children').remove($itemWithSubmenu))
+  
+      openMenu($itemWithSubmenu, isMouseEnter)
+    }
+  })
+  
+  // set a timer when we mouseleave
+  $('.sub-menu').on('mouseleave', function(e) {
+    $itemWithSubmenu = $(e.target).parents('li.menu-item-has-children');
+    isOpenMouseenter = $itemWithSubmenu.find('ul.sub-menu.open.mouseenter').length > 0
+
+    if(isOpenMouseenter) {
+      clearTimeout(closeMenuTimeout)
+      closeMenuTimeout = setTimeout(() => closeMenu($itemWithSubmenu), 1000);
     }
   })
 
+  function openMenu($itemWithSubmenu, isMouseEnter = false) {
+    $itemWithSubmenu.find('ul.sub-menu').addClass('open');
+    $itemWithSubmenu.find('> a').attr("aria-expanded", 'true');
+    $itemWithSubmenu.find('> button').attr("aria-expanded", 'true');
+    $itemWithSubmenu.find('> button span').text('Close submenu');
 
-  /*
-  $itemWithSubmenu.on(
-    'focusin mouseover', function (e) {
-      // if target is within submenu, "aria-expanded" is true
-      if ($.contains($itemWithSubmenu[0], e.target)) {
-        $itemWithSubmenu.attr('aria-expanded', true);
-      }
-    }).on('focusout mouseout', function (e) {
-      // if the focused element is outside of submenu, "aria-expanded" is false
-      if (!$.contains($itemWithSubmenu[0], document.activeElement)) {
-        $itemWithSubmenu.attr('aria-expanded', false);
-      }
-    })
-  */
+    if(isMouseEnter) {
+      $itemWithSubmenu.find('ul.sub-menu').addClass('mouseenter');
+    }
+  }
+
+  function closeMenu($itemWithSubmenu) {
+    $itemWithSubmenu.find('ul.sub-menu').removeClass('open').removeClass('mouseenter');
+    $itemWithSubmenu.find('> a').attr("aria-expanded", 'false');
+    $itemWithSubmenu.find('> button').attr("aria-expanded", 'false');
+    $itemWithSubmenu.find('> button span').text('Open submenu');
+  }
 
   createToc();
 

--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -30,7 +30,8 @@ function createToc() {
 (function ($) {
 
   const $menuToggle = $('button.navbar-toggler');
-  const $itemWithSubmenu = $('.menu-item-has-children');
+  //const $itemWithSubmenu = $('.menu-item-has-children');
+  const $submenuButton = $('.menu-item-has-children button');
 
   $menuToggle.on('click', function (e) {
     // toggle "aria-expanded"
@@ -47,6 +48,25 @@ function createToc() {
     $menu.toggleClass('show');
   })
 
+  $submenuButton.on('click', function (e) {
+    $itemWithSubmenu = $(e.target).parent();
+    isOpen = $itemWithSubmenu.find('ul.sub-menu').hasClass('open');
+
+    if(isOpen) {
+      $itemWithSubmenu.find('ul.sub-menu').removeClass('open');
+      $itemWithSubmenu.find('> a').attr("aria-expanded", 'false');
+      $itemWithSubmenu.find('> button').attr("aria-expanded", 'false');
+      $itemWithSubmenu.find('> button span').text('Open');
+    } else {
+      $itemWithSubmenu.find('ul.sub-menu').addClass('open');
+      $itemWithSubmenu.find('> a').attr("aria-expanded", 'true');
+      $itemWithSubmenu.find('> button').attr("aria-expanded", 'true');
+      $itemWithSubmenu.find('> button span').text('Close');
+    }
+  })
+
+
+  /*
   $itemWithSubmenu.on(
     'focusin mouseover', function (e) {
       // if target is within submenu, "aria-expanded" is true
@@ -59,6 +79,7 @@ function createToc() {
         $itemWithSubmenu.attr('aria-expanded', false);
       }
     })
+  */
 
   createToc();
 

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -131,8 +131,8 @@ nav ul, .sub-menu {
     padding: 10px 15px 10px 11px;
 }
 
-.menu-item-has-children a {
-    padding-right: 25px;
+.nav > li.menu-item-has-children > a {
+    padding-right: 10px;
 }
 
 .menu-item-has-children button {
@@ -241,6 +241,10 @@ button.navbar-toggler[aria-expanded='true']::after {
 
 /* Small screens */
 @media screen and (max-width: 599px) {
+    li.menu-item-has-children .sub-menu--button {
+        display: none;
+    }
+
     .nav.nav--primary:not(.show) {
         display: none;
     }

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -110,8 +110,11 @@ nav ul, .sub-menu {
     border-left: 4px solid #284162;
 }
 
+/*
 .nav--primary li:hover > .sub-menu,
 .nav--primary li:focus-within > .sub-menu,
+*/
+.nav--primary li > .sub-menu.open,
 .nav--primary li > .sub-menu:hover,
 .nav--primary li > .sub-menu:focus {
    visibility: visible;
@@ -132,6 +135,17 @@ nav ul, .sub-menu {
     padding-right: 25px;
 }
 
+.menu-item-has-children button {
+    padding: 14px 14px;
+    margin-left: -4px;
+}
+
+.menu-item-has-children:hover button,
+.menu-item-has-children > a:focus + button,
+.menu-item-has-children > button:focus {
+        background: #e2e2e2;
+}
+
 button.navbar-toggler {
     color: #284162;
     padding: 10px 25px 10px 15px;
@@ -144,7 +158,6 @@ button.navbar-toggler:hover {
     color: #0535d2;
     background: #d4d6da;
 }
-
 
 button.navbar-toggler[aria-expanded]::after {
     color: currentColor;
@@ -202,14 +215,13 @@ button.navbar-toggler[aria-expanded='true']::after {
         background: #e1e1e1;
     }
 
-    .nav--primary > .menu-item-has-children > a::after {
+    .nav--primary > .menu-item-has-children > button::after {
         color: currentColor;
         border-style: solid;
         border-width: 2px 2px 0 0;
         content: '';
         display: inline-block;
         height: 8px;
-        left: 10px;
         position: relative;
         top: -3px;
         transform: rotate(-225deg);
@@ -218,8 +230,7 @@ button.navbar-toggler[aria-expanded='true']::after {
         transition: all 0.2s ease;
     }
     
-    .nav--primary > .menu-item-has-children:hover > a::after,
-    .nav--primary > .menu-item-has-children:focus-within > a::after {
+    .nav--primary > .menu-item-has-children > button[aria-expanded="true"]::after {
         transform: rotate(-45deg);
     }
 


### PR DESCRIPTION
# Summary 

Add a little button to the nav menu instead of just the hover state.

The interaction we end up with is:

- Hover over "Contact us" link - highlights it with the focus colour, and submenu toggle button has hover state
- Hover over toggle button - opens the submenu, will close in 1 second once you un-hover
- Click on "Contact us" - links to page
- Click on toggle button: closes or opens submenu. Submenu stays open until arrow is clicked or another submenu is opened
- Focus on “contact us”: Focus indicator over "Contact us", and submenu toggle button has hover state
- Focus on toggle button: Focus indicator on toggle button, space or enter to open submenu.  Focus moves into submenu. Submenu stays open until arrow is clicked or another submenu is opened.

On mobile screens, the submenu toggle button disappears.

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/362



## gif

![Screen Recording 2022-05-18 at 20 03 28](https://user-images.githubusercontent.com/2454380/169136798-75d4f6c2-29d3-44ea-9878-cd0da10503cf.gif)
