### PR TITLE
Fail nonce check on WPML rest actions

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/index.php
+++ b/wordpress/wp-content/plugins/cds-base/index.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 use CDS\Modules\Notify\NotifyTemplateSender;
 use CDS\Setup;
+use Illuminate\Support\Str;
 
 defined('ABSPATH') || exit();
 
@@ -103,6 +104,17 @@ if (! function_exists('wp_verify_nonce')) :
      */
     function wp_verify_nonce($nonce, $action = -1)
     {
+        /**
+         * Fail nonce check on all these actions
+         */
+        if (
+            Str::startsWith($action, 'WPML\TranslationRoles') ||
+            Str::startsWith($action, 'WPML\TM\ATE\AutoTranslate') ||
+            Str::startsWith($action, 'WPML\TM\ATE\TranslateEverything')
+        ) {
+            die("403 Unauthorized");
+        }
+
         $nonce = (string) $nonce;
         $user  = wp_get_current_user();
 

--- a/wordpress/wp-content/plugins/cds-base/index.php
+++ b/wordpress/wp-content/plugins/cds-base/index.php
@@ -112,7 +112,7 @@ if (! function_exists('wp_verify_nonce')) :
             Str::startsWith($action, 'WPML\TM\ATE\AutoTranslate') ||
             Str::startsWith($action, 'WPML\TM\ATE\TranslateEverything')
         ) {
-            die("403 Unauthorized");
+            die("403 Forbidden");
         }
 
         $nonce = (string) $nonce;

--- a/wordpress/wp-content/plugins/cds-base/index.php
+++ b/wordpress/wp-content/plugins/cds-base/index.php
@@ -112,7 +112,7 @@ if (! function_exists('wp_verify_nonce')) :
             Str::startsWith($action, 'WPML\TM\ATE\AutoTranslate') ||
             Str::startsWith($action, 'WPML\TM\ATE\TranslateEverything')
         ) {
-            die("403 Forbidden");
+            die('{ "success": false, "data": "403 Forbidden" }');
         }
 
         $nonce = (string) $nonce;


### PR DESCRIPTION
# Summary | Résumé

There are a bunch of WPML Rest Actions that are not multi-site safe. Since we don't use any of these features, we're just going to disable them by force-failing the nonce check.
