### PR TITLE
Disable and prevent access to xmlrpc

### DIFF
--- a/wordpress/.htaccess-multisite
+++ b/wordpress/.htaccess-multisite
@@ -1,6 +1,12 @@
 # BEGIN WordPress Multisite
 # Using subfolder network type: https://wordpress.org/support/article/htaccess/#multisite
 
+# Block WordPress xmlrpc.php requests
+<Files xmlrpc.php>
+order deny,allow
+ deny from all
+</Files>
+
 RewriteEngine On
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /

--- a/wordpress/wp-content/plugins/cds-base/index.php
+++ b/wordpress/wp-content/plugins/cds-base/index.php
@@ -161,4 +161,9 @@ if (! function_exists('wp_verify_nonce')) :
     }
 endif;
 
+/**
+ * Disable XMLRPC as authentication bypasses 2fa if configured.
+ */
+add_filter('xmlrpc_enabled', '__return_false');
+
 $setupComponents = new Setup();


### PR DESCRIPTION
# Summary | Résumé

Using XMLRPC for authentication bypasses 2fa if configured. This just disables and prevents access to it since we don't need it.