### PR TITLE
Update references to alpha domain

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/RequestSiteForm.php
@@ -161,7 +161,7 @@ class RequestSiteForm
                     />
                     <div id="url-typer" class="url-typer gc-description" aria-live="polite" aria-atomic="true">
                         <div class="url-typer--empty"><?php _e('Enter a title to preview your URL', 'cds-snc'); ?></div>
-                        <div class="url-typer--message displayNone"><?php _e('Your URL preview:', 'cds-snc'); ?> <strong>articles.alpha.canada.ca/<span id="url-typer__preview"></span></strong></div>
+                        <div class="url-typer--message displayNone"><?php _e('Your URL preview:', 'cds-snc'); ?> <strong>articles.canada.ca/<span id="url-typer__preview"></span></strong></div>
                     </div>
                 </div>
                 <!-- end site -->

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Releases/Releases.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Releases/Releases.php
@@ -48,7 +48,7 @@ class Releases
 
     public function getEmbedPage()
     {
-        $response = wp_remote_get("https://articles.alpha.canada.ca/wp-json/wp/v2/pages/?slug=updates");
+        $response = wp_remote_get("https://articles.canada.ca/wp-json/wp/v2/pages/?slug=updates");
         $responseBody = wp_remote_retrieve_body($response);
         $result = json_decode($responseBody);
         if (is_array($result) && ! is_wp_error($result)) {

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/public/index.html
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/public/index.html
@@ -8,38 +8,38 @@
     <link
       rel="stylesheet"
       id="buttons-css"
-      href="https://articles.alpha.canada.ca/wp-includes/css/buttons.css?ver=5.9.2"
+      href="https://articles.canada.ca/wp-includes/css/buttons.css?ver=5.9.2"
       media="all"
     />
 
     <link
       rel="stylesheet"
       id="common-css"
-      href="https://articles.alpha.canada.ca/wp-admin/css/common.css?ver=5.9.2"
+      href="https://articles.canada.ca/wp-admin/css/common.css?ver=5.9.2"
       media="all"
     />
     <link
       rel="stylesheet"
       id="forms-css"
-      href="https://articles.alpha.canada.ca/wp-admin/css/forms.css?ver=5.9.2"
+      href="https://articles.canada.ca/wp-admin/css/forms.css?ver=5.9.2"
       media="all"
     />
     <link
       rel="stylesheet"
       id="list-tables-css"
-      href="https://articles.alpha.canada.ca/wp-admin/css/list-tables.css?ver=5.9.2"
+      href="https://articles.canada.ca/wp-admin/css/list-tables.css?ver=5.9.2"
       media="all"
     />
     <link
       rel="stylesheet"
       id="cds-base-style-admin-css"
-      href="https://articles.alpha.canada.ca/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css?ver=2.21.0"
+      href="https://articles.canada.ca/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css?ver=2.21.0"
       media="all"
     />
     <link
       rel="stylesheet"
       id="cds-base-style-admin-wet-css"
-      href="https://articles.alpha.canada.ca/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css?ver=2.21.0"
+      href="https://articles.canada.ca/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css?ver=2.21.0"
       media="all"
     />
     <title>GC Lists</title>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -36,9 +36,9 @@ export const CreateList = () => {
     const formData = {
         service_id: serviceId,
         language: "en",
-        subscribe_redirect_url: "https://articles.alpha.canada.ca/thanks-for-subscribing-merci-pour-votre-labonnement",
-        unsubscribe_redirect_url: "https://articles.alpha.canada.ca/unsubscribed-from-mailing-list-labonnement-supprime",
-        confirm_redirect_url: "https://articles.alpha.canada.ca/confirmation"
+        subscribe_redirect_url: "https://articles.canada.ca/thanks-for-subscribing-merci-pour-votre-labonnement",
+        unsubscribe_redirect_url: "https://articles.canada.ca/unsubscribed-from-mailing-list-labonnement-supprime",
+        confirm_redirect_url: "https://articles.canada.ca/confirmation"
     }
 
 


### PR DESCRIPTION
# Summary | Résumé

Updates references to alpha domain to new articles.canada.ca domain.
