### PR TITLE
Bugfix - Flyout menu - catch and log exception

### DIFF
--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -62,7 +62,11 @@ function createToc() {
       
     } else {
       // close other submenus
-      closeMenu($('li.menu-item-has-children').remove($itemWithSubmenu))
+      try {
+        closeMenu($('li.menu-item-has-children').remove($itemWithSubmenu))
+      } catch (e) {
+        console.log(e);
+      }
   
       openMenu($itemWithSubmenu, isMouseEnter)
     }


### PR DESCRIPTION
# Summary | Résumé

There was an uncaught exception causing the flyout menu to break in some situations. Catching the exception seems to fix the issue, we'll log it for now and see if we can identify the underlying issue later.
