### PR TITLE
Fix all the translations bugs

### DIFF
--- a/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/components/PageSelect.js
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/components/PageSelect.js
@@ -5,6 +5,28 @@ const { __ } = wp.i18n;
 
 import { getData, sendData } from '../util/fetch.js';
 
+/**
+ * The WPML metabox panel is removed using "removeEditorPanel" in sidebar.js, but that
+ * just hides the metabox using CSS, it's not actually removed from the DOM.
+ *
+ * The WPML metabox loads with a pre-populated select box with the name of the post that is
+ * assigned as the translation when the page loads. This value is then submitted as part of
+ * a general "POST" request when the page/post is updated. WPML looks for this value and,
+ * when it finds it, it uses it as the translation.
+ *
+ * What this means is that on some posts, our new translation ID is sent, the translation is updated,
+ * but then half a second later the "icl_translation_of" value is received by WPML, which resets the translation to its prior value.
+ *
+ * Our solution to this is to remove the WPML metabox from the DOM if we find it.
+ * It would be better to remove the WPML panel completely using a WordPress API but this doesn't seem to be possible.
+ */
+const _removeWPMLPanel = () => {
+    const wpmlPanel = document.querySelector('#icl_div');
+    if(wpmlPanel) {
+        wpmlPanel.parentNode.removeChild(wpmlPanel);
+    }
+}
+
 export const PageSelect = () => {
     const { isSavingPost } = select( 'core/editor' );
 
@@ -118,7 +140,8 @@ export const PageSelect = () => {
             hintTextIndex = 'translated_post_id'
         }
         setHintText(hintTexts[hintTextIndex](page.label))
-        // set hint text
+
+        _removeWPMLPanel()
     }, [page, post, hintTexts]);
 
     useEffect(() => {

--- a/wordpress/wp-content/plugins/cds-wpml-mods/src/Api/Endpoints.php
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/src/Api/Endpoints.php
@@ -170,7 +170,7 @@ class Endpoints extends BaseEndpoint
             }
 
             // Note that post_trid is a string (normal ids are integers)
-            $postTrid = $sitepress->get_element_trid($originalPost->ID, $postType);
+            $postTrid = $this->post->getTRID($originalPost->ID, $postType);
 
             // Set translations for each post
             $this->post->setTranslationForPost($originalPost->ID, $postType, $originalPostLanguage, $postTrid);

--- a/wordpress/wp-content/plugins/cds-wpml-mods/tests/Integration/TestPost.php
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/tests/Integration/TestPost.php
@@ -92,6 +92,21 @@ test('getLanguageCodeOfPostObject', function() {
 	expect($language)->toEqual('en');
 });
 
+test('getTRID', function() {
+	global $sitepress;
+	$sitepress = mock('\SitePress');
+	$sitepress->shouldReceive("get_element_trid")->andReturn('100');
+
+	$post_id = $this->factory()->post->create();
+	$post = get_post($post_id);
+
+	$postClass = new Post();
+
+	$trid = $postClass->getTRID($post->ID, 'post_post');
+
+	expect($trid)->toEqual('100');
+});
+
 test('getTranslatedPostID', function() {
 	global $sitepress;
 	$sitepress = mock('\SitePress');
@@ -114,6 +129,7 @@ test('getTranslatedPostID', function() {
 test('setTranslationForPost calls set_element_language_details_action', function() {
 	global $sitepress;
 	$sitepress = mock('\SitePress');
+	$sitepress->shouldReceive("get_element_trid")->andReturn('100');
 	$sitepress->shouldReceive("set_element_language_details_action");
 
 	$postClass = new Post();


### PR DESCRIPTION
# Summary 

Fix all the weird translation bugs.

There were 2 different things that were messing up our translation-setting code:

1. The WPML metabox was sometimes sending along the id of the source post as a POST value, meaning you would try sometimes to link "Post 2" and "Post 3" but then find out that "Post 2" was still linked to "Post 1"
2. We are setting a `wpml_trid` in the `wp_postmeta` database but then never updating it, which means that it would reset the post meta whenever you saved that post in the future.

Both are now fixed.

## 1. WPML metabox

The WPML metabox panel is removed using "removeEditorPanel" in sidebar.js, but that just hides the metabox using CSS, it's not actually removed from the DOM.

The WPML metabox loads with a pre-populated select box with the name of the post that is set to the current translation when the page loads (see photo). 

| before | after |
|--------|-------|
| the "source" post has the metabox open but there is no select dropdown with post names       |  the "translated" post has the metabox open with a select box including the "source" post (the original)     |
|   <img width="1441" alt="Screen Shot 2022-08-04 at 16 13 03" src="https://user-images.githubusercontent.com/2454380/183111911-0a3993b3-30ab-44d7-bc95-689dc2f08ddd.png">    |  <img width="1441" alt="Screen Shot 2022-08-04 at 16 13 16" src="https://user-images.githubusercontent.com/2454380/183111921-54884043-046e-4ca3-a991-f2f81f0751f6.png">    |

This value is then submitted as part of a general "POST" request when the page/post is updated. WPML looks for this value and, when it finds it, it uses it as the translation (see photo).

| before | after |
|--------|-------|
|   first POST request is our /translation post, which correctly sets the post ID    |  subsequent  POST request is a generic "post.php", which includes a bunch of form values on the screen, including the "id" of the original post |
|  <img width="1066" alt="Screen Shot 2022-08-04 at 16 13 51" src="https://user-images.githubusercontent.com/2454380/183112332-70fa4cc7-f17f-4ba0-9f32-374ae3a8e915.png">    |    <img width="935" alt="Screen Shot 2022-08-04 at 16 14 19" src="https://user-images.githubusercontent.com/2454380/183112339-b21743bf-1b0e-4dee-860d-82dd38b8ee96.png">   |

What this means is that on some posts, our new translation ID is sent, the translation is updated,
but then half a second later the "icl_translation_of" value is received by WPML, which resets the translation to its prior value.

Our solution to this is to remove the WPML metabox from the DOM if we find it.

It would be better to remove the WPML panel completely using a WordPress API but this doesn't seem to be possible.


## 2. `wpml_trid` in `wp_postmeta`

If you click the "+" button to add a translation to a post/page, a meta field called `wpml_trid` is created and populated with the new `trid`. This is all well and good, except that it never gets updated and is triggered on all subsequent saves. Was seeing weird behaviour around this where the original trid was continually being reset but wasn't sure where it was coming from. 

Now, after resetting the trid, we check if this meta field exists, and, if it does, update it to the new trid.
