### PR TITLE
Style empty placeholders

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/ListTemplates.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/ListTemplates.tsx
@@ -32,6 +32,23 @@ const StyledDeleteButton = styled.button`
     }
 `;
 
+export const StyledPlaceholder = styled.div`
+    display:block;
+    border: 1px solid #CCCCCC;
+    min-width:250px;
+    padding:10px;
+
+    h3 {
+        display:inline-block;
+        font-size: 1.2em;
+        margin: 0;
+    }
+
+    p {
+        margin: 0;
+    }
+`
+
 export const ListTemplates = ({ perPage, pageNav }: { perPage?: number, pageNav?: boolean }) => {
     const { loading, templates, getTemplates, deleteTemplate } = useTemplateApi();
 
@@ -138,7 +155,10 @@ export const ListTemplates = ({ perPage, pageNav }: { perPage?: number, pageNav?
                     <>
                         {!loading &&
                             <>
-                                <p>{__("You have no draft messages", "gc-lists")}</p>
+                                <StyledPlaceholder>
+                                    <h3>{__("You have no draft messages", "gc-lists")}</h3>
+                                    <p>{__("Saving a draft allows you to keep a message you aren't ready to send yet.", "gc-lists")}</p>
+                                </StyledPlaceholder>
                             </>
                         }
                     </>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/SendingHistory.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/SendingHistory.tsx
@@ -11,6 +11,7 @@ import { Table, StyledPaging, StyledLink } from "./Table";
 import { Next } from "./icons/Next";
 
 import { v4 as uuidv4 } from 'uuid';
+import { StyledPlaceholder } from './ListTemplates';
 
 const StyledTableLink = styled(Link)`
     text-decoration:underline !important;
@@ -90,6 +91,9 @@ export const SendingHistory = ({ perPage, pageNav, allLink }: { perPage?: number
         </> :
         <>
             <h2>{__("Sending history", "gc-lists")}</h2>
-            <p>{__("You have no sent messages", "gc-lists")}</p>
+            <StyledPlaceholder>
+                <h3>{__("You have not sent any message yet.", "gc-lists")}</h3>
+                <p>{__("When you send a message, a copy is automatically saved in your sending history.", "gc-lists")}</p>
+            </StyledPlaceholder>
         </>
 }


### PR DESCRIPTION
# Summary | Résumé

Updates text and adds some styling around the placeholders when there are no Drafts or Sent Messsages

<img width="710" alt="image" src="https://user-images.githubusercontent.com/1187115/173870965-51f45c25-9ed2-4eda-8d7b-268bbcddc8ed.png">

