### PR TITLE
Add parser option to rich text field

### DIFF
--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -8,7 +8,13 @@ export const CDSRichText = compose(
         return {
             setMetaValue: (value, content) => {
                 const { key } = parseMetaKey(props.metaKey);
-                const newValue = updateValue(props.metaKey, value, content);
+                let newValue = updateValue(props.metaKey, value, content);
+                if (props.parser) {
+                    let data = JSON.parse(newValue);
+                    const parserKey = `parsed-${key}`;
+                    data[parserKey] = props.parser(value);
+                    newValue = JSON.stringify(data);
+                }
                 dispatch('core/editor').editPost({ meta: { [key]: newValue } });
             }
         }

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -10,7 +10,7 @@ export const CDSRichText = compose(
                 const { key } = parseMetaKey(props.metaKey);
                 let newValue = updateValue(props.metaKey, value, content);
                 if (props.parser) {
-                    const parserKey = `parsed-${props.metaKey}`;
+                    const parserKey = `parsed-${props.metaKey}`.replace(":", "_");
                     let data = JSON.parse(newValue);
                     data[parserKey] = props.parser(value);
                     newValue = JSON.stringify(data);

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -10,8 +10,8 @@ export const CDSRichText = compose(
                 const { key } = parseMetaKey(props.metaKey);
                 let newValue = updateValue(props.metaKey, value, content);
                 if (props.parser) {
-                    let data = JSON.parse(newValue);
                     const parserKey = `parsed-${key}`;
+                    let data = JSON.parse(newValue);
                     data[parserKey] = props.parser(value);
                     newValue = JSON.stringify(data);
                 }

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -10,7 +10,7 @@ export const CDSRichText = compose(
                 const { key } = parseMetaKey(props.metaKey);
                 let newValue = updateValue(props.metaKey, value, content);
                 if (props.parser) {
-                    const parserKey = `parsed-${props.metaKey}`.replace(":", "-");
+                    const parserKey = `parsed_${props.metaKey}`.replace(":", "_");
                     let data = JSON.parse(newValue);
                     data[parserKey] = props.parser(value);
                     newValue = JSON.stringify(data);

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -10,7 +10,7 @@ export const CDSRichText = compose(
                 const { key } = parseMetaKey(props.metaKey);
                 let newValue = updateValue(props.metaKey, value, content);
                 if (props.parser) {
-                    const parserKey = `parsed-${props.metaKey}`.replace(":", "_");
+                    const parserKey = `parsed-${props.metaKey}`.replace(":", "-");
                     let data = JSON.parse(newValue);
                     data[parserKey] = props.parser(value);
                     newValue = JSON.stringify(data);

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/components/RichText.js
@@ -10,7 +10,7 @@ export const CDSRichText = compose(
                 const { key } = parseMetaKey(props.metaKey);
                 let newValue = updateValue(props.metaKey, value, content);
                 if (props.parser) {
-                    const parserKey = `parsed-${key}`;
+                    const parserKey = `parsed-${props.metaKey}`;
                     let data = JSON.parse(newValue);
                     data[parserKey] = props.parser(value);
                     newValue = JSON.stringify(data);

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/edit.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/edit.js
@@ -4,6 +4,7 @@ import RichText from '../components/RichText';
 import { __ } from '@wordpress/i18n';
 import GCPostMetaSlotFill from "../../../../../gc-post-meta/resources/js/slot";
 import { ProductFields } from './components/sidebar';
+import { parseRichTextLinks } from '../utils/parseRichTextLinks';
 
 const Edit = ({ attributes, setAttributes }) => {
 
@@ -24,9 +25,17 @@ const Edit = ({ attributes, setAttributes }) => {
             <TextControl label={__('Weight', 'cds-web')} metaKey="cds_product:weight" />
             <TextControl label={__('TagId', 'cds-web')} metaKey="cds_product:tag-id" />
             <p>{__('Product Link(s)', 'cds-web')}</p>
-            <RichText allowedFormats={['core/link']} metaKey="cds_product:links" />
+            <RichText
+                parser={parseRichTextLinks}
+                allowedFormats={['core/link']}
+                metaKey="cds_product:links"
+            />
             <p>{__('Related Link(s)', 'cds-web')}</p>
-            <RichText allowedFormats={['core/link']} metaKey="cds_product:links-related" />
+            <RichText
+                parser={parseRichTextLinks}
+                allowedFormats={['core/link']}
+                metaKey="cds_product:links-related"
+            />
         </div>
     );
 };

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/edit.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/product/edit.js
@@ -18,12 +18,12 @@ const Edit = ({ attributes, setAttributes }) => {
             <TextControl label={__('Subtitle', 'cds-web')} metaKey="cds_product:subtitle" />
             <TextControl label={__('Description', 'cds-web')} metaKey="cds_product:description" />
             <p>{__('Call to action', 'cds-web')}</p>
-            <TextControl label={__('Button Text', 'cds-web')} metaKey="cds_product:button-text" />
-            <TextControl label={__('Button Link', 'cds-web')} metaKey="cds_product:button-link" />
-            <TextControl label={__('Button Aria', 'cds-web')} metaKey="cds_product:button-aria" />
+            <TextControl label={__('Button Text', 'cds-web')} metaKey="cds_product:button_text" />
+            <TextControl label={__('Button Link', 'cds-web')} metaKey="cds_product:button_link" />
+            <TextControl label={__('Button Aria', 'cds-web')} metaKey="cds_product:button_aria" />
             <p>{__('Other', 'cds-web')}</p>
             <TextControl label={__('Weight', 'cds-web')} metaKey="cds_product:weight" />
-            <TextControl label={__('TagId', 'cds-web')} metaKey="cds_product:tag-id" />
+            <TextControl label={__('TagId', 'cds-web')} metaKey="cds_product:tag_id" />
             <p>{__('Product Link(s)', 'cds-web')}</p>
             <RichText
                 parser={parseRichTextLinks}
@@ -34,7 +34,7 @@ const Edit = ({ attributes, setAttributes }) => {
             <RichText
                 parser={parseRichTextLinks}
                 allowedFormats={['core/link']}
-                metaKey="cds_product:links-related"
+                metaKey="cds_product:links_related"
             />
         </div>
     );

--- a/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/utils/parseRichTextLinks.js
+++ b/wordpress/wp-content/plugins/cds-web-blocks/resources/js/src/utils/parseRichTextLinks.js
@@ -1,0 +1,16 @@
+function stripSlashes(str) {
+    return str.replace(new RegExp("\\\\", "g"), "");
+}
+
+function parseTag(str) {
+    const link = str.trim();
+    const linkRx = /<a\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/;
+    const href = link.match(linkRx)[2];
+    const text = link.match(/<a [^>]+>([^<]+)<\/a>/)[1];
+    return { link: href, text };
+}
+
+export const parseRichTextLinks = (str) => {
+    const links = stripSlashes(str).split("<br>");
+    return links.map(link => parseTag(link));
+}


### PR DESCRIPTION
# Summary | Résumé

Adds parser as an optional prop so that RichText fields can return structured data.

<img width="1342" alt="Screen Shot 2022-08-18 at 3 55 55 PM" src="https://user-images.githubusercontent.com/62242/185483922-8a298f59-3b2f-4f7b-be27-436a839f3b4f.png">

