### PR TITLE
Yoast breadcrumb - Home translation

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-filters.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-filters.php
@@ -139,7 +139,8 @@ function wpseo_breadcrumb_single_link_translate($link_output, $link)
 {
     $lang = get_active_language();
     if ($link['text'] === "Home" && $lang === "fr") {
-        $link_output = str_replace(">Home</a>", ">Accueil</a>", $link_output);
+        $text = 'Accueil';
+        $link_output = str_replace("Home", $text, $link_output);
         return $link_output;
     }
 

--- a/wordpress/wp-content/themes/cds-default/inc/template-filters.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-filters.php
@@ -134,3 +134,17 @@ add_filter('locale', 'define_locale', 10);
 add_filter('gutenberg_can_edit_post', '__return_true', 5);
 add_filter('use_block_editor_for_post', '__return_true', 5);
 add_filter('user_can_richedit', '__return_true', 50);
+
+function wpseo_breadcrumb_single_link_translate($link_output, $link)
+{
+    $lang = get_active_language();
+    if ($link['text'] === "Home" && $lang === "fr") {
+        $link_output = str_replace(">Home</a>", ">Accueil</a>", $link_output);
+        return $link_output;
+    }
+
+    return $link_output;
+}
+
+
+add_filter('wpseo_breadcrumb_single_link', 'wpseo_breadcrumb_single_link_translate', 10, 2);


### PR DESCRIPTION
# Summary | Résumé

Ensures the "Home" link in the breadcrumb gets translated when navigating FR site.

The "Home" link is set under the Yoast search appearance settings and doesn't end up in a translation file.  Given we're not using the WPML string translation plugin this string ends up not being translated.

This PR adds a filter to ensure `Home` gets translated to `Accueil`

<img width="913" alt="Screen Shot 2022-08-02 at 1 59 07 PM" src="https://user-images.githubusercontent.com/62242/182443094-57dd4c2a-881b-4b09-9537-e5dbbbd9618e.png">

