### PR TITLE
WPML: Only retrieve trid from post meta if it cannot be retrieved otherwise

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Wpml.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Wpml.php
@@ -50,10 +50,11 @@ class Wpml
      */
     public function retrieveTridFromPostMeta($trid, $post_status)
     {
-        global $post;
-        if (isset($post) && isset($post->ID)) {
-            $trid = get_post_meta($post->ID, 'wpml_trid', true);
-            return $trid;
+        if (!$trid) {
+            global $post;
+            if (isset($post) && isset($post->ID)) {
+                $trid = get_post_meta($post->ID, 'wpml_trid', true);
+            }
         }
 
         return $trid;


### PR DESCRIPTION
# Summary | Résumé

In our previous fix (#869 #872) we inadvertently broke the other method of adding page translations from the sidebar. With this change we will only retrieve the trid from post meta *if* it is not available otherwise from $_POST, $_GET, or referer (the default behaviour).
