### PR TITLE
Recursively composer install gc-lists dependencies

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -117,7 +117,8 @@
       "cd wp-content/themes/cds-default && composer compile-translations",
       "cd wp-content/plugins/cds-base && composer compile-translations"
     ],
-    "generate-encryption-key": "CDS\\Modules\\Cli\\GenerateEncryptionKey::generateEncryptionKey"
+    "generate-encryption-key": "CDS\\Modules\\Cli\\GenerateEncryptionKey::generateEncryptionKey",
+    "post-install-cmd": "cd wp-content/plugins/gc-lists && composer install"
   },
   "autoload": {
     "psr-4": {

--- a/wordpress/wp-content/plugins/gc-lists/gc-lists.php
+++ b/wordpress/wp-content/plugins/gc-lists/gc-lists.php
@@ -14,6 +14,8 @@
 
 namespace GCLists;
 
+use Exception;
+
 /**
  * Autoloader
  */


### PR DESCRIPTION
Recuirsively build gc-lists plugin on composer install.
Also adds missing import for `\Exception`
