### PR TITLE
Configure php memory_limit and php.ini in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/wordpress
 
 USER root
 
+RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+
 RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
     libmcrypt-dev && \
     # install dev utils

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       - ./:/home/default/project
       - ~/.ssh:/home/default/.ssh
       - ~/.gitconfig:/home/default/.gitconfig
+      - ./wordpress/docker/php/conf.d/memory_limit.ini:/usr/local/etc/php/conf.d/memory_limit.ini
     restart: unless-stopped
     networks:
       - app-network


### PR DESCRIPTION
# Summary | Résumé

Copy PHP config into devcontainer.
PHP CLI was throwing an out of memory error in some circumstances, due to these missing config files.
