### PR TITLE
Feature/testing setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,7 +53,8 @@ RUN echo "source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highl
 # A few helpful aliases
 RUN echo "alias gclists=\"cd ~/project/wordpress/wp-content/plugins/gc-lists\"" >> ~/.zshrc && \
     echo "alias cds=\"cd ~/project/wordpress/wp-content/plugins/cds-base\"" >> ~/.zshrc && \
-    echo "alias webroot=\"cd /usr/src/wordpress\"" >> ~/.zshrc
+    echo "alias webroot=\"cd /usr/src/wordpress\"" >> ~/.zshrc && \
+    echo "alias wordpress=\"cd ~/project/wordpress\"" >> ~/.zshrc
 
 ENV SHELL /bin/zsh
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,6 +50,11 @@ RUN echo "source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highl
     echo "source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc && \
     echo "PROMPT=\"(devcontainer) \$PROMPT\"" >> ~/.zshrc
 
+# A few helpful aliases
+RUN echo "alias gclists=\"cd ~/project/wordpress/wp-content/plugins/gc-lists\"" >> ~/.zshrc && \
+    echo "alias cds=\"cd ~/project/wordpress/wp-content/plugins/cds-base\"" >> ~/.zshrc && \
+    echo "alias webroot=\"cd /usr/src/wordpress\"" >> ~/.zshrc
+
 ENV SHELL /bin/zsh
 
 CMD ["sleep", "infinity"]

--- a/wordpress/wp-content/plugins/gc-lists/composer.json
+++ b/wordpress/wp-content/plugins/gc-lists/composer.json
@@ -33,6 +33,8 @@
     },
     "type": "wordpress-plugin",
     "scripts": {
+        "prepare-test-db": "echo y | ./bin/install-wp-tests.sh wordpress_testing root secret db",
+        "test": "pest --coverage",
         "make-pot": "wp i18n make-pot --domain=gc-lists . languages/gc-lists.pot",
         "merge-po": "msgmerge -U --no-wrap --backup none -N ./languages/gc-lists-fr_CA.po ./languages/gc-lists.pot",
         "compile-mo": "msgfmt -o ./languages/gc-lists-fr_CA.mo ./languages/gc-lists-fr_CA.po",

--- a/wordpress/wp-content/plugins/gc-lists/package.json
+++ b/wordpress/wp-content/plugins/gc-lists/package.json
@@ -1,9 +1,10 @@
-
 {
     "name": "gc-lists",
     "version": "1.0.0",
     "author": "Canadian Digital Service",
-    "scripts" : {
-      "postinstall": "cd resources/js && npm install && npm run build"
+    "scripts": {
+        "postinstall": "cd resources/js && npm install && npm run build",
+        "prepare-test-db": "echo y | ./bin/install-wp-tests.sh wordpress_testing root secret db",
+        "test": "./vendor/bin/pest --coverage"
     }
 }


### PR DESCRIPTION
# Summary | Résumé

Adds some script commands to assist with running GC Lists tests. The following commands are available within the gc-lists plugin folder:

**Prepare the testing database:**
- `composer prepare-test-db` or
- `npm run prepare-test-db`

**Run PHP tests:**
- `composer test` or
- `npm run test`

Also adds a few helpful aliases to the devcontainer:

| Alias  | Destination |
| ------------- | ------------- |
| wordpress  | /home/default/project/wordpress |
| gclists | /home/default/project/wordpress/wp-content/plugins/gc-lists  |
| cds | /home/default/project/wordpress/wp-content/plugins/cds-base |
| webroot | /usr/src/wordpress |