### PR TITLE
CSS fixes

### DIFF
--- a/wordpress/wp-content/themes/cds-default/js/main.js
+++ b/wordpress/wp-content/themes/cds-default/js/main.js
@@ -73,13 +73,13 @@ function createToc() {
   })
   
   // set a timer when we mouseleave
-  $('.sub-menu').on('mouseleave', function(e) {
+  $('li.menu-item-has-children').on('mouseleave', function(e) {
     $itemWithSubmenu = $(e.target).parents('li.menu-item-has-children');
     isOpenMouseenter = $itemWithSubmenu.find('ul.sub-menu.open.mouseenter').length > 0
 
     if(isOpenMouseenter) {
       clearTimeout(closeMenuTimeout)
-      closeMenuTimeout = setTimeout(() => closeMenu($itemWithSubmenu), 1000);
+      closeMenuTimeout = setTimeout(() => closeMenu($itemWithSubmenu), 500);
     }
   })
 

--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -341,6 +341,7 @@ nav.nav--about li a:focus {
     }
     .wp-block-columns:not(.is-not-stacked-on-mobile)>.wp-block-column.page__content {
         flex: 5 !important;
+        margin-left: var(--wp--style--block-gap, 2em);
     }
 }
 


### PR DESCRIPTION
# Summary | Résumé

There are 2 fixes in here: 
- Add padding back to the left-hand menu, resolves https://github.com/cds-snc/gc-articles/issues/881
- Fix the menu hover interaction, resolves https://github.com/cds-snc/gc-articles/issues/882

(Note: Issue https://github.com/cds-snc/gc-articles/issues/882 is already resolved, but I just added that comment to automatically close the issue when this PR is merged.)

For the first issue, looks like when we upgraded to WP 6, we lost some CSS I was relying on. Just manually added it to our theme file and it's all good.

For the second issue, How the menu used to work was really annoying. You had to exit the _submenu_ specifically to get the menu to close itself (after a 1 second delay). This meant that if you triggered the button and then just left by moving your mouse up or sideways, that the menu would stay open forever.

Changed the "mouseout" selector so that it applies to everything inside the "has-submenu" link element, which means that it will trigger the delay to close the menu no matter where you leave it from. I've also shortened the delay to half a second, based on advice in [an article I was reading](https://www.smashingmagazine.com/2021/05/frustrating-design-patterns-mega-dropdown-hover-menus/)

> We need to make sure that the menu doesn’t open and doesn’t close too early. To achieve that, we introduce a delay, usually around 0.5 seconds.

| before | after |
|--------|-------|
|  mousing out of the button in most directions doesn't close the menu    |   However you leave the button, the menu closes    |
|  ![Screen Recording 2022-07-04 at 13 41 29](https://user-images.githubusercontent.com/2454380/177202020-283639b2-2ac3-4239-a9ad-c674fc34cbdf.gif)      |    ![Screen Recording 2022-07-04 at 14 01 20](https://user-images.githubusercontent.com/2454380/177202024-8887664c-dfd6-4705-95f9-a1e54b7b3ac1.gif)  |

