### PR TITLE
Add sort option to collection routes

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/SendingHistory.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/SendingHistory.tsx
@@ -28,7 +28,6 @@ export const SendingHistory = ({ perPage, pageNav, allLink }: { perPage?: number
         const getSentMessages = async () => {
             setLoading(true);
             await request.get(`/messages/sent?${uuidv4()}`);
-            console.log(response.data);
             if (response.ok) {
                 setData(response.data);
                 setLoading(false)

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/store/useTemplateApi.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/store/useTemplateApi.tsx
@@ -48,7 +48,7 @@ function useTemplateApi() {
     const getTemplates = async () => {
         setLoading(true);
         let templates: any = [];
-        await request.get("/messages");
+        await request.get("/messages?sort=desc");
 
         if (response.ok) {
             response.data.forEach((item: any) => {

--- a/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/Messages.php
@@ -538,6 +538,11 @@ class Messages extends BaseEndpoint
             $options['limit'] = (int)$params['limit'] ?: 5;
         }
 
+        // asc or desc will sortBy created_at
+        if (isset($params['sort']) && in_array($params['sort'], ['asc', 'desc'])) {
+            $options['sort'] = $params['sort'];
+        }
+
         return $options;
     }
 }

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Message.php
@@ -230,11 +230,24 @@ class Message extends Model
      */
     public static function templates(array $options = []): ?Collection
     {
-        $messages = static::whereNull('original_message_id', $options);
+        $messages = static::whereNull('original_message_id');
 
+        // In case the name of the template has been changed, display latest
         $messages->map(function ($message) {
             $message->name = $message->latest()->name;
         });
+
+        // Apply sort if provided
+        if (isset($options['sort']) && $options['sort'] === 'desc') {
+            $messages = $messages->sortByDesc(function ($message) {
+                return strtotime($message->created_at);
+            })->values();
+        }
+
+        // Apply limit if provided
+        if (isset($options['limit'])) {
+            $messages = $messages->take((int)$options['limit']);
+        }
 
         return $messages;
     }
@@ -248,6 +261,20 @@ class Message extends Model
      */
     public static function sentMessages(array $options = []): ?Collection
     {
-        return static::whereNotNull(['sent_at'], $options);
+        $messages = static::whereNotNull(['sent_at']);
+
+        // Apply sort if provided
+        if (isset($options['sort']) && $options['sort'] === 'desc') {
+            $messages = $messages->sortByDesc(function ($message) {
+                return strtotime($message->created_at);
+            })->values();
+        }
+
+        // Apply limit if provided
+        if (isset($options['limit'])) {
+            $messages = $messages->take((int)$options['limit']);
+        }
+
+        return $messages;
     }
 }

--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -456,7 +456,7 @@ class Model implements JsonSerializable
 
         $query = "SELECT {$instance->getVisibleColumns()} FROM {$instance->tableName}";
 
-        if (isset($options['limit'])) {
+        if (isset($options['limit']) && is_numeric($options['limit'])) {
             $query .= " LIMIT {$options['limit']}";
         }
 
@@ -486,7 +486,7 @@ class Model implements JsonSerializable
             $query .= $wpdb->prepare(" AND {$key} = %s", $value);
         }
 
-        if (isset($options['limit'])) {
+        if (isset($options['limit']) && is_numeric($options['limit'])) {
             $query .= " LIMIT {$options['limit']}";
         }
 
@@ -521,7 +521,7 @@ class Model implements JsonSerializable
             $query .= " AND {$column} IS NOT NULL";
         }
 
-        if (isset($options['limit'])) {
+        if (isset($options['limit']) && is_numeric($options['limit'])) {
             $query .= " LIMIT {$options['limit']}";
         }
 
@@ -556,7 +556,7 @@ class Model implements JsonSerializable
             $query .= " AND {$column} IS NULL";
         }
 
-        if (isset($options['limit'])) {
+        if (isset($options['limit']) && is_numeric($options['limit'])) {
             $query .= " LIMIT {$options['limit']}";
         }
 


### PR DESCRIPTION
# Summary | Résumé

Enables sorting collection results by created_at on the `/messages` and `/messages/sent` endpoints.
