### PR TITLE
Remove WPML_TM_SETTINGS from page

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Cleanup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Cleanup.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CDS\Modules\Wpml;
 
+use Illuminate\Support\Str;
+
 class Cleanup
 {
     public static function register()
@@ -17,6 +19,19 @@ class Cleanup
     protected function addActions()
     {
         add_action('wpml_override_is_translator', '__return_true');
+
+        /**
+         * Removes WPML_TM_SETTINGS script from page which was serializing
+         * the WP_User object, including hashed password.
+         */
+        add_action('wp_print_scripts', function () {
+            global $wp_scripts;
+
+            if (!is_a($wp_scripts, 'WP_Scripts')) {
+                $wp_scripts = new \WP_Scripts();
+            }
+             $wp_scripts->remove('wpml-ate-jobs-sync-ui');
+        });
 
         add_action('admin_footer', function () {
 


### PR DESCRIPTION
# Summary | Résumé

WPML_TM_SCRIPTS was embedding a WP_User object on the page, which includes the user's hashed password.
