### PR TITLE
Update the "create/edit new list" page and enforce filling in settings page

### DIFF
--- a/cypress/integration/notify.settings.spec.js
+++ b/cypress/integration/notify.settings.spec.js
@@ -10,7 +10,7 @@ describe('GC Lists Settings', () => {
     it('Displays settings screen', () => {
       cy.visit('/wp-admin/admin.php?page=settings');
   
-      cy.get('h2').should('have.text', 'Notify API Settings');
+      cy.get('h2').should('have.text', 'API Settings');
   
       cy.get('#notify_api_key').should('be.empty');
       cy.get('#notify_generic_template_id').should('be.empty');

--- a/cypress/integration/notify.settings.spec.js
+++ b/cypress/integration/notify.settings.spec.js
@@ -10,7 +10,7 @@ describe('GC Lists Settings', () => {
     it('Displays settings screen', () => {
       cy.visit('/wp-admin/admin.php?page=settings');
   
-      cy.get('h2').should('have.text', 'GC Lists Settings');
+      cy.get('h2').should('have.text', 'Notify API Settings');
   
       cy.get('#notify_api_key').should('be.empty');
       cy.get('#notify_generic_template_id').should('be.empty');

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -116,7 +116,7 @@ class NotifySettings
 
         add_settings_section(
             'notify_api_settings_setting_section', // id
-            __('Notify API Settings', 'cds-snc'), // title
+            __('API Settings', 'cds-snc'), // title
             array( $this, 'notifyApiSettingsSectionInfo'), // callback
             'notify-api-settings-admin' // page
         );
@@ -134,7 +134,7 @@ class NotifySettings
 
         add_settings_field(
             'notify_subscribe_template', // id
-            __('Subscribe template id', 'cds-snc'), // title
+            __('Subscribe template ID', 'cds-snc'), // title
             array( $this, 'notifySubscribeTemplateIdCallback'), // callback
             'notify-api-settings-admin', // page
             'notify_api_settings_setting_section', // section
@@ -145,7 +145,7 @@ class NotifySettings
 
         add_settings_field(
             'notify_generic_template_id', // id
-            __('Email integration template ID', 'cds-snc'), // title
+            __('Message template ID', 'cds-snc'), // title
             array( $this, 'notifyGenericTemplateIdCallback'), // callback
             'notify-api-settings-admin', // page
             'notify_api_settings_setting_section', // section
@@ -211,7 +211,7 @@ class NotifySettings
             <summary>%s. (%s)</summary>
             <code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
         </details>
-        <p class="description">%s</p>', __('Enter your generic Email Template ID', 'cds-snc'), __('See example template ID format.', 'cds-snc'), $link);
+        <p class="description">%s</p>', __('Enter your message template ID', 'cds-snc'), __('See example template ID format.', 'cds-snc'), $link);
     }
 
     public function notifySubscribeTemplateIdCallback()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -49,8 +49,8 @@ class NotifySettings
     {
         add_submenu_page(
             "gc-lists_messages",
-            __('Settings', 'cds-snc'), // page_title
-            __('Settings', 'cds-snc'), // menu_title
+            __('API Settings', 'cds-snc'), // page_title
+            __('API Settings', 'cds-snc'), // menu_title
             'manage_notify',
             "settings",
             [ $this, 'notifyApiSettingsCreateAdminPage' ] // function
@@ -102,7 +102,6 @@ class NotifySettings
             }
         );
 
-
         register_setting(
             'notify_api_settings_option_group', // option_group
             'NOTIFY_SUBSCRIBE_TEMPLATE_ID',
@@ -117,7 +116,7 @@ class NotifySettings
 
         add_settings_section(
             'notify_api_settings_setting_section', // id
-            __('GC Lists Settings', 'cds-snc'), // title
+            __('Notify API Settings', 'cds-snc'), // title
             array( $this, 'notifyApiSettingsSectionInfo'), // callback
             'notify-api-settings-admin' // page
         );

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/common/Back.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/common/Back.tsx
@@ -1,0 +1,6 @@
+export const Back = () => {
+    return (
+        <svg width="9" height="15" viewBox="0 0 9 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 1.5L2 7.49999L7.99999 13.5" stroke="#2B4380" strokeWidth="2" />
+        </svg>)
+}

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/common/StyledLink.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/common/StyledLink.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+*/
+import styled from 'styled-components';
+import { Link } from "react-router-dom";
+
+export const StyledLink = styled(Link)`
+    position:relative;
+    display:block;
+    margin-top:20px;
+    margin-bottom: 20px;
+    span{
+        display:inline-block;
+        text-decoration:underline !important;
+        position:relative;
+        top:-1px;
+        margin-right:10px;
+
+        :hover{
+            text-decoration:none !important;
+        }
+    }
+`

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/common/index.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/common/index.tsx
@@ -1,0 +1,4 @@
+export { Back } from "./Back";
+export { Error } from "./Error";
+export { Spinner } from "./Spinner";
+export { StyledLink } from "./StyledLink";

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/Back.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/Back.tsx
@@ -1,9 +1,0 @@
-/**
- * External dependencies
- */
-import { Link } from "react-router-dom";
-import { __ } from "@wordpress/i18n";
-
-export const Back = () => {
-    return <Link className="button action" to={{ pathname: `/lists` }}>{__('Go back', 'gc-lists')}</Link>
-}

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -43,7 +43,11 @@ export const CreateList = () => {
 
 
 
-    return data.id ? <Navigate to={`/lists`} replace={true} /> : <ListForm formData={formData} serverErrors={[]} handler={onSubmit} />
+    return data.id ? <Navigate to={`/lists`} replace={true} /> : (
+        <>
+            <h1>Edit list{/* or new list */}</h1>
+            <ListForm formData={formData} serverErrors={[]} handler={onSubmit} />
+        </>)
 }
 
 export default CreateList;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -14,8 +14,7 @@ import { __ } from "@wordpress/i18n";
 import { ListForm } from "./ListForm";
 import { useList, useService } from "../../store";
 import { List } from "../../types";
-import { StyledLink } from "../../common/StyledLink";
-import { Back } from "../../common/Back";
+import { Back, StyledLink } from "../../common";
 
 export const CreateList = () => {
     const [data, setData] = useState({ id: null })
@@ -48,7 +47,7 @@ export const CreateList = () => {
 
     return data.id ? <Navigate to={`/lists`} replace={true} /> : (
         <>
-            <StyledLink to={`/`}>
+            <StyledLink to={`/lists`}>
                 <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
             </StyledLink>
             <h1>Edit list{/* or new list */}</h1>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -50,7 +50,7 @@ export const CreateList = () => {
             <StyledLink to={`/lists`}>
                 <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
             </StyledLink>
-            <h1>Edit list{/* or new list */}</h1>
+            <h1>{__("Create new list", "gc-lists")}</h1>
             <ListForm formData={formData} serverErrors={[]} handler={onSubmit} />
         </>)
 }

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -6,6 +6,7 @@ import { useState, useCallback } from 'react'
 import { SubmitHandler } from "react-hook-form";
 import useFetch from 'use-http';
 import { Navigate } from "react-router-dom";
+import { __ } from "@wordpress/i18n";
 
 /**
  * Internal dependencies
@@ -13,6 +14,8 @@ import { Navigate } from "react-router-dom";
 import { ListForm } from "./ListForm";
 import { useList, useService } from "../../store";
 import { List } from "../../types";
+import { StyledLink } from "../../common/StyledLink";
+import { Back } from "../../common/Back";
 
 export const CreateList = () => {
     const [data, setData] = useState({ id: null })
@@ -45,6 +48,9 @@ export const CreateList = () => {
 
     return data.id ? <Navigate to={`/lists`} replace={true} /> : (
         <>
+            <StyledLink to={`/`}>
+                <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
+            </StyledLink>
             <h1>Edit list{/* or new list */}</h1>
             <ListForm formData={formData} serverErrors={[]} handler={onSubmit} />
         </>)

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -9,39 +9,31 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { List, FieldError } from "../../types";
+import { List, FieldError as ErrorType } from "../../types";
 import { useList } from "../../store";
 
-const StyledForm = styled.form`
-    .field{
-        margin-bottom: 20px;
-    }
+import { FieldError } from '../../messages/components';
 
-    strong{
-        color:#1d2327;
-        font-size:16px;
-        font-weight:600;
-        display:inline-block;
-        margin-bottom: 5px;
-    }
+const StyledCell = styled.td`
+    padding-left: 0 !important;
 
-    p{
-        margin-top:4px;
+    input[type="radio"] + label {
+        display: inline-block;
+        margin: 2px 0 5px 3px;
+    }
+`
+
+const StyledDetails = styled.details`
+    padding: 20px 10px 20px 0;
+
+    summary > span {
+        text-decoration: underline;
     }
 `
 
 const textWidth = { width: "25em" }
 
-const Asterisk = () => {
-    return (
-        <>
-            <span data-testid="asterisk" aria-hidden="true">* </span>
-            <i style={{ display: "none" }} className="visually-hidden">{__("Required Field", "gc-lists")}</i>
-        </>
-    )
-}
-
-export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handler: (list: List) => void, formData: {} | List, serverErrors: FieldError[] }) => {
+export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handler: (list: List) => void, formData: {} | List, serverErrors: ErrorType[] }) => {
     const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
 
@@ -57,119 +49,125 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
     }, [setError, serverErrors]);
 
     return (
-        <StyledForm onSubmit={handleSubmit(handler)}>
-            <input id="service_id" type="hidden" {...register("service_id", { required: true })} />
-            {/* @todo np phone access use default language field will be replaced with "list_type" field */}
-            {!user?.hasPhone && <input type="hidden" name="language" value="en" />}
-            <div className="field">
-                <label className="required" htmlFor="name"><Asterisk />
-                    <strong>{__("List name", "gc-lists")}</strong>
-                </label>
-                <div className={errors.name ? "error-wrapper" : ""}>
-                    {errors.name && <span className="validation-error">{errors.name?.message || __("List name is required", "gc-lists")}</span>}
-                    <input id="name" style={textWidth} type="text" {...register("name", { required: true })} />
-                </div>
-            </div>
-            {
-                user?.hasPhone && <div>
-                    <label className="required" htmlFor="language"><Asterisk />
-                        <strong>{__("List type", "gc-lists")}</strong>
-                    </label>
-                    <div className={errors.language ? "field error-wrapper" : "field"}>
-                        {errors.language && <span className="validation-error">{errors.language?.message || __("List type is required", "gc-lists")}</span>}
-                        <fieldset>
-                            <label htmlFor="en">
-                                <input id="en" {...register("language", { required: true })} type="radio" value="en" />
-                                {" "}<strong>{__("Email", "gc-lists")}</strong>
-                            </label>
-                            <br />
-                            <label htmlFor="fr">
-                                <input id="fr" {...register("language", { required: true })} type="radio" value="fr" />
-                                {" "}<strong>{__("Phone", "gc-lists")}</strong>
-                            </label>
-                        </fieldset>
-                    </div>
-                </div>
-            }
-            <details className="list-advanced">
+        <form style={{ maxWidth: '700px' }} onSubmit={handleSubmit(handler)}>
+            <table className="form-table" role="presentation">
+
+                {/* @todo np phone access use default language field will be replaced with "list_type" field */}
+                {!user?.hasPhone && <input type="hidden" name="language" value="en" />}
+                <input id="service_id" type="hidden" {...register("service_id", { required: true })} />
+
+                {/* Optional hidden field, pulled from value entered on the settings panel if set */}
+                <input id="unsubscribe_email_template_id" type="hidden" {...register("unsubscribe_email_template_id")} />
+
+                <tbody>
+                    {user?.hasPhone &&
+                        <tr>
+                            <th scope="row">
+                                <label htmlFor="language">{__("Subscribers", "gc-lists")}</label>
+                            </th>
+                            <StyledCell>
+                                <FieldError errors={[]} id="language">
+                                    <div>
+                                        <input {...register("language", { required: true })} type="radio" id="en" value="en" />
+                                        <label htmlFor="en">{__('Email subscribers', 'gc-lists')}</label>
+                                    </div>
+                                    <div>
+                                        <input {...register("language", { required: true })} type="radio" id="fr" value="fr" />
+                                        <label htmlFor="fr">{__('Text message subscribers', 'gc-lists')}</label>
+                                    </div>
+                                    <p className="description" id="language-description">
+                                        Choose the type of subscribers for this list.
+                                    </p>
+                                </FieldError>
+                            </StyledCell>
+                        </tr>
+                    }
+                    <tr>
+                        <th scope="row">
+                            <label htmlFor="name">{__("List name", "gc-lists")}</label>
+                        </th>
+                        <StyledCell>
+                            <div className={errors.name ? "error-wrapper" : ""}>
+                                {errors.name && <span className="validation-error">{errors.name?.message || __("List name is required", "gc-lists")}</span>}
+                                <input id="name" style={textWidth} type="text" {...register("name", { required: true })} />
+                            </div>
+                        </StyledCell>
+                    </tr>
+                </tbody>
+            </table>
+
+            <StyledDetails className="list-advanced">
                 <summary>
                     <span>{__("Advanced list settings", "gc-lists")}</span>
                 </summary>
-                <p>{__("Changing these settings is optional.", "gc-lists")}</p>
-                <div className="field">
-                    <label htmlFor="subscribe_email_template_id">
-                        <strong>
-                            {__("Subscribe template id", "gc-lists")}
-                        </strong>
-                    </label>
-                    <div className={errors.subscribe_email_template_id ? "error-wrapper" : ""}>
-                        {errors.subscribe_email_template_id && <span className="validation-error">{errors.subscribe_email_template_id?.message}</span>}
-                        <input id="subscribe_email_template_id" style={textWidth} type="text" {...register("subscribe_email_template_id")} />
-                        <div className="role-desc description">
-                            <details>
-                                <summary>{__("See example template ID format.", "gc-lists")}</summary><code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
-                            </details>
-                        </div>
-                    </div>
-                </div>
-                <div className="field">
-                    <label htmlFor="unsubscribe_email_template_id">
-                        <strong>
-                            {__("Unsubscribe template id", "gc-lists")}
-                        </strong>
-                    </label>
-                    <div className={errors.unsubscribe_email_template_id ? "error-wrapper" : ""}>
-                        {errors.unsubscribe_email_template_id && <span className="validation-error">{errors.unsubscribe_email_template_id?.message}</span>}
-                        <input id="unsubscribe_email_template_id" style={textWidth} type="text" {...register("unsubscribe_email_template_id")} />
-                        <div className="role-desc description">
-                            <details>
-                                <summary>{__("See example template ID format.", "gc-lists")}</summary><code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
-                            </details>
-                        </div>
-                    </div>
-                </div>
-                <div className="field">
-                    <label className="gc-label" htmlFor="subscribe_redirect_url">
-                        <strong>
-                            {__("Subscribe redirect url", "gc-lists")}
-                        </strong>
-                    </label>
-                    <p>
-                        {__("Subscribers are directed to this page when submitting the subscribe request form.", "gc-lists")}
-                    </p>
-                    <div className={errors.subscribe_redirect_url ? "error-wrapper" : ""}>
-                        {errors.subscribe_redirect_url && <span className="validation-error">{errors.subscribe_redirect_url?.message}</span>}
-                        <input id="subscribe_redirect_url" style={textWidth} type="text" {...register("subscribe_redirect_url")} />
-                    </div>
-                </div>
-                <div className="field">
-                    <label htmlFor="unsubscribe_redirect_url">
-                        <strong>
-                            {__("Unsubscribe redirect url", "gc-lists")}
-                        </strong>
-                    </label>
-                    <p>{__("Subscribers are directed to this page when submitting the unsubscribe request form.", "gc-lists")}</p>
-                    <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
-                        {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
-                        <input id="unsubscribe_redirect_url" style={textWidth} type="text" {...register("unsubscribe_redirect_url")} />
-                    </div>
-                </div>
-                <div className="field">
-                    <label htmlFor="confirm_redirect_url">
-                        <strong>
-                            {__("Confirm redirect url", "gc-lists")}
-                        </strong>
-                    </label>
-                    <p>{__("Subscribers are directed to this page when they confirm their subscription to a list.", "gc-lists")}</p>
-                    <div className={errors.confirm_redirect_url ? "error-wrapper" : ""}>
-                        {errors.confirm_redirect_url && <span className="validation-error">{errors.confirm_redirect_url?.message}</span>}
-                        <input id="confirm_redirect_url" style={textWidth} type="text" {...register("confirm_redirect_url")} />
-                    </div>
-                </div>
-            </details>
-            <div className="field submit">
-                <input className="button button-primary" type="submit" value={__("Save list", "gc-lists")} />
+                <p>{__("These settings are optional.", "gc-lists")} {__("They only apply if you setup a form to collect emails from subscribers.", "gc-lists")}</p>
+
+                <table className="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row">
+                                <label htmlFor="subscribe_redirect_url">{__("Subscribe confirmation url", "gc-lists")}</label>
+                            </th>
+                            <StyledCell>
+                                <div className={errors.name ? "error-wrapper" : ""}>
+                                    {errors.subscribe_redirect_url && <span className="validation-error">{errors.subscribe_redirect_url?.message}</span>}
+                                    <input id="subscribe_redirect_url" style={textWidth} type="text" {...register("subscribe_redirect_url")} />
+                                    <p className="description" id="language-description">
+                                        {__("Subscribers are directed to this page when submitting the subscribe request form.", "gc-lists")}
+                                    </p>
+                                </div>
+                            </StyledCell>
+                        </tr>
+
+                        <tr>
+                            <th scope="row">
+                                <label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe redirect url", "gc-lists")}</label>
+                            </th>
+                            <StyledCell>
+                                <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
+                                    {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
+                                    <input id="unsubscribe_redirect_url" style={textWidth} type="text" {...register("unsubscribe_redirect_url")} />
+                                    <p className="description" id="language-description">
+                                        {__("Subscribers are directed to this page when submitting the unsubscribe request form.", "gc-lists")}
+                                    </p>
+                                </div>
+                            </StyledCell>
+                        </tr>
+
+                        <tr>
+                            <th scope="row">
+                                <label htmlFor="confirm_redirect_url">{__("Verify email url", "gc-lists")}</label>
+                            </th>
+                            <StyledCell>
+                                <div className={errors.confirm_redirect_url ? "error-wrapper" : ""}>
+                                    {errors.confirm_redirect_url && <span className="validation-error">{errors.confirm_redirect_url?.message}</span>}
+                                    <input id="confirm_redirect_url" style={textWidth} type="text" {...register("confirm_redirect_url")} />
+                                    <p className="description" id="language-description">
+                                        {__("Subscribers are directed to this page when they confirm their subscription to a list.", "gc-lists")}
+                                    </p>
+                                </div>
+                            </StyledCell>
+                        </tr>
+                    </tbody>
+                </table>
+            </StyledDetails>
+
+            <div>
+                <button style={{ marginRight: "20px" }} type="submit" className="button button-primary">
+                    {__('Save and continue', 'gc-lists')}
+                </button>
+
+                <button
+                    className="button"
+                    type="button"
+                    onClick={() => {
+                        console.log('cancel!!');
+                    }}
+                >
+                    {__('Cancel', 'gc-lists')}
+                </button>
             </div>
-        </StyledForm>
+
+        </form>
     );
 }

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -60,28 +60,6 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                 <input id="unsubscribe_email_template_id" type="hidden" {...register("unsubscribe_email_template_id")} />
 
                 <tbody>
-                    {user?.hasPhone &&
-                        <tr>
-                            <th scope="row">
-                                <label htmlFor="language">{__("Subscribers", "gc-lists")}</label>
-                            </th>
-                            <StyledCell>
-                                <FieldError errors={[]} id="language">
-                                    <div>
-                                        <input {...register("language", { required: true })} type="radio" id="en" value="en" />
-                                        <label htmlFor="en">{__('Email subscribers', 'gc-lists')}</label>
-                                    </div>
-                                    <div>
-                                        <input {...register("language", { required: true })} type="radio" id="fr" value="fr" />
-                                        <label htmlFor="fr">{__('Text message subscribers', 'gc-lists')}</label>
-                                    </div>
-                                    <p className="description" id="language-description">
-                                        Choose the type of subscribers for this list.
-                                    </p>
-                                </FieldError>
-                            </StyledCell>
-                        </tr>
-                    }
                     <tr>
                         <th scope="row">
                             <label htmlFor="name">{__("List name", "gc-lists")}</label>
@@ -93,6 +71,28 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                             </div>
                         </StyledCell>
                     </tr>
+                    {user?.hasPhone &&
+                        <tr>
+                            <th scope="row">
+                                <label htmlFor="language">{__("Message type", "gc-lists")}</label>
+                            </th>
+                            <StyledCell>
+                                <FieldError errors={[]} id="language">
+                                    <div>
+                                        <input {...register("language", { required: true })} type="radio" id="en" value="en" />
+                                        <label htmlFor="en">{__('Email', 'gc-lists')}</label>
+                                    </div>
+                                    <div>
+                                        <input {...register("language", { required: true })} type="radio" id="fr" value="fr" />
+                                        <label htmlFor="fr">{__('Text message', 'gc-lists')}</label>
+                                    </div>
+                                    <p className="description" id="language-description">
+                                        Choose the type of message this list will get.
+                                    </p>
+                                </FieldError>
+                            </StyledCell>
+                        </tr>
+                    }
                 </tbody>
             </table>
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
  * Internal dependencies
  */
 import { List, FieldError as ErrorType } from "../../types";
-import { useList } from "../../store";
+import { useList, useService } from "../../store";
 
 import { FieldError } from '../../messages/components';
 
@@ -38,6 +38,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
     const navigate = useNavigate();
     const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
+    const { subscribeTemplate } = useService();
 
     useEffect(() => {
         serverErrors && serverErrors.length >= 1 && serverErrors.forEach((item) => {
@@ -56,10 +57,12 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
 
                 {/* @todo np phone access use default language field will be replaced with "list_type" field */}
                 {!user?.hasPhone && <input type="hidden" name="language" value="en" />}
+
+                {/* TODO: do we need this?  */}
                 <input id="service_id" type="hidden" {...register("service_id", { required: true })} />
 
                 {/* Optional hidden field, pulled from value entered on the settings panel if set */}
-                <input id="subscribe_email_template_id" type="hidden" {...register("subscribe_email_template_id")} />
+                <input id="subscribe_email_template_id" type="hidden" value={ subscribeTemplate } {...register("subscribe_email_template_id")} />
 
                 <tbody>
                     <tr>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { __ } from "@wordpress/i18n";
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ const StyledDetails = styled.details`
 const textWidth = { width: "25em" }
 
 export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handler: (list: List) => void, formData: {} | List, serverErrors: ErrorType[] }) => {
+    const navigate = useNavigate();
     const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
 
@@ -57,7 +59,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                 <input id="service_id" type="hidden" {...register("service_id", { required: true })} />
 
                 {/* Optional hidden field, pulled from value entered on the settings panel if set */}
-                <input id="unsubscribe_email_template_id" type="hidden" {...register("unsubscribe_email_template_id")} />
+                <input id="subscribe_email_template_id" type="hidden" {...register("subscribe_email_template_id")} />
 
                 <tbody>
                     <tr>
@@ -87,7 +89,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                                         <label htmlFor="fr">{__('Text message', 'gc-lists')}</label>
                                     </div>
                                     <p className="description" id="language-description">
-                                        Choose the type of message this list will get.
+                                        {__('Choose the type of message this list will receive.', 'gc-lists')}
                                     </p>
                                 </FieldError>
                             </StyledCell>
@@ -98,22 +100,24 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
 
             <StyledDetails className="list-advanced">
                 <summary>
-                    <span>{__("Advanced list settings", "gc-lists")}</span>
+                    <span>{__("Confirmation page settings", "gc-lists")}</span>
                 </summary>
-                <p>{__("These settings are optional.", "gc-lists")} {__("They only apply if you setup a form to collect emails from subscribers.", "gc-lists")}</p>
+
+                <p>{__("Subscribers will see the default confirmation pages if you’ve set up a form to collect their email addresses.", "gc-lists")}</p>
+                <p>{__("Changing these pages is optional.", "gc-lists")}</p>
 
                 <table className="form-table" role="presentation">
                     <tbody>
                         <tr>
                             <th scope="row">
-                                <label htmlFor="subscribe_redirect_url">{__("Subscribe confirmation url", "gc-lists")}</label>
+                                <label htmlFor="subscribe_redirect_url">{__("Subscribe confirmation", "gc-lists")}</label>
                             </th>
                             <StyledCell>
                                 <div className={errors.name ? "error-wrapper" : ""}>
                                     {errors.subscribe_redirect_url && <span className="validation-error">{errors.subscribe_redirect_url?.message}</span>}
                                     <input id="subscribe_redirect_url" style={textWidth} type="text" {...register("subscribe_redirect_url")} />
                                     <p className="description" id="language-description">
-                                        {__("Subscribers are directed to this page when submitting the subscribe request form.", "gc-lists")}
+                                        {__("The page people see after they subscribe.", "gc-lists")}
                                     </p>
                                 </div>
                             </StyledCell>
@@ -121,29 +125,29 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
 
                         <tr>
                             <th scope="row">
-                                <label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe redirect url", "gc-lists")}</label>
-                            </th>
-                            <StyledCell>
-                                <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
-                                    {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
-                                    <input id="unsubscribe_redirect_url" style={textWidth} type="text" {...register("unsubscribe_redirect_url")} />
-                                    <p className="description" id="language-description">
-                                        {__("Subscribers are directed to this page when submitting the unsubscribe request form.", "gc-lists")}
-                                    </p>
-                                </div>
-                            </StyledCell>
-                        </tr>
-
-                        <tr>
-                            <th scope="row">
-                                <label htmlFor="confirm_redirect_url">{__("Verify email url", "gc-lists")}</label>
+                                <label htmlFor="confirm_redirect_url">{__("Verify email confirmation", "gc-lists")}</label>
                             </th>
                             <StyledCell>
                                 <div className={errors.confirm_redirect_url ? "error-wrapper" : ""}>
                                     {errors.confirm_redirect_url && <span className="validation-error">{errors.confirm_redirect_url?.message}</span>}
                                     <input id="confirm_redirect_url" style={textWidth} type="text" {...register("confirm_redirect_url")} />
                                     <p className="description" id="language-description">
-                                        {__("Subscribers are directed to this page when they confirm their subscription to a list.", "gc-lists")}
+                                        {__("The page people see after they verify their email address.", "gc-lists")}
+                                    </p>
+                                </div>
+                            </StyledCell>
+                        </tr>
+
+                        <tr>
+                            <th scope="row">
+                                <label htmlFor="unsubscribe_redirect_url">{__("Unsubscribe confirmation", "gc-lists")}</label>
+                            </th>
+                            <StyledCell>
+                                <div className={errors.unsubscribe_redirect_url ? "error-wrapper" : ""}>
+                                    {errors.unsubscribe_redirect_url && <span className="validation-error">{errors.unsubscribe_redirect_url?.message}</span>}
+                                    <input id="unsubscribe_redirect_url" style={textWidth} type="text" {...register("unsubscribe_redirect_url")} />
+                                    <p className="description" id="language-description">
+                                        {__("The page people see after they unsubscribe.", "gc-lists")}
                                     </p>
                                 </div>
                             </StyledCell>
@@ -161,7 +165,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                     className="button"
                     type="button"
                     onClick={() => {
-                        console.log('cancel!!');
+                        navigate('/lists/');
                     }}
                 >
                     {__('Cancel', 'gc-lists')}

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -53,17 +53,14 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
 
     return (
         <form style={{ maxWidth: '700px' }} onSubmit={handleSubmit(handler)}>
+
+            {/* @todo np phone access use default language field will be replaced with "list_type" field */}
+            {!user?.hasPhone && <input type="hidden" name="language" value="en" />}
+
+            {/* Optional hidden field, pulled from value entered on the settings panel if set */}
+            <input id="subscribe_email_template_id" type="hidden" value={ subscribeTemplate } {...register("subscribe_email_template_id")} />
+
             <table className="form-table" role="presentation">
-
-                {/* @todo np phone access use default language field will be replaced with "list_type" field */}
-                {!user?.hasPhone && <input type="hidden" name="language" value="en" />}
-
-                {/* TODO: do we need this?  */}
-                <input id="service_id" type="hidden" {...register("service_id", { required: true })} />
-
-                {/* Optional hidden field, pulled from value entered on the settings panel if set */}
-                <input id="subscribe_email_template_id" type="hidden" value={ subscribeTemplate } {...register("subscribe_email_template_id")} />
-
                 <tbody>
                     <tr>
                         <th scope="row">

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListViewTable.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListViewTable.tsx
@@ -102,8 +102,8 @@ const StyledNoLists = styled.div`
 const NoLists = () => {
     return (
         <StyledNoLists>
-            <p><strong>{__("You have no subscriber lists.", "gc-lists")}</strong></p>
-            <p>{__("A subscriber list allows you to collect a group of subscribers that you can send messages to.", "gc-lists")}</p>
+            <p><strong>{__("You have no mailing lists.", "gc-lists")}</strong></p>
+            <p>{__("A mailing list allows you to collect a group of subscribers that you can send messages to.", "gc-lists")}</p>
         </StyledNoLists>
     )
 }
@@ -169,7 +169,6 @@ export const ListViewTable = () => {
             </StyledCreateButton>
 
             {hasLists ? <Table columns={columns} data={lists} /> : <NoLists />}
-
         </>
     )
 }

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/Service.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/Service.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from "@wordpress/i18n";
+
+/**
  * Internal dependencies
  */
 import { ListViewTable } from "./ListViewTable";
@@ -14,10 +19,11 @@ export const Service = () => {
     }
 
     return (
-        <div>
+        <>
+            <h1>{__("Mailing lists", "gc-lists")}</h1>
             <Messages />
             <ListViewTable />
-        </div>
+        </>
     )
 }
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
@@ -5,6 +5,7 @@ import { useState, useCallback } from 'react'
 import useFetch from 'use-http';
 import { SubmitHandler } from "react-hook-form";
 import { Navigate } from "react-router-dom";
+import { __ } from "@wordpress/i18n";
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import { Navigate } from "react-router-dom";
 import { ListForm } from "./ListForm";
 import { useService, useList, useListFetch } from '../../store';
 import { ErrorResponse, ServerErrors, FieldError, List, ListId } from "../../types";
+import { Back, StyledLink } from "../../common";
 
 const parseError = async (response: Response) => {
     try {
@@ -62,7 +64,15 @@ export const UpdateList = () => {
         return <Navigate to={`/lists`} replace={true} />
     }
 
-    return list ? <ListForm formData={list} handler={onSubmit} serverErrors={errors} /> : null
+    return list ? (
+        <>
+            <StyledLink to={`/lists`}>
+                <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
+            </StyledLink>
+            <h1>{__("Edit list", "gc-lists")}</h1>
+            <ListForm formData={list} handler={onSubmit} serverErrors={errors} />
+        </>)
+         : null
 }
 
 export default UpdateList;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
@@ -64,12 +64,24 @@ export const UpdateList = () => {
         return <Navigate to={`/lists`} replace={true} />
     }
 
+    let subscriberMessage = '';
+    if(list && list.subscriber_count !== undefined) {
+        const subscriber_count = parseInt(list.subscriber_count)
+        subscriberMessage = subscriber_count > 1 ?
+            __(`This list has ${subscriber_count} subscribers.`, "gc-lists") :
+            subscriber_count === 1 ?
+            __("This list has 1 subscriber.", "gc-lists") :
+            __("This list has no subscribers.", "gc-lists");
+    }
+
+
     return list ? (
         <>
             <StyledLink to={`/lists`}>
                 <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
             </StyledLink>
             <h1>{__("Edit list", "gc-lists")}</h1>
+            {subscriberMessage && <p>{subscriberMessage}</p>}
             <ListForm formData={list} handler={onSubmit} serverErrors={errors} />
         </>)
          : null

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
@@ -88,7 +88,6 @@ export const UploadList = () => {
                 <StyledLink to={`/lists`}>
                     <Back /> <span>{__("Go back", "gc-lists")}</span>
                 </StyledLink>
-                <Back />
             </div>
         </>)
 }

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { Importer, ImporterField } from "react-csv-importer";
 import useFetch from 'use-http';
 import { Navigate } from "react-router-dom";
+import { __ } from "@wordpress/i18n";
 
 // theme CSS for React CSV Importer
 import "react-csv-importer/dist/index.css";
@@ -14,7 +15,7 @@ import "react-csv-importer/dist/index.css";
  */
 import { useService, useList } from '../../store';
 import { ListType } from "../../types";
-import { Back } from "./Back";
+import { Back, StyledLink } from '../../common';
 import { capitalize } from "../../util/functions";
 
 export const UploadList = () => {
@@ -84,6 +85,9 @@ export const UploadList = () => {
                 {uploadType === ListType.PHONE && <ImporterField name="phone" label="Phone" />}
             </Importer >
             <div style={{ marginTop: "0.5rem" }}>
+                <StyledLink to={`/lists`}>
+                    <Back /> <span>{__("Go back", "gc-lists")}</span>
+                </StyledLink>
                 <Back />
             </div>
         </>)

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/ListDrafts.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/ListDrafts.tsx
@@ -9,7 +9,8 @@ import { Link, useLocation } from "react-router-dom";
 /**
  * Internal dependencies
  */
-import { Table, StyledLink, StyledPaging, ConfirmDelete, Spinner, Next } from ".";
+import { Table, StyledPaging, ConfirmDelete, Spinner, Next } from ".";
+import { StyledLink } from '../../common';
 import { useList, useTemplateApi } from '../../store';
 import { ToastMessage } from './ToastMessage';
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/NotAuthorized.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/NotAuthorized.tsx
@@ -6,7 +6,7 @@
  /**
  * Internal dependencies
  */
-import { StyledLink, Back } from '../components';
+import { Back, StyledLink } from '../../common';
 
 export const NotAuthorized = () => {
     return (

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/SendingHistory.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/SendingHistory.tsx
@@ -12,7 +12,9 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
-import { StyledPlaceholder, Table, StyledPaging, StyledLink, Next } from ".";
+import { StyledPlaceholder, Table, StyledPaging, Next } from ".";
+import { StyledLink } from '../../common';
+
 
 const StyledTableLink = styled(Link)`
     text-decoration:underline !important;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/Table.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/Table.tsx
@@ -4,12 +4,12 @@
 import { __ } from "@wordpress/i18n";
 import styled from 'styled-components';
 import { useTable, usePagination } from 'react-table';
-import { Link } from "react-router-dom";
 
 /**
  * Internal dependencies
  */
-import { Next, Back } from ".";
+import { Next } from ".";
+import { Back } from "../../common";
 
 export const StyledH1 = styled.h1`
    margin-bottom:30px !important;
@@ -50,24 +50,6 @@ export const StyledButton = styled.button`
         top:-1px;
     }
 `;
-
-export const StyledLink = styled(Link)`
-    position:relative;
-    display:block;
-    margin-top:20px;
-    margin-bottom: 20px;
-    span{
-        display:inline-block;
-        text-decoration:underline !important;
-        position:relative;
-        top:-1px;
-        margin-right:10px;
-
-        :hover{
-            text-decoration:none !important;
-        }
-    }
-`
 
 export const Table = ({ columns, data, perPage = 6, pageNav = false }: { columns: any, data: any, perPage?: number, pageNav?: boolean }) => {
     const {

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/icons/Back.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/icons/Back.tsx
@@ -1,7 +1,0 @@
-export const Back = () => {
-    return (
-        <svg width="9" height="15" viewBox="0 0 9 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 1.5L2 7.49999L7.99999 13.5" stroke="#2B4380" strokeWidth="2" />
-        </svg>)
-
-}

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/icons/index.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/icons/index.tsx
@@ -1,4 +1,3 @@
-export { Back } from "./Back";
 export { Check } from "./Check";
 export { Next } from "./Next";
 export { Warn } from "./Warn";

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/index.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/components/index.tsx
@@ -11,7 +11,7 @@ export { SendingError } from "./SendingError";
 export { SendingHistory } from "./SendingHistory";
 export { SendToList } from "./SendToList";
 export { ListSelect } from "./ListSelect";
-export { Table, StyledH1, StyledLink, StyledPaging } from "./Table";
+export { Table, StyledH1, StyledPaging } from "./Table";
 export { Spinner } from "../../common/Spinner";
 export { Error } from "../../common/Error";
 export { ToastMessage } from "./ToastMessage";

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/AllDrafts.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/AllDrafts.tsx
@@ -6,7 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ListDrafts, StyledLink, Back } from '../components';
+import { Back, StyledLink } from '../../common';
+import { ListDrafts } from '../components';
 
 export const AllDrafts = () => {
     return (

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/AllSendingHistory.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/AllSendingHistory.tsx
@@ -6,7 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { SendingHistory, StyledLink, Back } from "../components";
+import { Back, StyledLink } from '../../common';
+import { SendingHistory } from "../components";
 
 export const AllSendingHistory = () => {
     return (

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/ChooseMessage.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/ChooseMessage.tsx
@@ -45,13 +45,17 @@ export const ChooseMessage = () => {
                             </th>
                             <td>
                                 <FieldError errors={errors} id={fieldId}>
-                                    <div style={{ marginBottom: "5px" }}>
+                                    <div>
                                         <input {...register(fieldId, { required: true })} type="radio" id="message_type_email" value="email" />
-                                        <label htmlFor="message_type_email">{__('Email', 'gc-lists')}</label>
+                                        <label htmlFor="message_type_email" style={{display: 'inline-block', margin: '2px 0 5px 3px' }}>
+                                            {__('Email', 'gc-lists')}
+                                        </label>
                                     </div>
                                     <div>
                                         <input {...register(fieldId, { required: true })} type="radio" id="message_type_phone" value="phone" />
-                                        <label htmlFor="message_type_phone">{__('Text message', 'gc-lists')}</label>
+                                        <label htmlFor="message_type_phone" style={{display: 'inline-block', margin: '2px 0 5px 3px' }}>
+                                            {__('Text message', 'gc-lists')}
+                                        </label>
                                     </div>
                                 </FieldError>
                             </td>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/ChooseMessage.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/ChooseMessage.tsx
@@ -8,7 +8,8 @@ import { useNavigate } from 'react-router-dom';
  /**
   * Internal dependencies
   */
-import { FieldError, StyledLink, Back, NotAuthorized } from '../components';
+import { Back, StyledLink } from '../../common';
+import { FieldError, NotAuthorized } from '../components';
 import { useList } from '../../store';
 
 export const ChooseMessage = () => {

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/EditMessage.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/EditMessage.tsx
@@ -11,9 +11,10 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
+import { Back, StyledLink } from '../../common';
 import { Editor, deserialize, serialize } from '../editor';
 import { useList, useTemplateApi } from '../../store';
-import { Success, Spinner, StyledLink, Back, NotAuthorized } from "../components";
+import { Success, Spinner, NotAuthorized } from "../components";
 
 const textWidth = { width: "25em" }
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/SendMessage.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/SendMessage.tsx
@@ -9,6 +9,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 /**
  * Internal dependencies
  */
+import { Back, StyledLink } from '../../common';
 import {
     MessagePreview,
     MessageSent,
@@ -16,9 +17,7 @@ import {
     SendingError,
     CreateNewList,
     ConfirmSend,
-    StyledLink,
     Next,
-    Back,
     FieldError
 } from "../components";
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/store/useService.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/store/useService.tsx
@@ -4,9 +4,9 @@ import { useList } from './listContext';
 export const useService = () => {
     const { state: { serviceData } } = useList();
     const params = useParams();
-    // @ts-ignore
     const serviceId = serviceData?.service_id;
+    const subscribeTemplate = serviceData?.subscribeTemplate;
     const listId = params?.listId;
     const type = params?.type;
-    return { serviceId, listId, type };
+    return { serviceId, subscribeTemplate, listId, type };
 }

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/types.ts
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/types.ts
@@ -37,9 +37,10 @@ export type Service = {
     name: string;
     service_id: string;
     sendingTemplate: string;
+    subscribeTemplate: string;
 };
 
-export type ServiceData = Service[] | null;
+export type ServiceData = Service | null;
 
 export type User = {
     hasPhone: boolean;

--- a/wordpress/wp-content/plugins/gc-lists/resources/templates/no_api_key.php
+++ b/wordpress/wp-content/plugins/gc-lists/resources/templates/no_api_key.php
@@ -4,7 +4,14 @@
  * Notify API Key not configured alert
  *
  * @var string $title
+ * @var array $missingValues
  */
+
+$missingValuesText = [
+    'NOTIFY_API_KEY' => __('your Notify API key', 'gc-lists'),
+    'NOTIFY_GENERIC_TEMPLATE_ID' => __('a Notify email template ID'),
+    'NOTIFY_SUBSCRIBE_TEMPLATE_ID' => __('a Notify subscription template ID')
+]
 ?>
 
 <h1><?php echo $title; ?></h1>
@@ -12,8 +19,20 @@
 <p>
     <?php
         echo sprintf(
-            __('You must configure your <a href="%s">Notify API Key</a>', 'gc-lists'),
-            admin_url("options-general.php?page=notify-settings")
+            __('You must configure your <a href="%s">Notify API Settings</a>.', 'gc-lists'),
+            admin_url("/wp-admin/admin.php?page=settings")
         );
+        echo " ";
+        _e('Please provide:', 'gc-lists');
         ?>
+</p>
+<ul style="font-size: 16px; list-style: disc inside;">
+    <?php
+    foreach ($missingValues as $missingValue) {
+        echo "<li>$missingValuesText[$missingValue]</li>";
+    }
+    ?>
+</ul>
+<p>
+    <?php _e('If you need help with this, you can reach out to <a href="mailto:platform-mvp@cds-snc.ca">platform-mvp@cds-snc.ca</a> for support.', 'gc-lists'); ?>
 </p>

--- a/wordpress/wp-content/plugins/gc-lists/resources/templates/no_api_key.php
+++ b/wordpress/wp-content/plugins/gc-lists/resources/templates/no_api_key.php
@@ -9,7 +9,7 @@
 
 $missingValuesText = [
     'NOTIFY_API_KEY' => __('your Notify API key', 'gc-lists'),
-    'NOTIFY_GENERIC_TEMPLATE_ID' => __('a Notify email template ID'),
+    'NOTIFY_GENERIC_TEMPLATE_ID' => __('a Notify message template ID'),
     'NOTIFY_SUBSCRIBE_TEMPLATE_ID' => __('a Notify subscription template ID')
 ]
 ?>
@@ -19,8 +19,8 @@ $missingValuesText = [
 <p>
     <?php
         echo sprintf(
-            __('You must configure your <a href="%s">Notify API Settings</a>.', 'gc-lists'),
-            admin_url("/wp-admin/admin.php?page=settings")
+            __('You must configure your <a href="%s">API Settings</a>.', 'gc-lists'),
+            admin_url("admin.php?page=settings")
         );
         echo " ";
         _e('Please provide:', 'gc-lists');

--- a/wordpress/wp-content/plugins/gc-lists/resources/templates/subscribers.php
+++ b/wordpress/wp-content/plugins/gc-lists/resources/templates/subscribers.php
@@ -8,8 +8,6 @@
  */
 ?>
 
-<h1><?php echo $title ?></h1>
-
 <!-- app -->
 <div class="wrap">
     <?php

--- a/wordpress/wp-content/plugins/gc-lists/src/Menu.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Menu.php
@@ -21,6 +21,19 @@ class Menu
         return self::$instance;
     }
 
+    private function isNotifyConfigured(): bool
+    {
+        if (
+            get_option('NOTIFY_API_KEY') &&
+            get_option('NOTIFY_GENERIC_TEMPLATE_ID') &&
+            get_option('NOTIFY_SUBSCRIBE_TEMPLATE_ID')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function addMenu()
     {
         add_menu_page(
@@ -62,7 +75,7 @@ class Menu
      */
     public function renderMessages(): void
     {
-        if (!get_option('NOTIFY_API_KEY')) {
+        if (!$this->isNotifyConfigured()) {
             $this->renderNoApiKey();
             exit;
         }
@@ -79,7 +92,7 @@ class Menu
      */
     public function renderSubscribers(): void
     {
-        if (!get_option('NOTIFY_API_KEY')) {
+        if (!$this->isNotifyConfigured()) {
             $this->renderNoApiKey();
             exit;
         }
@@ -96,8 +109,19 @@ class Menu
      */
     public function renderNoApiKey()
     {
+        $values = [
+            'NOTIFY_API_KEY' => get_option('NOTIFY_API_KEY'),
+            'NOTIFY_GENERIC_TEMPLATE_ID' => get_option('NOTIFY_GENERIC_TEMPLATE_ID'),
+            'NOTIFY_SUBSCRIBE_TEMPLATE_ID' => get_option('NOTIFY_SUBSCRIBE_TEMPLATE_ID')
+        ];
+
+        $missingValues = array_filter($values, function ($var) {
+            return !$var ? true : false; // return falsey values
+        });
+
         $this->render('no_api_key', [
-            'title' => esc_html(get_admin_page_title())
+            'title' => esc_html(get_admin_page_title()),
+            'missingValues' => array_keys($missingValues)
         ]);
     }
 }

--- a/wordpress/wp-content/plugins/gc-lists/src/Menu.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Menu.php
@@ -49,8 +49,8 @@ class Menu
     {
         add_submenu_page(
             $this->messagesPageSlug,
-            __('Subscriber lists', 'gc-lists'),
-            __('Subscriber lists', 'gc-lists'),
+            __('Mailing lists', 'gc-lists'),
+            __('Mailing lists', 'gc-lists'),
             $this->capability,
             $this->subscribersPageSlug,
             [$this, 'renderSubscribers'],
@@ -85,7 +85,7 @@ class Menu
         }
 
         $this->render('subscribers', [
-            'title' => __('Subscriber lists', 'gc-lists'),
+            'title' => __('Mailing lists', 'gc-lists'),
             'services' => Utils::getServices(),
             'user' => Utils::getUserPermissions(),
         ]);

--- a/wordpress/wp-content/plugins/gc-lists/src/Utils.php
+++ b/wordpress/wp-content/plugins/gc-lists/src/Utils.php
@@ -36,7 +36,8 @@ class Utils
     {
         return [
             'name' => __('Your Lists', 'gc-lists'),
-            'service_id' => static::getServiceId()
+            'service_id' => static::getServiceId(),
+            'subscribeTemplate' => get_option('NOTIFY_SUBSCRIBE_TEMPLATE_ID'),
         ];
     }
 

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/TestUtils.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/TestUtils.php
@@ -21,10 +21,13 @@ test('getServiceId', function() {
 
 test('getServices', function() {
     add_option('NOTIFY_API_KEY', 'this-is-fake-a7902fc8-37f0-417c-54c8-9ab499ee54c8-8f43566b-e491-451h-99e7-4f604b5c8283');
+    add_option('NOTIFY_SUBSCRIBE_TEMPLATE_ID', 'ex4mp1e0-d248-4661-a3d6-0647167e3720');
+
     $services = Utils::getServices();
     $this->assertEquals($services, [
         'name' => 'Your Lists',
-        'service_id' => 'a7902fc8-37f0-417c-54c8-9ab499ee54c8'
+        'service_id' => 'a7902fc8-37f0-417c-54c8-9ab499ee54c8',
+        'subscribeTemplate' => 'ex4mp1e0-d248-4661-a3d6-0647167e3720'
     ]);
 });
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates the page titles to "Mailing lists", the "create/edit new list" page, and blocks you from creating messages or lists unless you have filled out all your API settings.

| before | after |
|--------|-------|
|  <img width="922" alt="Screen Shot 2022-08-09 at 09 58 22" src="https://user-images.githubusercontent.com/2454380/183668566-11dc5e3f-3f0c-402b-b65a-ed7e8e574791.png">   |  <img width="1445" alt="Screen Shot 2022-08-12 at 10 35 31" src="https://user-images.githubusercontent.com/2454380/184377650-25c53d69-e698-44c7-930e-9fd9deed92e1.png">  |

Changes:
- Call them "Mailing lists" (and other content updates from Figma)
- Use the "wordpress admin" setting styles (tables where label is on the left and field is on the right)
- Remove "subscribe" and "unsubscribe" template ID fields (subscribe is now a hidden field, you enter it on the settings page)
  - "subscribe template ID" is now a hidden field pulled from the API Settings page
- Add a back link
- Important: not filling out any of the "API settings" means you can't create lists or messages
  - Error page will tell you which fields are missing

### gif of the error page

![Screen Recording 2022-08-12 at 10 18 07](https://user-images.githubusercontent.com/2454380/184378860-4d745d7a-5ed8-4396-9b03-b353fc5ae969.gif)

