### PR TITLE
Allow self-hosted files to be embedded inline on GC Articles

### DIFF
--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -58,6 +58,7 @@ function cds_security_headers($headers)
             "'self'",
         ],
         "object-src" => [
+            "'self'",
             "https://digital.canada.ca",
         ],
         "script-src" => [
@@ -68,10 +69,12 @@ function cds_security_headers($headers)
             "'sha256-5/P+Wb5Puz2VZQuyT0B/H3kuum7v7A2XDV17K95mm2Q='",
             "'sha256-Ll9Pj6gzPpETya7YXsYglTFBzjPg0sc23VG6sms7FKE='",
             "'sha256-9vpql/NLyCCe3HPEb2b/lcLKPbkRi48w2Lfn0AbTxsQ='",
+            "'sha256-+zAcjG07bIcQUdOJ4VdpR6NeUqSj+ijz0iNFSRtHtFU='",
             "https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/i18n/en.min.js",
+            "https://www.canada.ca/etc/designs/canada/wet-boew/js/i18n/fr.min.js",
             "https://www.googletagmanager.com/",
             "https://digital.canada.ca",
         ],


### PR DESCRIPTION
Previously, our CSP rules would ban any self-hosted PDFs from being displayed (they had to come from Canada.ca), which seems overly-zealous.

This change allows PDFs to be uploaded to GC articles and then displayed on the frontend, as well as safelisting a french WET script that we missed and a WPML script.

Note that it doesn't work locally because of S3, we think, but it should work on staging and production.

**Screenshot**

Here are all the not working links that I am safelisting.

<img width="1409" alt="Screen Shot 2022-08-17 at 11 59 15" src="https://user-images.githubusercontent.com/2454380/185241694-91f6e401-4d37-4995-bf20-de85a42af454.png">

