### PR TITLE
Rework the settings page, add all the guidance 

### DIFF
--- a/cypress/integration/notify.settings.spec.js
+++ b/cypress/integration/notify.settings.spec.js
@@ -10,7 +10,7 @@ describe('GC Lists Settings', () => {
     it('Displays settings screen', () => {
       cy.visit('/wp-admin/admin.php?page=settings');
   
-      cy.get('h2').should('have.text', 'API Settings');
+      cy.get('h2').should('have.text', 'Set up GC Lists');
   
       cy.get('#notify_api_key').should('be.empty');
       cy.get('#notify_generic_template_id').should('be.empty');

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css
@@ -127,7 +127,8 @@ details ul li, details ol li {
   margin-bottom: 0;
 }
 
-.description * {
+.description *,
+p.smaller {
   font-size: 14.5px;
   color: #646970;
 }
@@ -145,6 +146,47 @@ details ul li, details ol li {
 
 .description details[open] summary {
   margin-bottom: 8px;
+}
+
+.description details a[target="_blank"]::after {
+  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+  margin: 0 3px 0 5px;
+}
+
+.description details a[target="_blank"]:hover::after {
+  color: #0535d2;
+}
+
+.description details p {
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.description details summary {
+  text-decoration: underline;
+}
+
+.description details ul {
+  list-style-type: decimal;
+  list-style-position: inside;
+}
+
+.description details ul li {
+  margin-bottom: 3px;
+}
+
+.description details code {
+  display: inline-block;
+  color: #1d2327;
+  padding: 8px;
+  font-size: 14px;
+}
+
+.wp-core-ui .description details code + .button.button-secondary {
+  font-size: 14.5px;
+  display: block;
+  margin-top: 8px;
+  margin-bottom: 15px;
 }
 
 /* screen reader shortcuts */

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -49,8 +49,8 @@ class NotifySettings
     {
         add_submenu_page(
             "gc-lists_messages",
-            __('API Settings', 'cds-snc'), // page_title
-            __('API Settings', 'cds-snc'), // menu_title
+            __('Set up GC Lists', 'cds-snc'), // page_title
+            __('Setup', 'cds-snc'), // menu_title
             'manage_notify',
             "settings",
             [ $this, 'notifyApiSettingsCreateAdminPage' ] // function
@@ -116,7 +116,7 @@ class NotifySettings
 
         add_settings_section(
             'notify_api_settings_setting_section', // id
-            __('API Settings', 'cds-snc'), // title
+            __('Set up GC Lists', 'cds-snc'), // title
             array( $this, 'notifyApiSettingsSectionInfo'), // callback
             'notify-api-settings-admin' // page
         );
@@ -133,17 +133,6 @@ class NotifySettings
         );
 
         add_settings_field(
-            'notify_subscribe_template', // id
-            __('Subscribe template ID', 'cds-snc'), // title
-            array( $this, 'notifySubscribeTemplateIdCallback'), // callback
-            'notify-api-settings-admin', // page
-            'notify_api_settings_setting_section', // section
-            [
-                'label_for' => 'notify_subscribe_template'
-            ]
-        );
-
-        add_settings_field(
             'notify_generic_template_id', // id
             __('Message template ID', 'cds-snc'), // title
             array( $this, 'notifyGenericTemplateIdCallback'), // callback
@@ -153,10 +142,29 @@ class NotifySettings
                 'label_for' => 'notify_generic_template_id'
             ]
         );
+
+        add_settings_field(
+            'notify_subscribe_template', // id
+            __('Subscribe template ID', 'cds-snc'), // title
+            array( $this, 'notifySubscribeTemplateIdCallback'), // callback
+            'notify-api-settings-admin', // page
+            'notify_api_settings_setting_section', // section
+            [
+                'label_for' => 'notify_subscribe_template'
+            ]
+        );
     }
 
     public function notifyApiSettingsSectionInfo()
     {
+        printf('<p>%s</p>', __('To start creating mailing lists and sending messages, you must connect a GC Notify service to GC Lists.', 'cds-snc'));
+        printf(
+            '<p>%s <a href="%s" target="_blank">%s</a> %s.</p>',
+            __('You can generate the required information below once you have a live', 'cds-snc'),
+            __('https://notification.canada.ca/', 'cds-snc'),
+            __('GC Notify', 'cds-snc'),
+            __('service', 'cds-snc'),
+        );
     }
 
     public function getObfuscatedOutputLabel($string, $labelId, $print = true)
@@ -190,12 +198,26 @@ class NotifySettings
         );
 
         $link = __('Read <a href="https://documentation.notification.canada.ca/en/keys.html" target="_blank">API keys</a> for details.', 'cds-snc');
-        printf('<div class="role-desc description">
-        <details>
-            <summary>%s. (%s)</summary>
-            <code>example_notify_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0</code>
-        </details>
-        <p class="description">%s</p>', __('Enter your API Key', 'cds-snc'), __('See example key format.', 'cds-snc'), $link);
+        printf(
+            '<div class="role-desc description">
+            <details>
+                <summary>%s</summary>
+                <ul>
+                    <li><a href="#" target="_blank">%s</a></li>
+                    <li>%s</li>
+                    <li>%s</li>
+                    <li>%s</li>
+                </ul>
+                <p class="description">%s</p>
+                <code>example_notify_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0</code>
+            </details>',
+            __('How to get an API key', 'cds-snc'),
+            __('Sign in to GC Notify', 'cds-snc'),
+            __('Go to the API integration page', 'cds-snc'),
+            __('Select API keys', 'cds-snc'),
+            __('Select Create an API key', 'cds-snc'),
+            __('The API key should follow this format:', 'cds-snc')
+        );
     }
 
     public function notifyGenericTemplateIdCallback()
@@ -205,13 +227,46 @@ class NotifySettings
             $this->NOTIFY_GENERIC_TEMPLATE_ID ? esc_attr($this->NOTIFY_GENERIC_TEMPLATE_ID) : ''
         );
 
-        $link = __('Read the <a href="https://notification.canada.ca/format" target="_blank">Email formatting guide</a> for details.', 'cds-snc');
-        printf('<div class="role-desc description">
+        printf(
+            '<p class="description smaller">%s</p>',
+            __('The messages you send will follow this format. It includes a way for people to unsubscribe from the mailing list.', 'cds-snc'),
+        );
+
+        printf(
+            '<div class="role-desc description">
         <details>
-            <summary>%s. (%s)</summary>
-            <code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
-        </details>
-        <p class="description">%s</p>', __('Enter your message template ID', 'cds-snc'), __('See example template ID format.', 'cds-snc'), $link);
+            <summary>%s</summary>
+            <ul>
+                <li><a href="#" target="_blank">%s</a></li>
+                <li>%s</li>
+                <li>%s</li>
+                <li>%s</li>
+            </ul>
+            <p class="description">%s</p>
+            <p><strong>%s</strong></p>
+            <code>((subject))</code>
+            <button type="button" class="button button-secondary">%s</button>
+            <p><strong>%s</strong></p>
+            <code>
+            ((message))<br /><br />
+            You may unsubscribe by clicking this link:<br /><br />
+            ((unsubscribe_link))<br /><br />
+            Vous pouvez vous desabonner en cliquant ce lien:<br /><br />
+            ((unsubscribe_link))
+            </code>
+            <button type="button" class="button button-secondary">%s</button>
+        </details>',
+            __('How to get an message template ID', 'cds-snc'),
+            __('Sign in to GC Notify', 'cds-snc'),
+            __('Select Create a template', 'cds-snc'),
+            __('Choose the type of message', 'cds-snc'),
+            __('Pick a name for your list', 'cds-snc'),
+            __('Enter below text into the corresponding fields in GC Notify:', 'cds-snc'),
+            __('Subject line of the email:', 'cds-snc'),
+            __('Copy to clipboard', 'cds-snc'),
+            __('Message:', 'cds-snc'),
+            __('Copy to clipboard', 'cds-snc')
+        );
     }
 
     public function notifySubscribeTemplateIdCallback()
@@ -221,12 +276,46 @@ class NotifySettings
             $this->NOTIFY_SUBSCRIBE_TEMPLATE_ID ? esc_attr($this->NOTIFY_SUBSCRIBE_TEMPLATE_ID) : ''
         );
 
-        printf('<div class="role-desc description">
+        printf(
+            '<p class="description smaller">%s</p>',
+            __('People will receive this message to verify their email address after subscribing to your mailing list.', 'cds-snc'),
+        );
+
+        printf(
+            '<div class="role-desc description">
         <details>
-            <summary>(%s)</summary>
-            <code>ex4mp1e0-d248-4661-a3d6-0647167e3720</code>
-        </details>
-        ', __('See example template ID format.', 'cds-snc'));
+            <summary>%s</summary>
+            <ul>
+                <li><a href="#" target="_blank">%s</a></li>
+                <li>%s</li>
+                <li>%s</li>
+                <li>%s</li>
+            </ul>
+            <p class="description">%s</p>
+            <p><strong>%s</strong></p>
+            <code>((subject))</code>
+            <button type="button" class="button button-secondary">%s</button>
+            <p><strong>%s</strong></p>
+            <code>
+            Thank you for subscribing to updates about ((name)).<br /><br />
+
+            To verify your email and activate your subscription, use this link: ((confirm_link))<br /><br />
+
+            If you did not subscribe, please ignore this message.
+            </code>
+            <button type="button" class="button button-secondary">%s</button>
+        </details>',
+            __('How to get an message template ID', 'cds-snc'),
+            __('Sign in to GC Notify', 'cds-snc'),
+            __('Select Create a template', 'cds-snc'),
+            __('Choose the type of message', 'cds-snc'),
+            __('Pick a name for your list', 'cds-snc'),
+            __('Enter below text into the corresponding fields in GC Notify:', 'cds-snc'),
+            __('Subject line of the email:', 'cds-snc'),
+            __('Copy to clipboard', 'cds-snc'),
+            __('Message:', 'cds-snc'),
+            __('Copy to clipboard', 'cds-snc')
+        );
     }
 
     public function addStyles()

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/src/copy-to-clipboard.js
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/src/copy-to-clipboard.js
@@ -1,0 +1,25 @@
+window.addEventListener('DOMContentLoaded', function(){
+    const { alertText } = CDS_VARS;
+
+    function copyToClipboard({ copyText, eventId }) {
+        try {
+            navigator.clipboard.writeText(copyText).then(() => {
+                alert(alertText + ': ' + eventId);
+            });
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    document.addEventListener('click', function (event) {
+        // If the clicked element doesn't have the right selector or no templateText, bail
+        if (!event.target.matches('.button--copy-to-clipboard') || !CDS_VARS[event.target.id]) return;
+    
+        // Cancel the default button action
+        event.preventDefault();
+        copyToClipboard({
+            copyText: CDS_VARS[event.target.id],
+            eventId: event.target.id
+        });
+    }, false);
+});


### PR DESCRIPTION
# Summary | Résumé

This is most of the code for the new settings page. Everything should work just fine, including using the buttons to "copy" the template content to the clipboard.

Here's the Figma render, for reference: https://www.figma.com/file/SGnOdzb51VNk2xRdA3bAJc/Bulk-sending?node-id=590%3A8450

This PR resolves https://github.com/cds-snc/gc-articles/pull/975

## Screenshots

| before | after |
|--------|-------|
|   less stuff     |    more stuff    |
|   ![Screen Shot 2022-08-18 at 17 33 45](https://user-images.githubusercontent.com/2454380/185499255-ff9d832c-73cd-488a-be33-a7488a2dff57.png)  |   ![Screen Shot 2022-08-18 at 17 31 50](https://user-images.githubusercontent.com/2454380/185499088-7cbea007-bfde-416d-83f6-d55d7a37ccc5.png)  |

## Example of copying

![Screen Recording 2022-08-19 at 11 37 21](https://user-images.githubusercontent.com/2454380/185655950-cabb5d4e-6abc-44d7-a680-0e38ace2e299.gif)

### Note about the formatting of the template text

I had initially kept the text indented like the rest of the code, but the "Copy" action was then preserving the tabs as whitespace, which is not something we actually wanted. To remove the tabs, I just unindented the text so that it hit the left-hand side of the editor. 

Just an FYI for the future if we need to update these templates again.

| left-justified text (current) | indented text | pasted from indented text |
|-------------------------------|---------------|---------------------------|
|   Currently the template text touches the left hand edge of the text editor, breaking the code nesting that we have. This is deliberate.                            |     This is how it would look if we indented the text properly to match the rest of the code. Unfortunately, this results in the tabs being preserved when the text is copied.      |      If we copy from the "indented text" version, you can see the tabs are being applied to all lines after the first line. This is not what we want, so that's why the template text is pushed to the left-hand edge of the editor.                     |
|          <img width="1209" alt="Screen Shot 2022-08-19 at 12 02 52" src="https://user-images.githubusercontent.com/2454380/185660874-680bd074-39d7-4be6-9dac-10be1ba6baba.png">           |     <img width="1209" alt="Screen Shot 2022-08-19 at 12 03 04" src="https://user-images.githubusercontent.com/2454380/185660892-ec4a3c52-db46-49ef-8024-7ebe232b08b2.png">       |     ![Screen Shot 2022-08-19 at 12 07 01](https://user-images.githubusercontent.com/2454380/185660897-d4a5fef3-67da-4855-9cc6-2f2bbe1b8fef.png)                      |





