### PR TITLE
fix: lower WAF rate limit to 2,000 requests

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -621,6 +621,13 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
       dynamic "block" {
         for_each = var.enable_waf == true ? [""] : []
         content {
+          custom_response {
+            response_code = 429
+            response_header {
+              name  = "waf-block"
+              value = "RateLimit"
+            }
+          }
         }
       }
 
@@ -633,7 +640,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
     statement {
       rate_based_statement {
-        limit              = 10000
+        limit              = 2000
         aggregate_key_type = "IP"
       }
     }

--- a/infrastructure/terragrunt/env/staging/env_vars.hcl
+++ b/infrastructure/terragrunt/env/staging/env_vars.hcl
@@ -1,7 +1,7 @@
 inputs = {
   account_id        = "729164266357"
   enable_efs        = false
-  enable_waf        = false
+  enable_waf        = true
   env               = "staging"
   billing_tag_key   = "CostCentre"
   billing_tag_value = "PlatformGCArticles"


### PR DESCRIPTION
# Summary
Update the WAF rate limit to only allow 2,000 requests from a single
IP in a 5 minute period.  This is in response to the fuzzing attacks
we've seen that have caused problems, but been below the previous
limit of 10,000.

Also re-enable the WAF in Staging now that the pentesting exercise
is complete.

# Related
* cds-snc/gc-articles-issues#474 