### PR TITLE
Add new CSP rule for gravatar image

### DIFF
--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -48,6 +48,7 @@ function cds_security_headers($headers)
             "https://www.canada.ca",
             "https://secure.gravatar.com",
             "2.gravatar.com",
+            "0.gravatar.com",
             "https://digital.canada.ca",
         ],
         "manifest-src" => [


### PR DESCRIPTION
My gravatar image has been broken for like 2-3 weeks and this fixes it.

Not sure why it picks different numbers for domains.

| before | after |
|--------|-------|
|   <img width="494" alt="Screen Shot 2022-08-03 at 11 47 58" src="https://user-images.githubusercontent.com/2454380/182652300-37c60047-a6e0-454c-ba01-b307381ba73d.png">  |   <img width="494" alt="Screen Shot 2022-08-03 at 11 47 39" src="https://user-images.githubusercontent.com/2454380/182652297-6ebf68b3-ac7b-4b72-9dfc-8f25e5ca3d9a.png">   |

