### PR TITLE
Fixes for Checklists Plugin

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -39,11 +39,21 @@ class Setup
             add_action('enqueue_block_editor_assets', [$this, 'enqueueGutenbergScripts']);
             add_action('admin_footer', [$this, 'ppcMarkup']);
 
+            add_filter('publishpress_checklists_supported_module_post_types_args', [$this, 'onlyPublicPostTypes']);
+
             // Keep until issue is solved: https://github.com/publishpress/PublishPress-Checklists/issues/369
             add_action('admin_init', [$this, 'defaultGETparam'], 99);
         }
     }
 
+    /* Only show public post types in the settings (we don't want Navigation Menus, for example)
+       https://github.com/publishpress/PublishPress-Checklists/blob/73b3a4b48de65f116b22671431f948fe0b527694/core/Legacy/Module.php#L96
+    */
+    public function onlyPublicPostTypes($postTypeArgs)
+    {
+        $postTypeArgs['public'] = true;
+        return $postTypeArgs;
+    }
 
     public function defaultGETparam()
     {

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -40,9 +40,6 @@ class Setup
             add_action('admin_footer', [$this, 'ppcMarkup']);
 
             add_filter('publishpress_checklists_supported_module_post_types_args', [$this, 'onlyPublicPostTypes']);
-
-            // Keep until issue is solved: https://github.com/publishpress/PublishPress-Checklists/issues/369
-            add_action('admin_init', [$this, 'defaultGETparam'], 99);
         }
     }
 
@@ -53,18 +50,6 @@ class Setup
     {
         $postTypeArgs['public'] = true;
         return $postTypeArgs;
-    }
-
-    public function defaultGETparam()
-    {
-        if (!isset($_POST['action'], $_POST['_wpnonce'], $_POST['option_page'], $_POST['_wp_http_referer'], $_POST['submit']) || !is_admin()) {
-            return false;
-        }
-
-        if (!isset($_GET['page'])) {
-            // set a default GET['page'] param if none exists
-            $_GET = array_merge($_GET, array( 'page' => 'cds-default' ));
-        }
     }
 
     public function addChecklistRole(): void

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/js/meta-box.js
@@ -154,12 +154,15 @@ jQuery(document).ready(
 
         /* ====== Events ====== */
 
-        /* Observer that triggers whenever a checkbox's state changes */
-        const checkboxObserver = new MutationObserver((e) => ppc_checkbox_function());
-        checkboxObserver.observe($itemsContainer[0], {
-            subtree: true,
-            attributeFilter: ['class']}
-        );
+        /* Only set mutation observer if there are checkboxes */
+        if($items.length) {
+            /* Observer that triggers whenever a checkbox's state changes */
+            const checkboxObserver = new MutationObserver((e) => ppc_checkbox_function());
+            checkboxObserver.observe($itemsContainer[0], {
+                subtree: true,
+                attributeFilter: ['class']}
+            );
+        }
 
         // Trigger whenever the custom "publish" or "update" buttons are clicked
         $(document).on('click', "#ppc-update, #ppc-publish", function() {


### PR DESCRIPTION
# Summary | Résumé

This PR has 3 updates in it:
1. Solves a console bug where a jquery MutationObserver wouldn't have anything to attach to if the plugin was active but checklists were not applied to a post type.
2. Removes "Navigation Menu" from the post types that we can apply to checklists to. Checklists are only applicable to posts and pages now. 
3. Removes an action added to resolve a [downstream plugin issue](https://github.com/publishpress/PublishPress-Checklists/issues). The issue has been resolved in the plugin so we are good to remove this action hook.

The only visible change is that in the Checklist "Settings", you don't see "Navigation menus" anymore. Other than that, the changes are behind the scenes.
