### PR TITLE
Handle editor content

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/EditTemplate.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/EditTemplate.tsx
@@ -106,8 +106,7 @@ export const EditTemplate = () => {
             <div>
                 <button style={{ marginRight: "20px" }}
                     onClick={async () => {
-                        //@todo handle validation
-                        navigate(`/messages/send/${templateId}`, { state: getValues() });
+                        navigate(`/messages/send/${templateId}`, { state: { ...getValues(), template: currentTemplate && serialize(currentTemplate) } });
                     }}
                     className="button button-primary">
                     {__('Send message to a list', 'cds-snc')}


### PR DESCRIPTION
After updating the validation in https://github.com/cds-snc/gc-articles/pull/813 -- we need this update to send the template content "not" via the hidden field.