### PR TITLE
Refactor gc-lists templates to simplify by moving logic to Menu.php

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/resources/templates/messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/resources/templates/messages.php
@@ -1,24 +1,15 @@
 <?php
-
-use CDS\Modules\Notify\Utils;
-
+/**
+ * Base template for the messages UI
+ *
+ * @var string $title
+ * @var array $services
+ * @var object $user
+ */
 ?>
 
 <h1><?php echo $title ?></h1>
 
-<?php
-$serviceId = Utils::extractServiceIdFromApiKey(get_option('NOTIFY_API_KEY'));
-
-$services[] = [
-    'name' => __('Your Lists', 'cds-snc'),
-    'service_id' => $serviceId,
-    'sendingTemplate' => get_option('NOTIFY_GENERIC_TEMPLATE_ID', '')
-];
-
-$user = new \stdClass();
-$user->hasEmail = current_user_can('list_manager_bulk_send');
-$user->hasPhone = current_user_can('list_manager_bulk_send_sms');
-?>
 <!-- app -->
 <div class="wrap">
     <?php
@@ -31,6 +22,7 @@ $user->hasPhone = current_user_can('list_manager_bulk_send_sms');
     <div id="list-manager-app" data-user='<?php echo json_encode($user); ?>' data-ids='<?php echo json_encode($services); ?>'>
     </div>
 </div>
+
 <script>
     window.location = "#/messages";
 </script>

--- a/wordpress/wp-content/plugins/gc-lists/resources/templates/no_api_key.php
+++ b/wordpress/wp-content/plugins/gc-lists/resources/templates/no_api_key.php
@@ -1,10 +1,19 @@
-<h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+<?php
+
+/**
+ * Notify API Key not configured alert
+ *
+ * @var string $title
+ */
+?>
+
+<h1><?php echo $title; ?></h1>
 
 <p>
     <?php
-    echo sprintf(
-        __('You must configure your <a href="%s">Notify API Key</a>', 'cds-snc'),
-        admin_url("options-general.php?page=notify-settings")
-    );
-    ?>
+        echo sprintf(
+            __('You must configure your <a href="%s">Notify API Key</a>', 'cds-snc'),
+            admin_url("options-general.php?page=notify-settings")
+        );
+        ?>
 </p>

--- a/wordpress/wp-content/plugins/gc-lists/resources/templates/subscribers.php
+++ b/wordpress/wp-content/plugins/gc-lists/resources/templates/subscribers.php
@@ -1,24 +1,15 @@
 <?php
-
-use CDS\Modules\Notify\Utils;
-
+/**
+ * Base template for the lists UI
+ *
+ * @var string $title
+ * @var array $services
+ * @var object $user
+ */
 ?>
 
 <h1><?php echo $title ?></h1>
 
-<?php
-$serviceId = Utils::extractServiceIdFromApiKey(get_option('NOTIFY_API_KEY'));
-
-$services[] = [
-    'name' => __('Your Lists', 'cds-snc'),
-    'service_id' => $serviceId,
-    'sendingTemplate' => get_option('NOTIFY_GENERIC_TEMPLATE_ID', '')
-];
-
-$user = new \stdClass();
-$user->hasEmail = current_user_can('list_manager_bulk_send');
-$user->hasPhone = current_user_can('list_manager_bulk_send_sms');
-?>
 <!-- app -->
 <div class="wrap">
     <?php
@@ -31,6 +22,7 @@ $user->hasPhone = current_user_can('list_manager_bulk_send_sms');
     <div id="list-manager-app" data-user='<?php echo json_encode($user); ?>' data-ids='<?php echo json_encode($services); ?>'>
     </div>
 </div>
+
 <script>
     window.location = "#/lists";
 </script>

--- a/wordpress/wp-content/plugins/gc-lists/src/Menu.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Menu.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GCLists;
 
+use CDS\Modules\Notify\Utils;
+
 class Menu
 {
     protected static $instance;
@@ -61,6 +63,34 @@ class Menu
         );
     }
 
+    public function extractServiceIdFromApiKey($apiKey): string
+    {
+        return substr($apiKey, -73, 36);
+    }
+
+    public function getServiceId()
+    {
+        return $this->extractServiceIdFromApiKey(get_option('NOTIFY_API_KEY'));
+    }
+
+    public function getServices()
+    {
+        return [
+            'name' => __('Your Lists', 'cds-snc'),
+            'service_id' => $this->getServiceId(),
+            'sendingTemplate' => get_option('NOTIFY_GENERIC_TEMPLATE_ID', '')
+        ];
+    }
+
+    public function getUserPermissions()
+    {
+        $user = new \stdClass();
+        $user->hasEmail = current_user_can('list_manager_bulk_send');
+        $user->hasPhone = current_user_can('list_manager_bulk_send_sms');
+
+        return $user;
+    }
+
     public function renderMessages(): void
     {
         if (!get_option('NOTIFY_API_KEY')) {
@@ -68,10 +98,10 @@ class Menu
             exit;
         }
 
-        $messages = "Hello";
-
         $this->render('messages', [
-            'title' => 'Messages'
+            'title' => __('Messages', 'cds-snc'),
+            'services' => $this->getServices(),
+            'user' => $this->getUserPermissions(),
         ]);
     }
 
@@ -83,13 +113,17 @@ class Menu
         }
 
         $this->render('subscribers', [
-            'title' => 'Subscribers'
+            'title' => __('Subscribers', 'cds-snc'),
+            'services' => $this->getServices(),
+            'user' => $this->getUserPermissions(),
         ]);
     }
 
     public function renderNoApiKey()
     {
-        $this->render('no_api_key');
+        $this->render('no_api_key', [
+            'title' => esc_html(get_admin_page_title())
+        ]);
     }
 
     public function enqueue($hook_suffix)

--- a/wordpress/wp-content/plugins/gc-lists/src/Menu.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Menu.php
@@ -77,7 +77,7 @@ class Menu
      *
      * @return string
      */
-    public function getServiceId()
+    public function getServiceId(): string
     {
         return $this->extractServiceIdFromApiKey(get_option('NOTIFY_API_KEY'));
     }
@@ -87,12 +87,11 @@ class Menu
      *
      * @return array
      */
-    public function getServices()
+    public function getServices(): array
     {
         return [
             'name' => __('Your Lists', 'cds-snc'),
-            'service_id' => $this->getServiceId(),
-            'sendingTemplate' => get_option('NOTIFY_GENERIC_TEMPLATE_ID', '')
+            'service_id' => $this->getServiceId()
         ];
     }
 
@@ -101,7 +100,7 @@ class Menu
      *
      * @return \stdClass
      */
-    public function getUserPermissions()
+    public function getUserPermissions(): \stdClass
     {
         $user = new \stdClass();
         $user->hasEmail = current_user_can('list_manager_bulk_send');

--- a/wordpress/wp-content/plugins/gc-lists/src/Menu.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Menu.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace GCLists;
 
-use CDS\Modules\Notify\Utils;
-
 class Menu
 {
     protected static $instance;
@@ -63,16 +61,32 @@ class Menu
         );
     }
 
+    /**
+     * Extract ServiceID from API key
+     *
+     * @param $apiKey
+     * @return string
+     */
     public function extractServiceIdFromApiKey($apiKey): string
     {
         return substr($apiKey, -73, 36);
     }
 
+    /**
+     * Get ServiceId
+     *
+     * @return string
+     */
     public function getServiceId()
     {
         return $this->extractServiceIdFromApiKey(get_option('NOTIFY_API_KEY'));
     }
 
+    /**
+     * Get services array
+     *
+     * @return array
+     */
     public function getServices()
     {
         return [
@@ -82,6 +96,11 @@ class Menu
         ];
     }
 
+    /**
+     * Build up a user permissions object for the current user
+     *
+     * @return \stdClass
+     */
     public function getUserPermissions()
     {
         $user = new \stdClass();
@@ -91,6 +110,9 @@ class Menu
         return $user;
     }
 
+    /**
+     * Render messages template
+     */
     public function renderMessages(): void
     {
         if (!get_option('NOTIFY_API_KEY')) {
@@ -105,6 +127,9 @@ class Menu
         ]);
     }
 
+    /**
+     * Render subscribers template
+     */
     public function renderSubscribers(): void
     {
         if (!get_option('NOTIFY_API_KEY')) {
@@ -119,6 +144,9 @@ class Menu
         ]);
     }
 
+    /**
+     * Render NoApiKey error
+     */
     public function renderNoApiKey()
     {
         $this->render('no_api_key', [


### PR DESCRIPTION
# Summary | Résumé

Tidied up the templates used to render the lists and messages apps:
- Moved logic out to Menu.php
- Added phpdoc headers so phpstorm doesn't complain about Undefined variables