### PR TITLE
Add where filter to base Model

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Database/Models/Model.php
@@ -510,7 +510,7 @@ class Model implements JsonSerializable
      *
      * @return Collection|null
      */
-    public static function andWhere(array $whereClauses, array $options = []): ?Collection
+    public static function where(array $whereClauses, array $options = []): ?Collection
     {
         global $wpdb;
         $instance = new static();

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
@@ -252,16 +252,16 @@ test('Retrieve using where', function() {
 
     $message->send($uuid, $listName, 1, $email);
 
-    $sentOriginals = Message::andWhere(['sent_at IS NOT NULL', 'original_message_id IS NULL']);
+    $sentOriginals = Message::where(['sent_at IS NOT NULL', 'original_message_id IS NULL']);
     $this->assertEquals(0, $sentOriginals->count());
 
-    $originals = Message::andWhere(['original_message_id IS NULL']);
+    $originals = Message::where(['original_message_id IS NULL']);
     $this->assertEquals(1, $originals->count());
 
-    $sent = Message::andWhere(['sent_at IS NOT NULL']);
+    $sent = Message::where(['sent_at IS NOT NULL']);
     $this->assertEquals(1, $sent->count());
 
-    $versions = Message::andWhere(["original_message_id = {$message_id}"]);
+    $versions = Message::where(["original_message_id = {$message_id}"]);
     $this->assertEquals(2, $versions->count());
 });
 

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/Database/Models/TestMessage.php
@@ -237,6 +237,34 @@ test('Retrieve using whereNull param and Limit', function() {
     $this->assertEquals(5, count($messages));
 });
 
+test('Retrieve using where', function() {
+    $message_id = $this->factory->message->create([
+        'name' => 'Foo'
+    ]);
+
+    $message = Message::find($message_id);
+    $message->name = 'Bar';
+    $message->saveVersion();
+
+    $uuid = faker()->uuid();
+    $email = faker()->email;
+    $listName = 'This is a list name';
+
+    $message->send($uuid, $listName, 1, $email);
+
+    $sentOriginals = Message::andWhere(['sent_at IS NOT NULL', 'original_message_id IS NULL']);
+    $this->assertEquals(0, $sentOriginals->count());
+
+    $originals = Message::andWhere(['original_message_id IS NULL']);
+    $this->assertEquals(1, $originals->count());
+
+    $sent = Message::andWhere(['sent_at IS NOT NULL']);
+    $this->assertEquals(1, $sent->count());
+
+    $versions = Message::andWhere(["original_message_id = {$message_id}"]);
+    $this->assertEquals(2, $versions->count());
+});
+
 test('Create a model with invalid attribute throws InvalidAttributeException', function() {
     $this->expectException(InvalidAttributeException::class);
 


### PR DESCRIPTION
# Summary | Résumé

Add an `where` filter to the base Model. Enables querying the model using an array of custom WHERE...AND clauses.

Accepts an array of SQL conditions that will be resolved as inclusive ANDs.

For example:

```
Message::where([
    'sent_at IS NOT NULL', 
    'original_message_id = 5'
])
```

Will result in a query like:

```
SELECT * from messages
WHERE 1=1
AND sent_at IS NOT NULL
AND original_message_id = 5
```

Which will return all sent versions of a given original message.