### PR TITLE
feat: cache WordPress API endpoints

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -201,8 +201,8 @@ resource "aws_cloudfront_distribution" "wordpress" {
     }
 
     min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }
@@ -225,8 +225,8 @@ resource "aws_cloudfront_distribution" "wordpress" {
     }
 
     min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }


### PR DESCRIPTION
# Summary
Update CloudFront to cache WordPress API endpoints.  The cache
behaviour will be as follows:

- If cache control headers are present, they will be respected up to a
maximum cache time-to-live (TTL) of one day (86,400 seconds).
- If no cache control headers are present, responses will be cached
for 1 hour (3,600 seconds).

This is being done to help ease the strain on WordPress ECS tasks.

# Related
* cds-snc/gc-articles-issues#474