### PR TITLE
Remove WPML Language panel with JS and not CSS

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin.css
@@ -372,8 +372,3 @@ th.column-disable_user_login {
   content: "\f349";
   color: #26374a;
 }
-
-#icl_div {
-  display: none !important;
-}
-

--- a/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/sidebar.js
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/sidebar.js
@@ -5,9 +5,13 @@ const { registerPlugin } = wp.plugins;
 const { PluginDocumentSettingPanel } = wp.editPost;
 const { Fragment } = wp.element;
 const { PanelRow } = wp.components;
+const { dispatch } = wp.data;
 
 import { PageSelect } from "./components/PageSelect";
 const { __ } = wp.i18n;
+
+/* Remove the WPML "Language" panel */
+dispatch('core/edit-post').removeEditorPanel('meta-box-icl_div');
 
 registerPlugin('cds-wpml-mods', {
 	icon: 'translation',


### PR DESCRIPTION
# Summary

This PR removes the WPML language panel more permanently, using JavaScript rather than CSS. 

We have a theory that leaving this hidden panel is causing some anomalies in the staging version of our "Translation plugin" release, so removing this should solve our issue. Succinctly, we think that both panels (ours and WPML's) are submitting info trying to set the translation, which causes the WPML one to override our current one.

Not sure if this is the best place to put the code, Tim?