### PR TITLE
Add more security headers to management plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - ./wordpress/docker/php/conf.d/memory_limit.ini:/usr/local/etc/php/conf.d/memory_limit.ini
       - ./wordpress/docker/php/conf.d/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
       - ./wordpress/docker/php/conf.d/max_execution_time.ini:/usr/local/etc/php/conf.d/max_execution_time.ini
+      - ./wordpress/docker/php/conf.d/expose_php.ini:/usr/local/etc/php/conf.d/expose_php.ini
     networks:
       - app-network
 

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -37,6 +37,7 @@ COPY ./wordpress/docker/php/conf.d/error_reporting.ini /usr/local/etc/php/conf.d
 COPY ./wordpress/docker/php/conf.d/upload_max_filesize.ini /usr/local/etc/php/conf.d/upload_max_filesize.ini
 COPY ./wordpress/docker/php/conf.d/memory_limit.ini /usr/local/etc/php/conf.d/memory_limit.ini
 COPY ./wordpress/docker/php/conf.d/uploads.ini /usr/local/etc/php/conf.d/uploads.ini
+COPY ./wordpress/docker/php/conf.d/expose_php.ini /usr/local/etc/php/conf.d/expose_php.ini
 
 # Copy wp-content (including installed plugins) and vendor folder from composer stage
 COPY --from=composer /app/wordpress/wp-content ./wp-content

--- a/wordpress/docker/php/conf.d/expose_php.ini
+++ b/wordpress/docker/php/conf.d/expose_php.ini
@@ -1,0 +1,1 @@
+expose_php = off

--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -87,11 +87,16 @@ function cds_security_headers($headers)
         }
     }
 
-    $headers['Content-Security-Policy'] = $csp;
+    if (! is_admin()) {
+        $headers['Content-Security-Policy'] = $csp;
+    }
+
+    $headers['strict-transport-security'] = 'max-age=31536000; includeSubDomains; preload';
+    $headers['X-XSS-Protection'] = '1; mode=block';
+    $headers['X-Frame-Options'] = 'SAMEORIGIN';
+    $headers['X-Content-Type-Options'] = 'nosniff';
 
     return $headers;
 }
 
-if (! is_admin()) {
-    add_filter('wp_headers', 'cds_security_headers');
-}
+add_filter('wp_headers', 'cds_security_headers');

--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -89,10 +89,7 @@ function cds_security_headers($headers)
         }
     }
 
-    if (! is_admin()) {
-        $headers['Content-Security-Policy'] = $csp;
-    }
-
+    $headers['Content-Security-Policy'] = $csp;
     $headers['strict-transport-security'] = 'max-age=31536000; includeSubDomains; preload';
     $headers['X-XSS-Protection'] = '1; mode=block';
     $headers['X-Frame-Options'] = 'SAMEORIGIN';

--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -44,6 +44,7 @@ function cds_security_headers($headers)
             "https://wet-boew.github.io",
             "https://www.canada.ca",
             "https://secure.gravatar.com",
+            "2.gravatar.com"
         ],
         "manifest-src" => [
             "'self'",
@@ -61,6 +62,7 @@ function cds_security_headers($headers)
             "'sha256-8//zSBdstORCAlBMo1/Cig3gKc7QlPCh9QfWbRu0OjU='",
             "'sha256-5/P+Wb5Puz2VZQuyT0B/H3kuum7v7A2XDV17K95mm2Q='",
             "'sha256-Ll9Pj6gzPpETya7YXsYglTFBzjPg0sc23VG6sms7FKE='",
+            "'sha256-9vpql/NLyCCe3HPEb2b/lcLKPbkRi48w2Lfn0AbTxsQ='",
             "https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js",


### PR DESCRIPTION
# Summary | Résumé

Fleshes out the security headers plugin with HSTS, XSS, X-Frame-Options, and X-Content-Type-Options headers.

Also conditionally adds only the CSP headers on non-admin pages.
