### PR TITLE
Unlink translations from each other

### DIFF
--- a/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/components/PageSelect.js
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/components/PageSelect.js
@@ -39,7 +39,19 @@ export const PageSelect = () => {
 
     const updatePost = async () => {
         setIsLoading(true)
-        const response = await sendData(`cds/wpml/posts/${postID}/translation`, {translationId: page.value})
+
+        let args = {
+            endpoint: `cds/wpml/posts/${postID}/translation`,
+            data: { translationId: page.value },
+            method: 'POST'
+        }
+
+        if(!page.value) {
+            delete args.data;
+            args.method = 'DELETE';
+        }
+
+        const response = await sendData(args)
 
         if (response.ID) {
             setPost(response)
@@ -59,7 +71,7 @@ export const PageSelect = () => {
 
     useEffect(() => {
         const getPost = async (postID) => {
-            const response = await getData(`cds/wpml/posts/${postID}/translation`);
+            const response = await getData({ endpoint: `cds/wpml/posts/${postID}/translation` });
 
             if (response.ID) {
                 setPost(response)
@@ -72,7 +84,7 @@ export const PageSelect = () => {
     useEffect(() => {
         const getPages = async (post) => {
             const altLanguage = post.language_code === 'en' ? 'fr' : 'en';
-            const response = await getData(`cds/wpml/${post.post_type}s/${altLanguage}`);
+            const response = await getData({ endpoint: `cds/wpml/${post.post_type}s/${altLanguage}` });
 
             if (response.length >= 1) {
 

--- a/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/util/fetch.js
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/util/fetch.js
@@ -1,6 +1,6 @@
 const CDS_VARS = window.CDS_VARS
 
-export const getData = async (endpoint) => {
+export const getData = async ({ endpoint }) => {
     const requestHeaders = new Headers();
     requestHeaders.append('X-WP-Nonce', CDS_VARS.rest_nonce);
 
@@ -21,14 +21,14 @@ export const getData = async (endpoint) => {
     return await response.json();
 };
 
-export const sendData = async (endpoint, data) => {
+export const sendData = async ({ endpoint, data, method }) => {
     const requestHeaders = new Headers({
         'Content-Type': 'application/json;charset=UTF-8',
     });
     requestHeaders.append('X-WP-Nonce', CDS_VARS.rest_nonce);
 
     const response = await fetch(`${CDS_VARS.rest_url}${endpoint}`, {
-        method: 'POST',
+        method: method,
         headers: requestHeaders,
         mode: 'cors',
         cache: 'default',

--- a/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/util/fetch.js
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/util/fetch.js
@@ -28,7 +28,7 @@ export const sendData = async ({ endpoint, data, method }) => {
     requestHeaders.append('X-WP-Nonce', CDS_VARS.rest_nonce);
 
     const response = await fetch(`${CDS_VARS.rest_url}${endpoint}`, {
-        method: method,
+        method: method === 'DELETE' ? 'DELETE' : 'POST',
         headers: requestHeaders,
         mode: 'cors',
         cache: 'default',

--- a/wordpress/wp-content/plugins/cds-wpml-mods/src/Post.php
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/src/Post.php
@@ -63,19 +63,24 @@ class Post
     }
 
     /**
-     * @param $postId
-     * @param $postType
-     * @param $languageCode
-     * @param  false  $trid
-     * @param  null  $sourceLanguageCode
+     * @param int $postId  Use term_taxonomy_id for taxonomies, post_id for posts
+     * @param string $postType The type of an element. Can be a post type: post_post, post_page, post_attachment, post_nav_menu_item, post_{custom post key} or taxonomy: tax_category, tax_post_tag, tax_nav_menu, tax_{custom taxonomy key}. Defaults to post_post if not set.
+     * @param string $languageCode  The language code for the element
+     * @param int  $trid   The trid to which the element is to be assigned to. If set to FALSE it will create a new trid for the element causing any potential translation relations to/from it to disappear.
+     * @param null|string  $sourceLanguageCode  The source language code for the element. NULL is reserved for original elements i.e. elements that are not a translation of another. Defaults to NULL when not set.
+     *
+     * This function uses the sitepress method directly, but the args from the hook are all passed in.
+     * Reference: https://wpml.org/wpml-hook/wpml_set_element_language_details/
      */
     public function setTranslationForPost($postId, $postType, $languageCode, $trid = false, $sourceLanguageCode = null)
     {
         global $sitepress;
 
+        $elementType = str_starts_with($postType, 'post_') ? $postType : 'post_' . $postType;
+
         $sitepress->set_element_language_details_action([
             'element_id'    => $postId,
-            'element_type'  => 'post_' . $postType,
+            'element_type'  => $elementType,
             'trid'          => $trid,
             'language_code' => $languageCode,
             'source_language_code' => $sourceLanguageCode


### PR DESCRIPTION
# Summary | Résumé

This PR introduces a new API route and some new logic in our PageSelect component to call the new route if we select "None" as the page translation. It also adds some tests, which brings up our total coverage up to 67%.

Routes we have:

1. Set a translation: `POST` -> `http://localhost/wp-json/cds/wpml/posts/47/translation` (param: `translationId`)
2. Get a translation: `GET` -> `http://localhost/wp-json/cds/wpml/posts/47/translation`
3. (New ✨) Unset a translation: `DELETE` -> `http://localhost/wp-json/cds/wpml/posts/47/translation`

It's not technically a `DELETE`, since no resource is actually getting deleted, but Dave and I talked about it and it was the most intuitive route we came up with.

## gif

![Screen Recording 2022-08-03 at 11 08 39](https://user-images.githubusercontent.com/2454380/182643531-8706d206-35f2-4225-95cc-758e2b164251.gif)

