### PR TITLE
Increase automated account lockout time to a year

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/UserLockout.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/UserLockout.php
@@ -8,7 +8,7 @@ use CDS\Modules\TrackLogins\TrackLogins;
 
 class UserLockout
 {
-    public const USER_LOCKOUT_TIME = (60 * 60 * 24) * 90; // 90 days
+    public const USER_LOCKOUT_TIME = (60 * 60 * 24) * 365; // 365 days
 
     public $loginPlugin;
     public $trackLogins;


### PR DESCRIPTION
Previously, if someone didn't log in for 90 days, we would lock their account. This was a security feature to just be more proactive around dormant accounts.

Old PR is here: https://github.com/cds-snc/gc-articles/pull/217

However, it seems we have some sleepy users and there are a number of legitimate users who don't log in for longer than 90 days and then need to be unlocked. Bryan has requested the lockout time be 1 year, so that's what we're going to go with. Luckily the previous PR was really well-written PR so it's just a one-line change.

Source:
- https://github.com/cds-snc/gc-articles-issues/issues/476
