### PR TITLE
Security Headers Plugin: Use correct CSP header name, and remove others for now

### DIFF
--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -87,9 +87,7 @@ function cds_security_headers($headers)
         }
     }
 
-    $headers['X-XSS-Protection'] = '1; mode=block';
-    $headers['X-Content-Type-Options'] = 'nosniff';
-    $headers['X-Content-Security-Policy'] = $csp;
+    $headers['Content-Security-Policy'] = $csp;
 
     return $headers;
 }


### PR DESCRIPTION
# Summary | Résumé

X-Content-Security-Policy header is deprecated (and Chrome does not enforce), updated to Content-Security-Policy.

Also going to leave off the other headers for now, focus on CSP.
