### PR TITLE
Update the php CLI version in our install step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
     depends_on:
       - db
       - wordpress
-    image: wordpress:cli-php8.0
+    image: wordpress:cli-php8.1
     profiles:
       - tools
     env_file: .env


### PR DESCRIPTION
Running 'docker-composer run install' was failing because our version of PHP hadn't been updated to 8.1

But now it's all good.
