### PR TITLE
fix: add `config.platform.php` key to composer.json

### DIFF
--- a/.github/workflows/check-php-version.yml
+++ b/.github/workflows/check-php-version.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Check PHP version of WordPress composer.json files
         working-directory: wordpress
         run: |
-          find . -name "composer.json" -print0 | while read -d $'\0' FILE; do
-            CURR_VERSION="$(cat $FILE | jq -r .config.platform.php)"
+          find . -name "composer.json" -print0 | while read -d $'\0' COMPOSER; do
+            CURR_VERSION="$(cat $COMPOSER | jq -r .config.platform.php)"
             if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
-              echo "💩 PHP version does not match ${{ env.PHP_VERSION }} in $FILE ($CURR_VERSION)"
+              echo "💩 PHP version does not match ${{ env.PHP_VERSION }} in $COMPOSER: $CURR_VERSION"
               exit 1
             fi
           done
@@ -32,10 +32,10 @@ jobs:
       - name: Check PHP version in GitHub workflows
         working-directory: .github/workflows
         run: |
-          grep -r "php-version:" --exclude=check-php-version.yml *.yml | while read MATCH; do
-            CURR_VERSION="$(echo $MATCH | awk -F' ' '{ print $3 }')"
+          grep -r "php-version:" --exclude=check-php-version.yml *.yml | while read WORKFLOW; do
+            CURR_VERSION="$(echo $WORKFLOW | awk -F' ' '{ print $3 }')"
             if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
-              echo "💩 PHP version does not match in $MATCH"
+              echo "💩 PHP version does not match ${{ env.PHP_VERSION }} in $WORKFLOW"
               exit 1
             fi
           done

--- a/.github/workflows/check-php-version.yml
+++ b/.github/workflows/check-php-version.yml
@@ -1,4 +1,4 @@
-name: Check PHP version
+name: Check PHP version match
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  check-php-version:
+  check-php-version-match:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check PHP version in GitHub workflows
         run: |
-          grep -r "php-version: " .github/workflows/*.yml | while read MATCH; do
+          grep -r "php-version:" .github/workflows/*.yml | while read MATCH; do
             CURR_VERSION="$(echo $MATCH | awk -F' ' '{ print $3 }')"
             if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
               echo "💩 PHP version does not match in $MATCH"

--- a/.github/workflows/check-php-version.yml
+++ b/.github/workflows/check-php-version.yml
@@ -19,8 +19,9 @@ jobs:
           echo "PHP_VERSION=$PHP_VERSION" >> $GITHUB_ENV
 
       - name: Check PHP version of WordPress composer.json files
+        working-directory: wordpress
         run: |
-          find ./wordpress -name "composer.json" -print0 | while read -d $'\0' FILE; do
+          find . -name "composer.json" -print0 | while read -d $'\0' FILE; do
             CURR_VERSION="$(cat $FILE | jq -r .config.platform.php)"
             if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
               echo "💩 PHP version does not match ${{ env.PHP_VERSION }} in $FILE ($CURR_VERSION)"
@@ -29,8 +30,9 @@ jobs:
           done
 
       - name: Check PHP version in GitHub workflows
+        working-directory: .github/workflows
         run: |
-          grep -r "php-version:" .github/workflows/*.yml | while read MATCH; do
+          grep -r "php-version:" --exclude=check-php-version.yml *.yml | while read MATCH; do
             CURR_VERSION="$(echo $MATCH | awk -F' ' '{ print $3 }')"
             if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
               echo "💩 PHP version does not match in $MATCH"
@@ -39,5 +41,6 @@ jobs:
           done
 
       - name: Check PHP version in WordPress Dockerfile
+        working-directory: wordpress/docker
         run: |
-          cat ./wordpress/docker/Dockerfile | grep -E "FROM wordpress:[0-9\.]+-php${{ env.PHP_VERSION }}-fpm-alpine"
+          cat Dockerfile | grep -E "FROM wordpress:[0-9\.]+-php${{ env.PHP_VERSION }}-fpm-alpine"

--- a/.github/workflows/check-php-version.yml
+++ b/.github/workflows/check-php-version.yml
@@ -1,0 +1,43 @@
+name: Check PHP version
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check-php-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set PHP target version from .wp-env.json
+        run: |
+          PHP_VERSION="$(cat .wp-env.json | jq -r .phpVersion)"
+          echo "PHP_VERSION=$PHP_VERSION" >> $GITHUB_ENV
+
+      - name: Check PHP version of WordPress composer.json files
+        run: |
+          find ./wordpress -name "composer.json" -print0 | while read -d $'\0' FILE; do
+            CURR_VERSION="$(cat $FILE | jq -r .config.platform.php)"
+            if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
+              echo "💩 PHP version does not match ${{ env.PHP_VERSION }} in $FILE ($CURR_VERSION)"
+              exit 1
+            fi
+          done
+
+      - name: Check PHP version in GitHub workflows
+        run: |
+          grep -r "php-version: " .github/workflows/*.yml | while read MATCH; do
+            CURR_VERSION="$(echo $MATCH | awk -F' ' '{ print $3 }')"
+            if [ "$CURR_VERSION" != "${{ env.PHP_VERSION }}" ]; then
+              echo "💩 PHP version does not match in $MATCH"
+              exit 1
+            fi
+          done
+
+      - name: Check PHP version in WordPress Dockerfile
+        run: |
+          cat ./wordpress/docker/Dockerfile | grep -E "FROM wordpress:[0-9\.]+-php${{ env.PHP_VERSION }}-fpm-alpine"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
           composer config http-basic.my.yoast.com token ${{ secrets.COMPOSER_YOAST_TOKEN }}
 
-      - run: cd wordpress && composer install --prefer-dist --no-progress --no-suggest --check-platform-reqs
+      - run: cd wordpress && composer install --prefer-dist --no-progress --no-suggest
+      - run: cd wordpress && composer check-platform-reqs
       - run: cd wordpress && ./vendor/bin/pest
 
   gc-lists-php-tests:
@@ -51,7 +52,8 @@ jobs:
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           cd wordpress/wp-content/plugins/gc-lists
           bash bin/install-wp-tests.sh wordpress_test root 'root' localhost $WP_VERSION
-          composer install --check-platform-reqs
+          composer install
+          composer check-platform-reqs
 
       - name: Run the tests
         run: |
@@ -81,7 +83,8 @@ jobs:
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           cd wordpress/wp-content/plugins/cds-wpml-mods
           bash bin/install-wp-tests.sh wordpress_test root 'root' localhost $WP_VERSION
-          composer install --check-platform-reqs
+          composer install
+          composer check-platform-reqs
 
       - name: Run the tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
           composer config http-basic.my.yoast.com token ${{ secrets.COMPOSER_YOAST_TOKEN }}
 
-      - run: cd wordpress && composer install --prefer-dist --no-progress --no-suggest
+      - run: cd wordpress && composer install --prefer-dist --no-progress --no-suggest --check-platform-reqs
       - run: cd wordpress && ./vendor/bin/pest
 
   gc-lists-php-tests:
@@ -51,7 +51,7 @@ jobs:
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           cd wordpress/wp-content/plugins/gc-lists
           bash bin/install-wp-tests.sh wordpress_test root 'root' localhost $WP_VERSION
-          composer install
+          composer install --check-platform-reqs
 
       - name: Run the tests
         run: |
@@ -81,7 +81,7 @@ jobs:
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           cd wordpress/wp-content/plugins/cds-wpml-mods
           bash bin/install-wp-tests.sh wordpress_test root 'root' localhost $WP_VERSION
-          composer install
+          composer install --check-platform-reqs
 
       - name: Run the tests
         run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -40,7 +40,10 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Composer install
-        run: cd wordpress && composer install --prefer-dist --no-progress --check-platform-reqs
+        working-directory: wordpress
+        run: |
+          composer install --prefer-dist --no-progress
+          composer check-platform-reqs
 
       - name: Cache NPM
         uses: actions/cache@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Composer install
-        run: cd wordpress && composer install --prefer-dist --no-progress
+        run: cd wordpress && composer install --prefer-dist --no-progress --check-platform-reqs
 
       - name: Cache NPM
         uses: actions/cache@v2

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -120,8 +120,8 @@
     ],
     "generate-encryption-key": "CDS\\Modules\\Cli\\GenerateEncryptionKey::generateEncryptionKey",
     "post-install-cmd": [
-      "cd wp-content/plugins/gc-lists && composer install",
-      "cd wp-content/plugins/cds-wpml-mods && composer install"
+      "cd wp-content/plugins/gc-lists && composer install --check-platform-reqs",
+      "cd wp-content/plugins/cds-wpml-mods && composer install --check-platform-reqs"
     ]
   },
   "autoload": {
@@ -134,6 +134,9 @@
       "composer/installers": true,
       "ffraenz/private-composer-installer": true,
       "pestphp/pest-plugin": true
+    },
+    "platform": {
+      "php": "8.1"
     }
   }
 }

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -120,8 +120,8 @@
     ],
     "generate-encryption-key": "CDS\\Modules\\Cli\\GenerateEncryptionKey::generateEncryptionKey",
     "post-install-cmd": [
-      "cd wp-content/plugins/gc-lists && composer install --check-platform-reqs",
-      "cd wp-content/plugins/cds-wpml-mods && composer install --check-platform-reqs"
+      "cd wp-content/plugins/gc-lists && composer install && composer check-platform-reqs",
+      "cd wp-content/plugins/cds-wpml-mods && composer install && composer check-platform-reqs"
     ]
   },
   "autoload": {

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN echo "WPML_USER_ID=$WPML_USER_ID" > .env \
     && echo "WPML_KEY=$WPML_KEY" >> .env
 
-RUN cd wordpress && composer install --no-interaction --optimize-autoloader --no-dev
+RUN cd wordpress && composer install --no-interaction --optimize-autoloader --no-dev --check-platform-reqs
 
 ## Install NPM dependencies
 

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -10,7 +10,9 @@ COPY . .
 RUN echo "WPML_USER_ID=$WPML_USER_ID" > .env \
     && echo "WPML_KEY=$WPML_KEY" >> .env
 
-RUN cd wordpress && composer install --no-interaction --optimize-autoloader --no-dev --check-platform-reqs
+RUN cd wordpress \
+    && composer install --no-interaction --optimize-autoloader --no-dev \
+    && composer check-platform-reqs
 
 ## Install NPM dependencies
 

--- a/wordpress/wp-content/plugins/cds-base/composer.json
+++ b/wordpress/wp-content/plugins/cds-base/composer.json
@@ -5,6 +5,11 @@
       "CDS\\": "classes/"
     }
   },
+  "config": { 
+    "platform": {
+      "php": "8.1"
+    }
+  },
   "require": {
     "php": ">=5.6",
     "wa72/htmlpagedom": "^3.0",

--- a/wordpress/wp-content/plugins/cds-web-blocks/composer.json
+++ b/wordpress/wp-content/plugins/cds-web-blocks/composer.json
@@ -16,14 +16,17 @@
         "mockery/mockery": "^1.5"
     },
     "autoload": {
-      "psr-4": {
-          "CDSWeb\\": "src/"
-      }
+        "psr-4": {
+            "CDSWeb\\": "src/"
+        }
     },
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "composer/installers": true
+        },
+        "platform": {
+            "php": "8.1"
         }
     },
     "require": {},

--- a/wordpress/wp-content/plugins/cds-wpml-mods/composer.json
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/composer.json
@@ -27,6 +27,9 @@
     "allow-plugins": {
       "pestphp/pest-plugin": true,
       "composer/installers": true
+    },
+    "platform": {
+      "php": "8.1"
     }
   },
   "require": {

--- a/wordpress/wp-content/plugins/gc-lists/composer.json
+++ b/wordpress/wp-content/plugins/gc-lists/composer.json
@@ -26,6 +26,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "composer/installers": true
+        },
+        "platform": {
+            "php": "8.1"
         }
     },
     "require": {

--- a/wordpress/wp-content/plugins/gc-post-meta/composer.json
+++ b/wordpress/wp-content/plugins/gc-post-meta/composer.json
@@ -25,6 +25,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "composer/installers": true
+        },
+        "platform": {
+            "php": "8.1"
         }
     },
     "require": {},

--- a/wordpress/wp-content/themes/cds-default/composer.json
+++ b/wordpress/wp-content/themes/cds-default/composer.json
@@ -45,6 +45,9 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "platform": {
+            "php": "8.1"
         }
     }
 }


### PR DESCRIPTION
# Summary
Update the project's composer.json files with the PHP version.  This
is so [Renovate uses the correct version of PHP](https://github.com/renovatebot/renovate/pull/13657) when performing
dependency upgrades and version pinning.

Also add `composer check-platform-reqs` commands to the GitHub
actions and Dockerfile to validate the installed dependencies will
work with the target platform.

# Todo
- [x] Add GitHub workflow that checks PHP versions are in sync
based on version defined in [.wp-env.json](https://github.com/cds-snc/gc-articles/blob/main/.wp-env.json#L11).

# Related
* cds-snc/gc-articles-issues#472