### PR TITLE
fix: deprecated Node.js 12.x canary runtime

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/canary.tf
+++ b/infrastructure/terragrunt/aws/alarms/canary.tf
@@ -7,7 +7,7 @@ resource "aws_synthetics_canary" "wordpress" {
   execution_role_arn   = aws_iam_role.synthetic_canary_execution_role.arn
   zip_file             = data.archive_file.wordpress_canary.output_path
   handler              = "healthcheck.handler"
-  runtime_version      = "syn-nodejs-puppeteer-3.1"
+  runtime_version      = "syn-nodejs-puppeteer-3.6"
   start_canary         = true
 
   schedule {


### PR DESCRIPTION
# Summary
Update the synthetic canary runtime so that we're no longer using
the deprecated Node.js 12.x Lambda runtime environment.  This bumps
the canary to using:

- Lambda runtime Node.js 14.x
- Puppeteer-core version 10.1.0
- Chromium version 92.0.4512

# Related
* [Runtime versions using Node.js and Puppeteer](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-3.6)