### PR TITLE
fix: use uncached health check URL with canary

### DIFF
--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -64,8 +64,8 @@ inputs = {
   alb_target_5xx_maximum                   = 5
   alb_target_4xx_maximum                   = 100
 
-  canary_healthcheck_url_eng = "https://articles.alpha.canada.ca/"
-  canary_healthcheck_url_fra = "https://articles.alpha.canada.ca/"
+  canary_healthcheck_url_eng = "https://articles.alpha.canada.ca/sign-in-se-connecter/"
+  canary_healthcheck_url_fra = "https://articles.alpha.canada.ca/fr/sign-in-se-connecter/"
 
   cloudfront_arn              = dependency.load-balancer.outputs.cloudfront_arn
   cloudfront_distribution_id  = dependency.load-balancer.outputs.cloudfront_distribution_id

--- a/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -64,8 +64,8 @@ inputs = {
   alb_target_5xx_maximum                   = 5
   alb_target_4xx_maximum                   = 100
 
-  canary_healthcheck_url_eng = "https://articles.cdssandbox.xyz/"
-  canary_healthcheck_url_fra = "https://articles.cdssandbox.xyz/"
+  canary_healthcheck_url_eng = "https://articles.cdssandbox.xyz/sign-in-se-connecter/"
+  canary_healthcheck_url_fra = "https://articles.cdssandbox.xyz/fr/sign-in-se-connecter/"
 
   cloudfront_arn              = dependency.load-balancer.outputs.cloudfront_arn
   cloudfront_distribution_id  = dependency.load-balancer.outputs.cloudfront_distribution_id


### PR DESCRIPTION
# Summary
Update the synthetic canary health check URL to one that isn't cached
by CloudFront.  This will allow us to more quickly catch downtime
when the site is down.