### PR TITLE
Include service_api_key in payload to list manager send endpoint

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/src/Api/SendMessage.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Api/SendMessage.php
@@ -27,6 +27,7 @@ class SendMessage
                 ]),
                 'template_id' => get_option('NOTIFY_GENERIC_TEMPLATE_ID'),
                 'template_type' => "email",
+                'service_api_key' => get_option('NOTIFY_API_KEY'),
             ]),
         ];
 


### PR DESCRIPTION
# Summary | Résumé

We weren't including the service_api_key in the payload to list-manager/send so it was defaulting to the default Notify API key which is our generic GC Articles service.  Obviously once we tried using a custom service, we started seeing template not found errors from Notify because it was looking in the wrong service.