### PR TITLE
New page for choose subscribers

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/ListsApp.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/ListsApp.tsx
@@ -7,6 +7,7 @@ import './App.css';
 import { Service } from "./components/Service";
 import { UpdateList } from "./components/UpdateList";
 import { CreateList } from "./components/CreateList";
+import { ChooseSubscribers } from "./components/ChooseSubscribers";
 import { UploadList } from "./components/UploadList";
 
 const ListsApp = () => {
@@ -24,6 +25,11 @@ const ListsApp = () => {
             <CreateList />
           </React.Suspense>
         } />
+        <Route path="/choose-subscribers" element={
+          <React.Suspense fallback={<Spinner />}>
+            <ChooseSubscribers />
+          </React.Suspense>
+        } />
         <Route path="/:listId/update" element={
           <React.Suspense fallback={<Spinner />}>
             <UpdateList />
@@ -35,9 +41,7 @@ const ListsApp = () => {
           </React.Suspense>
         } />
       </Routes>
-
     </Suspense>
-
   )
 }
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/ListsApp.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/ListsApp.tsx
@@ -25,7 +25,7 @@ const ListsApp = () => {
             <CreateList />
           </React.Suspense>
         } />
-        <Route path="/choose-subscribers" element={
+        <Route path="/:listId/choose-subscribers/:type" element={
           <React.Suspense fallback={<Spinner />}>
             <ChooseSubscribers />
           </React.Suspense>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
@@ -8,8 +8,7 @@ import { __ } from "@wordpress/i18n";
  /**
   * Internal dependencies
   */
-import { Error } from "./Error";
-import { useService, useList } from "../../store";
+import { useService } from "../../store";
 import { Back, StyledLink } from "../../common";
 import { ListType } from "../../types";
 
@@ -34,15 +33,9 @@ const StyledDivider  = styled.div`
 
  export const ChooseSubscribers = () => {
     const navigate = useNavigate();
-    const { state: { serviceData } } = useList();
-    // Get the list ID and list type from the URL
     const { listId, type } = useService();
     const titleType = type === ListType.PHONE ? 'text message' : 'email';
     const importType = type === ListType.PHONE ? 'text messages' : 'email addresses';
-
-    if (!serviceData) {
-        return <Error />;
-    }
 
     return (
         <>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { __ } from "@wordpress/i18n";
 
  /**
@@ -34,13 +34,9 @@ const StyledDivider  = styled.div`
 
  export const ChooseSubscribers = () => {
     const navigate = useNavigate();
-    const { state: { serviceData, lists } } = useList();
-
-    console.log('serviceData', serviceData)
-    console.log('lists', lists)
-
-    //const { state: { lists } } = useList();
-    // const { listId } = useService()
+    const { state: { serviceData } } = useList();
+    // Get the list ID and list type from the URL
+    let { listId, type } = useParams();
 
     if (!serviceData) {
         return <Error />;
@@ -56,23 +52,21 @@ const StyledDivider  = styled.div`
             <p>{__("Choose an option to add subscribers to this list. You can come back at any time to add more subscribers.", "gc-lists")}</p>
 
             <StyledDivider>
-                <h2>{__("If you have an existing list.", "gc-lists")}</h2>
-                <p><strong>{__("Import subscribers", "gc-lists")}</strong></p>
+                <h2>{__("If you already have subscribers", "gc-lists")}</h2>
+                <p><strong>{__("Import existing subscribers", "gc-lists")}</strong></p>
                 <p>{__("Upload a spreadsheet of your subscribers in CSV format. It must have a column with the email addresses.", "gc-lists")}</p>
-
-
                 <button
                     className="button button-primary"
                     type="button"
                     onClick={() => {
-                        console.log('clicked!')
+                        navigate(`/lists/${listId}/upload/${type}`, { replace: true });
                     }}
                 >
-                    {__('Import using a CSV file', 'gc-lists')}
+                    {__('Choose a file', 'gc-lists')}
                 </button>
             </StyledDivider>
             <StyledDivider>
-                <h2>{__("If you don’t have an existing list", "gc-lists")}</h2>
+                <h2>{__("If you don’t have subscribers yet", "gc-lists")}</h2>
                 <p><strong>{__("Start collecting subscriber emails", "gc-lists")}</strong></p>
                 <p>{__("Set up a form to collect email addresses from subscribers. This will create a content block you can add to your pages.", "gc-lists")}</p>
             </StyledDivider>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { __ } from "@wordpress/i18n";
+
+ /**
+  * Internal dependencies
+  */
+import { Error } from "./Error";
+import { useList } from "../../store";
+import { Back, StyledLink } from "../../common";
+
+
+const StyledDivider  = styled.div`
+    border: 1px solid #cccccc;
+    padding: 10px;
+    margin-top: -1px; /* This is a hack so that the borders overlap */
+
+    h2 {
+        font-size: 1.4em;
+        margin-top: 5px;
+    }
+
+    p {
+        margin: 0;
+    }
+
+    button.button-primary {
+        margin: 10px 0 !important;
+    }
+`
+
+ export const ChooseSubscribers = () => {
+    const navigate = useNavigate();
+    const { state: { serviceData, lists } } = useList();
+
+    console.log('serviceData', serviceData)
+    console.log('lists', lists)
+
+    //const { state: { lists } } = useList();
+    // const { listId } = useService()
+
+    if (!serviceData) {
+        return <Error />;
+    }
+
+    return (
+        <>
+            <StyledLink to={`/lists`}>
+                {/* Put the name of the list here */}
+                <Back /> <span>{__("Edit list", "gc-lists")}</span>
+            </StyledLink>
+            <h1>{__("Add email subscribers", "gc-lists")}</h1>
+            <p>{__("Choose an option to add subscribers to this list. You can come back at any time to add more subscribers.", "gc-lists")}</p>
+
+            <StyledDivider>
+                <h2>{__("If you have an existing list.", "gc-lists")}</h2>
+                <p><strong>{__("Import subscribers", "gc-lists")}</strong></p>
+                <p>{__("Upload a spreadsheet of your subscribers in CSV format. It must have a column with the email addresses.", "gc-lists")}</p>
+
+
+                <button
+                    className="button button-primary"
+                    type="button"
+                    onClick={() => {
+                        console.log('clicked!')
+                    }}
+                >
+                    {__('Import using a CSV file', 'gc-lists')}
+                </button>
+            </StyledDivider>
+            <StyledDivider>
+                <h2>{__("If you don’t have an existing list", "gc-lists")}</h2>
+                <p><strong>{__("Start collecting subscriber emails", "gc-lists")}</strong></p>
+                <p>{__("Set up a form to collect email addresses from subscribers. This will create a content block you can add to your pages.", "gc-lists")}</p>
+            </StyledDivider>
+
+            <br />
+            <button
+                className="button"
+                type="button"
+                onClick={() => navigate('/lists/')}
+            >
+                {__('Return to mailing lists', 'gc-lists')}
+            </button>
+        </>
+    )
+ }
+ 
+ export default ChooseSubscribers;
+ 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
@@ -11,6 +11,7 @@ import { __ } from "@wordpress/i18n";
 import { Error } from "./Error";
 import { useService, useList } from "../../store";
 import { Back, StyledLink } from "../../common";
+import { ListType } from "../../types";
 
 const StyledDivider  = styled.div`
     border: 1px solid #cccccc;
@@ -36,6 +37,8 @@ const StyledDivider  = styled.div`
     const { state: { serviceData } } = useList();
     // Get the list ID and list type from the URL
     const { listId, type } = useService();
+    const titleType = type === ListType.PHONE ? 'text message' : 'email';
+    const importType = type === ListType.PHONE ? 'text messages' : 'email addresses';
 
     if (!serviceData) {
         return <Error />;
@@ -47,13 +50,13 @@ const StyledDivider  = styled.div`
                 {/* Put the name of the list here */}
                 <Back /> <span>{__("Edit list", "gc-lists")}</span>
             </StyledLink>
-            <h1>{__("Add email subscribers", "gc-lists")}</h1>
+            <h1>{__(`Add ${titleType} subscribers`, "gc-lists")}</h1>
             <p>{__("Choose an option to add subscribers to this list. You can come back at any time to add more subscribers.", "gc-lists")}</p>
 
             <StyledDivider>
                 <h2>{__("If you already have subscribers", "gc-lists")}</h2>
                 <p><strong>{__("Import existing subscribers", "gc-lists")}</strong></p>
-                <p>{__("Upload a spreadsheet of your subscribers in CSV format. It must have a column with the email addresses.", "gc-lists")}</p>
+                <p>{__("Upload a spreadsheet of your subscribers in CSV format. It must have a column with", "gc-lists")} {importType}.</p>
                 <button
                     className="button button-primary"
                     type="button"
@@ -64,11 +67,13 @@ const StyledDivider  = styled.div`
                     {__('Choose a file', 'gc-lists')}
                 </button>
             </StyledDivider>
-            <StyledDivider>
-                <h2>{__("If you don’t have subscribers yet", "gc-lists")}</h2>
-                <p><strong>{__("Start collecting subscriber emails", "gc-lists")}</strong></p>
-                <p>{__("Set up a form to collect email addresses from subscribers. This will create a content block you can add to your pages.", "gc-lists")}</p>
-            </StyledDivider>
+            {type === ListType.EMAIL &&
+                <StyledDivider>
+                    <h2>{__("If you don’t have subscribers yet", "gc-lists")}</h2>
+                    <p><strong>{__("Start collecting subscriber emails", "gc-lists")}</strong></p>
+                    <p>{__("Set up a form to collect email addresses from subscribers. This will create a content block you can add to your pages.", "gc-lists")}</p>
+                </StyledDivider>
+            }
 
             <br />
             <button

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ChooseSubscribers.tsx
@@ -2,16 +2,15 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { __ } from "@wordpress/i18n";
 
  /**
   * Internal dependencies
   */
 import { Error } from "./Error";
-import { useList } from "../../store";
+import { useService, useList } from "../../store";
 import { Back, StyledLink } from "../../common";
-
 
 const StyledDivider  = styled.div`
     border: 1px solid #cccccc;
@@ -36,7 +35,7 @@ const StyledDivider  = styled.div`
     const navigate = useNavigate();
     const { state: { serviceData } } = useList();
     // Get the list ID and list type from the URL
-    let { listId, type } = useParams();
+    const { listId, type } = useService();
 
     if (!serviceData) {
         return <Error />;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -48,7 +48,7 @@ export const CreateList = () => {
     return data.id ? <Navigate to={`/lists/${data.id}/choose-subscribers/${data.type}`} replace={true} /> : (
         <>
             <StyledLink to={`/lists`}>
-                <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
+                <Back /> <span>{__("Mailing lists", "gc-lists")}</span>
             </StyledLink>
             <h1>{__("Create new list", "gc-lists")}</h1>
             <ListForm formData={formData} serverErrors={[]} handler={onSubmit} />

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/CreateList.tsx
@@ -13,11 +13,11 @@ import { __ } from "@wordpress/i18n";
  */
 import { ListForm } from "./ListForm";
 import { useList, useService } from "../../store";
-import { List } from "../../types";
+import { List, ListType } from "../../types";
 import { Back, StyledLink } from "../../common";
 
 export const CreateList = () => {
-    const [data, setData] = useState({ id: null })
+    const [data, setData] = useState({ id: null, type: ListType.EMAIL })
     const { dispatch, state: { config: { listManagerApiPrefix } } } = useList();
     const { request, cache, response } = useFetch(listManagerApiPrefix, { data: [] })
     const { serviceId } = useService();
@@ -27,8 +27,9 @@ export const CreateList = () => {
 
         if (response.ok) {
             cache.clear();
-            const id = response.data
-            setData(id);
+            const id = response.data?.id
+            const type = formData.language === 'en' ? ListType.EMAIL : ListType.PHONE
+            setData({ id, type });
             dispatch({ type: "add", payload: id })
             return
         }
@@ -44,8 +45,7 @@ export const CreateList = () => {
     }
 
 
-
-    return data.id ? <Navigate to={`/lists`} replace={true} /> : (
+    return data.id ? <Navigate to={`/lists/${data.id}/choose-subscribers/${data.type}`} replace={true} /> : (
         <>
             <StyledLink to={`/lists`}>
                 <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -39,7 +39,8 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
     const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
     const { subscribeTemplate } = useService();
-    const saveButtonText = "name" in formData ? __("Save", "gc-lists") : __("Save and continue", "gc-lists");
+    const isNewList = "name" in formData // if the "name" exists, we are editing the list
+    const saveButtonText = isNewList ? __("Save and continue", "gc-lists") : __("Save", "gc-lists");
 
     useEffect(() => {
         serverErrors && serverErrors.length >= 1 && serverErrors.forEach((item) => {
@@ -74,7 +75,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                             </div>
                         </StyledCell>
                     </tr>
-                    {user?.hasPhone &&
+                    {user?.hasPhone && !isNewList &&
                         <tr>
                             <th scope="row">
                                 <label htmlFor="language">{__("Message type", "gc-lists")}</label>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -39,6 +39,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
     const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
     const { subscribeTemplate } = useService();
+    const saveButtonText = "name" in formData ? __("Save", "gc-lists") : __("Save and continue", "gc-lists");
 
     useEffect(() => {
         serverErrors && serverErrors.length >= 1 && serverErrors.forEach((item) => {
@@ -158,7 +159,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
 
             <div>
                 <button style={{ marginRight: "20px" }} type="submit" className="button button-primary">
-                    {__('Save and continue', 'gc-lists')}
+                    {saveButtonText}
                 </button>
 
                 <button

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -39,7 +39,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
     const { state: { user } } = useList();
     const { register, handleSubmit, setError, formState: { errors } } = useForm<List>({ defaultValues: formData });
     const { subscribeTemplate } = useService();
-    const isNewList = "name" in formData // if the "name" exists, we are editing the list
+    const isNewList = !("name" in formData) // if the "name" exists, we are editing the list
     const saveButtonText = isNewList ? __("Save and continue", "gc-lists") : __("Save", "gc-lists");
 
     useEffect(() => {
@@ -75,7 +75,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                             </div>
                         </StyledCell>
                     </tr>
-                    {user?.hasPhone && !isNewList &&
+                    {user?.hasPhone && isNewList &&
                         <tr>
                             <th scope="row">
                                 <label htmlFor="language">{__("Message type", "gc-lists")}</label>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListForm.tsx
@@ -164,9 +164,7 @@ export const ListForm = ({ handler, formData = {}, serverErrors = [] }: { handle
                 <button
                     className="button"
                     type="button"
-                    onClick={() => {
-                        navigate('/lists/');
-                    }}
+                    onClick={() => navigate('/lists/')}
                 >
                     {__('Cancel', 'gc-lists')}
                 </button>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListViewTable.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListViewTable.tsx
@@ -81,7 +81,7 @@ const EditLink = ({ listId }: { listId: string }) => {
     )
 }
 
-const UploadListLink = ({ name, listId, type }: { name: string, listId: string, type: ListType }) => {
+const UploadListLink = ({ listId, type }: { listId: string, type: ListType }) => {
     return (
         <StyledActionLink to={{ pathname: `/lists/${listId}/upload/${type}` }}>
             {__('Add subscribers', 'gc-lists')}
@@ -142,8 +142,8 @@ export const ListViewTable = () => {
                         <EditLink listId={`${row?.original?.id}`} />
                         <StyledDivider>|</StyledDivider>
                         {user?.isSuperAdmin && <><DeleteLink listId={`${row?.original?.id}`} /> <StyledDivider>|</StyledDivider> </>}
-                        {getListType(row?.original?.language) === ListType.EMAIL && <UploadListLink name={`${row?.values?.name}`} listId={`${row?.original?.id}`} type={ListType.EMAIL} />}
-                        {getListType(row?.original?.language) === ListType.PHONE && user?.hasPhone ? <UploadListLink name={`${row?.values?.name}`} listId={`${row?.original?.id}`} type={ListType.PHONE} /> : null}
+                        {getListType(row?.original?.language) === ListType.EMAIL && <UploadListLink listId={`${row?.original?.id}`} type={ListType.EMAIL} />}
+                        {getListType(row?.original?.language) === ListType.PHONE && user?.hasPhone ? <UploadListLink listId={`${row?.original?.id}`} type={ListType.PHONE} /> : null}
                     </>
                 },
             },

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
@@ -12,7 +12,7 @@ import { __ } from "@wordpress/i18n";
  */
 import { ListForm } from "./ListForm";
 import { useService, useList, useListFetch } from '../../store';
-import { ErrorResponse, ServerErrors, FieldError, List, ListType, ListIdAndType } from "../../types";
+import { ErrorResponse, ServerErrors, FieldError, List, ListId } from "../../types";
 import { Back, StyledLink } from "../../common";
 
 const parseError = async (response: Response) => {
@@ -31,7 +31,7 @@ export const UpdateList = () => {
     const { state: { config: { listManagerApiPrefix } } } = useList();
     const { request, cache, response } = useFetch(listManagerApiPrefix, { data: [] })
 
-    const [responseData, setResponseData] = useState<ListIdAndType>({ id: null, type: ListType.EMAIL });
+    const [responseData, setResponseData] = useState<ListId>({ id: null });
     const [errors, setErrors] = useState<ServerErrors>([]);
     const { state: { lists } } = useList();
     const { listId } = useService()
@@ -47,8 +47,7 @@ export const UpdateList = () => {
 
         if (response.ok) {
             cache.clear();
-            const listType = language === 'en' ? ListType.EMAIL : ListType.PHONE
-            setResponseData({ id: id, type: listType });
+            setResponseData({ id: id });
             return;
     }
 
@@ -62,8 +61,7 @@ export const UpdateList = () => {
     })[0];
 
     if (responseData.id) {
-        // @ TODO: don't do this for editing lists
-        return <Navigate to={`/lists/${responseData.id}/choose-subscribers/${responseData.type}`} replace={true} />
+        return <Navigate to={'/lists'} replace={true} />
     }
 
     let subscriberMessage = '';

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
@@ -79,7 +79,7 @@ export const UpdateList = () => {
     return list ? (
         <>
             <StyledLink to={`/lists`}>
-                <Back /> <span>{__("Back to mailing lists", "gc-lists")}</span>
+                <Back /> <span>{__("Mailing lists", "gc-lists")}</span>
             </StyledLink>
             <h1>{__("Edit list", "gc-lists")}</h1>
             {subscriberMessage && <p>{subscriberMessage}</p>}

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
+import styled from 'styled-components';
 import { useState } from 'react'
 import { Importer, ImporterField } from "react-csv-importer";
 import useFetch from 'use-http';
-import { Navigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { __ } from "@wordpress/i18n";
 
 // theme CSS for React CSV Importer
@@ -16,11 +17,41 @@ import "react-csv-importer/dist/index.css";
 import { useService, useList } from '../../store';
 import { ListType } from "../../types";
 import { Back, StyledLink } from '../../common';
-import { capitalize } from "../../util/functions";
+
+const StyledDivider  = styled.div`
+    margin: 20px 10px;
+
+    /* Give "importer" buttons 'button-primary' styles since they are the main actions */
+    .CSVImporter_TextButton {
+        background: #26374a;
+        border-color: #26374a;
+        color: #fff;
+    }
+
+    .CSVImporter_TextButton:active {
+        background-color: #16446c;
+        border-color: #000;
+    }
+
+    .CSVImporter_TextButton:hover,
+    .CSVImporter_TextButton:focus {
+        background-color: #1c578a;
+        border-color: #091c2d;
+    }
+
+
+    .CSVImporter_TextButton:focus {
+        box-shadow: 0 0 0 1px #fff, 0 0 0 3px #26374a;
+        outline: 2px solid transparent;
+        outline-offset: 0;
+    }
+`
 
 export const UploadList = () => {
+    const navigate = useNavigate();
     const [finished, setFinished] = useState<boolean>(false)
     const { listId, type } = useService();
+
     let uploadType = '';
 
     switch (type) {
@@ -43,52 +74,59 @@ export const UploadList = () => {
 
     return (
         <>
-            <h3>{capitalize(type)} upload</h3>
-            <Importer
-                delimiter={" "}
-                chunkSize={10000} // optional, internal parsing chunk size in bytes
-                assumeNoHeaders={false} // optional, keeps "data has headers" checkbox off by default
-                restartable={false} // optional, lets user choose to upload another file when import is complete
-                onStart={({ file, fields }) => {
-                    // optional, invoked when user has mapped columns and started import
-                    console.log("starting import of file", file, "with fields", fields);
-                }}
-                processChunk={async (rows) => {
-                    return new Promise(async (resolve) => {
-                        const data = rows.map((item) => {
-                            // @ts-ignore
-                            return item[uploadType].replace(/(^,)|(,$)/g, '');
+            <StyledLink to={`/lists/${listId}/update`}>
+                <Back /> <span>{__("Edit list", "gc-lists")}</span>
+            </StyledLink>
+            <h1>Import {type} subscribers</h1>
+            <StyledDivider>
+                <Importer
+                    delimiter={" "}
+                    chunkSize={10000} // optional, internal parsing chunk size in bytes
+                    assumeNoHeaders={false} // optional, keeps "data has headers" checkbox off by default
+                    restartable={false} // optional, lets user choose to upload another file when import is complete
+                    onStart={({ file, fields }) => {
+                        // optional, invoked when user has mapped columns and started import
+                        console.log("starting import of file", file, "with fields", fields);
+                    }}
+                    processChunk={async (rows) => {
+                        return new Promise(async (resolve) => {
+                            const data = rows.map((item) => {
+                                // @ts-ignore
+                                return item[uploadType].replace(/(^,)|(,$)/g, '');
+                            });
+
+                            const payload = { [uploadType]: data };
+                            await request.post(`/list/${listId}/import`, payload)
+
+                            if (response.ok) {
+                                cache.clear();
+                                console.log(response.data);
+                                resolve()
+                            }
                         });
-
-                        const payload = { [uploadType]: data };
-                        await request.post(`/list/${listId}/import`, payload)
-
-                        if (response.ok) {
-                            cache.clear();
-                            console.log(response.data);
-                            resolve()
-                        }
-                    });
-                }}
-                onComplete={({ file, fields }) => {
-                    // optional, invoked right after import is done (but user did not dismiss/reset the widget yet)
-                    console.log("finished import of file", file, "with fields", fields);
-                }}
-                onClose={() => {
-                    // optional, invoked when import is done and user clicked "Finish"
-                    // (if this is not specified, the widget lets the user upload another file)
-                    console.log("importer dismissed");
-                    setFinished(true);
-                }}
+                    }}
+                    onComplete={({ file, fields }) => {
+                        // optional, invoked right after import is done (but user did not dismiss/reset the widget yet)
+                        console.log("finished import of file", file, "with fields", fields);
+                    }}
+                    onClose={() => {
+                        // optional, invoked when import is done and user clicked "Finish"
+                        // (if this is not specified, the widget lets the user upload another file)
+                        console.log("importer dismissed");
+                        setFinished(true);
+                    }}
+                >
+                    {uploadType === ListType.EMAIL && <ImporterField name="email" label="Email" />}
+                    {uploadType === ListType.PHONE && <ImporterField name="phone" label="Phone" />}
+                </Importer >
+            </StyledDivider>
+            <button
+                className="button"
+                type="button"
+                onClick={() => navigate('/lists/')}
             >
-                {uploadType === ListType.EMAIL && <ImporterField name="email" label="Email" />}
-                {uploadType === ListType.PHONE && <ImporterField name="phone" label="Phone" />}
-            </Importer >
-            <div style={{ marginTop: "0.5rem" }}>
-                <StyledLink to={`/lists`}>
-                    <Back /> <span>{__("Go back", "gc-lists")}</span>
-                </StyledLink>
-            </div>
+                {__('Return to mailing lists', 'gc-lists')}
+            </button>
         </>)
 }
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UploadList.tsx
@@ -51,6 +51,7 @@ export const UploadList = () => {
     const navigate = useNavigate();
     const [finished, setFinished] = useState<boolean>(false)
     const { listId, type } = useService();
+    const titleType = type === ListType.PHONE ? 'text message' : 'email';
 
     let uploadType = '';
 
@@ -77,7 +78,7 @@ export const UploadList = () => {
             <StyledLink to={`/lists/${listId}/update`}>
                 <Back /> <span>{__("Edit list", "gc-lists")}</span>
             </StyledLink>
-            <h1>Import {type} subscribers</h1>
+            <h1>Import {titleType} subscribers</h1>
             <StyledDivider>
                 <Importer
                     delimiter={" "}
@@ -125,7 +126,7 @@ export const UploadList = () => {
                 type="button"
                 onClick={() => navigate('/lists/')}
             >
-                {__('Return to mailing lists', 'gc-lists')}
+                {__('Back to mailing lists', 'gc-lists')}
             </button>
         </>)
 }

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/types.ts
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/types.ts
@@ -27,6 +27,11 @@ export enum ListType {
     PHONE = 'phone',
 }
 
+export type ListIdAndType = {
+    id: string | null;
+    type: ListType;
+};
+
 export type Message = {
     id: string;
     type: string;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/types.ts
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/types.ts
@@ -27,11 +27,6 @@ export enum ListType {
     PHONE = 'phone',
 }
 
-export type ListIdAndType = {
-    id: string | null;
-    type: ListType;
-};
-
 export type Message = {
     id: string;
     type: string;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/util/functions.ts
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/util/functions.ts
@@ -1,5 +1,3 @@
-export const capitalize = (s: string) => s && s[0].toUpperCase() + s.slice(1);
-
 export const getListType = (type: string) => {
   //@todo --- temporary... note we're using language here -> en=email, fr=phone 
   if (type === 'en') {


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new step after creating a new list for choosing to add subscribers or not. 
It also makes a few tweaks to our existing "Create new list" page and the "Upload subscribers" page.

## New page for subscribers

Adds the new "Add {type} subscribers" page [we see in Figma](https://www.figma.com/file/SGnOdzb51VNk2xRdA3bAJc/Bulk-sending?node-id=590%3A8450). Note that it doesn't include the images, but is based on a slightly older design (we can add images in a future PR). When it's about adding text messages, there is no subscribe block, only the option to upload.

Note that the link to "Set up a form" is meant to link to a Knowledge Base article, but it doesn't exist yet so I didn't add a link there (only applies to the "Add email subscribers").

| email subs | text message subs |
|--------|-------|
|  <img width="1409" alt="Screen Shot 2022-08-17 at 09 22 38" src="https://user-images.githubusercontent.com/2454380/185145667-be391ed4-0910-4dbd-b09a-16e2af99b445.png">    |   <img width="1409" alt="Screen Shot 2022-08-17 at 09 24 52" src="https://user-images.githubusercontent.com/2454380/185145674-b257d11d-4541-4363-806d-503359077de1.png">  |

## Tweaks to existing pages

1.  Create new list vs. edit list
  - New lists have the "Save and continue" option, which leads to the "Add subscribers" page. Editing existing lists will just send you back to the main page of all lists.
  - New lists allow you to edit the type, but existing lists, I removed that option. I figured that we don't want to edit the type of a list after we've created it, but once we add subscribers we super don't want to change the type. So I just removed it for simplicity.
2. Upload subscribers
  - Added a back link at the top to edit the list again
  - Changed the H1
  - Added a button at the bottom to return to the mailing lists
  - Made the "choose columns/import" buttons blue since they are the primary actions

| before | after |
|--------|-------|
|        |   new back link, new h1, blue button inside the uploader    |
|   <img width="1409" alt="Screen Shot 2022-08-17 at 09 23 42" src="https://user-images.githubusercontent.com/2454380/185148383-b13e8eb8-30d9-49e4-aefb-c8bb8a96f15a.png">   |  <img width="1409" alt="Screen Shot 2022-08-17 at 09 23 39" src="https://user-images.githubusercontent.com/2454380/185148375-bc560e37-a089-4bf3-86a1-03cf5691f2d3.png">  |


## gif

Here's the whole thing working.

![Screen Recording 2022-08-17 at 09 13 29](https://user-images.githubusercontent.com/2454380/185148694-78bdb573-0a2a-4c2f-be05-938d52069574.gif)

