### PR TITLE
Adds rich text field for adding multiple links

### DIFF
--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -1,0 +1,37 @@
+import { RichText } from '@wordpress/block-editor';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { parseMetaKey, updateValue, getValue } from "../utils";
+
+export const CDSRichText = compose(
+    withDispatch((dispatch, props) => {
+        return {
+            setMetaValue: (value, content) => {
+                const { key } = parseMetaKey(props.metaKey);
+                const newValue = updateValue(props.metaKey, value, content);
+                dispatch('core/editor').editPost({ meta: { [key]: newValue } });
+            }
+        }
+    }),
+    withSelect((select, props) => {
+        const { key } = parseMetaKey(props.metaKey);
+        return {
+            metaValue: select('core/editor').getEditedPostAttribute('meta')[key],
+        }
+    })
+)((props) => {
+    const value = getValue(props.metaKey, props.metaValue);
+
+    return (
+        <RichText
+            tagName="div"
+            className="cds-rich-text"
+            allowedFormats={props.allowedFormats}
+            label={props.label}
+            value={value || ""}
+            onChange={(content) => { props.setMetaValue(content, props.metaValue) }}
+        />
+    );
+});
+
+export default CDSRichText;

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/edit.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/edit.js
@@ -1,5 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import TextControl from '../components/TextControl';
+import RichText from '../components/RichText';
 import { __ } from '@wordpress/i18n';
 import GCPostMetaSlotFill from "../../../../../gc-post-meta/resources/js/slot";
 import { ProductFields } from './components/sidebar';
@@ -22,6 +23,10 @@ const Edit = ({ attributes, setAttributes }) => {
             <p>{__('Other', 'cds-web')}</p>
             <TextControl label={__('Weight', 'cds-web')} metaKey="cds_product:weight" />
             <TextControl label={__('TagId', 'cds-web')} metaKey="cds_product:tag-id" />
+            <p>{__('Product Link(s)', 'cds-web')}</p>
+            <RichText allowedFormats={['core/link']} metaKey="cds_product:links" />
+            <p>{__('Related Link(s)', 'cds-web')}</p>
+            <RichText allowedFormats={['core/link']} metaKey="cds_product:links-related" />
         </div>
     );
 };

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/index.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/index.js
@@ -1,5 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
+import './style.scss';
 
 // http://localhost/cds/wp-json/wp/v2/product?_embed
 

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/style.scss
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/style.scss
@@ -1,6 +1,10 @@
-/**
- * The following styles get applied both on the front of your site
- * and in the editor.
- *
- * Replace them with your own styles or remove the file completely.
- */
+.cds-rich-text {
+  border: 1px solid #757575;
+  border-radius: 2px;
+  padding: 10px;
+  font-size: 13px;
+}
+
+.cds-rich-text:focus {
+  border: 2px solid #2271b1;
+}


### PR DESCRIPTION
# Summary | Résumé

Adds RichText block to allow entering multiple links

<img width="1026" alt="Screen Shot 2022-08-18 at 12 02 08 PM" src="https://user-images.githubusercontent.com/62242/185443650-fa844b2c-8eff-4618-804f-7217286cc654.png">



> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
