### PR TITLE
Make menu less mysterious

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/public.css
@@ -102,8 +102,12 @@ header #wb-srch .submit {
   display: none;
 }
 
-/* Hide menu (keeps the blue bar) */
-.hide-wet-menu .gcweb-menu .container {
+/* Hide Canada.ca menu (including the blue bar) */
+.hide-wet-menu .gcweb-menu {
+  display: none;
+}
+
+.hide-custom-menu .nav--primary__container {
   display: none;
 }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/css/admin-wet.css
@@ -292,6 +292,19 @@ p.smaller {
   text-shadow: none !important;
 }
 
+.wp-core-ui input[type="radio"][disabled],
+.wp-core-ui input[type="checkbox"][disabled] {
+  border-color: #dcdcde;
+  background-color: #f6f7f7;
+  cursor: not-allowed;
+}
+
+.wp-core-ui input[type="radio"][disabled] + label,
+.wp-core-ui input[type="checkbox"][disabled] + label {
+  color: #a7aaad;
+  cursor: not-allowed;
+}
+
 .wp-core-ui .button-group > .button.active {
   border-color: #26374a;
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
@@ -18,8 +18,6 @@ class SettingsFunctions
 
     public function addActions()
     {
-        add_action('admin_head', [$this, 'dequeuePrimaryMenu']);
-
         add_filter('body_class', [$this, 'addBodyClasses']);
     }
 
@@ -27,10 +25,10 @@ class SettingsFunctions
     {
         $showWetMenu = get_option('show_wet_menu');
 
-        if ($showWetMenu !== 'canada') {
+        if (!empty($showWetMenu) && $showWetMenu !== 'canada') {
             $classes[] = 'hide-wet-menu';
         }
-        if ($showWetMenu !== 'custom') {
+        if (!empty($showWetMenu) && $showWetMenu !== 'custom') {
             $classes[] = 'hide-custom-menu';
         }
 
@@ -47,31 +45,5 @@ class SettingsFunctions
         }
 
         return $classes;
-    }
-
-    public function dequeuePrimaryMenu()
-    {
-        $showWetMenu = get_option('show_wet_menu');
-        $locations = get_nav_menu_locations();
-
-        var_dump($showWetMenu);
-        var_dump($locations);
-
-        if (
-            $showWetMenu === 'off' &&                   // if we _don't_ want to show the "wet menu"
-            array_key_exists('header', $locations) &&   // if there _is_ a 'header' location
-            is_int($locations['header'])                // if 'header' is assigned to an integer
-        ) {
-            $current_page_path = $_SERVER['REQUEST_URI'];
-
-            // if we are explicitly setting a menu, turn on the "show canada.ca menu" option
-            if (str_contains($current_page_path, "nav-menus.php")) {
-                update_option('show_wet_menu', 'on');
-            } else {
-                // if not, remove 'header' menu
-                $locations['header'] = null; // remove assigned menu
-                set_theme_mod('nav_menu_locations', $locations); // save the new "locations" array
-            }
-        }
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SettingsFunctions.php
@@ -27,8 +27,11 @@ class SettingsFunctions
     {
         $showWetMenu = get_option('show_wet_menu');
 
-        if ($showWetMenu === 'off') {
+        if ($showWetMenu !== 'canada') {
             $classes[] = 'hide-wet-menu';
+        }
+        if ($showWetMenu !== 'custom') {
+            $classes[] = 'hide-custom-menu';
         }
 
         $showSearch = get_option('show_search');
@@ -50,6 +53,9 @@ class SettingsFunctions
     {
         $showWetMenu = get_option('show_wet_menu');
         $locations = get_nav_menu_locations();
+
+        var_dump($showWetMenu);
+        var_dump($locations);
 
         if (
             $showWetMenu === 'off' &&                   // if we _don't_ want to show the "wet menu"

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -392,13 +392,22 @@ class SiteSettings
             checked("canada", $show_wet_menu, false),
             __('Show Canada.ca menu', "cds-snc")
         );
-
         printf(
             '<input type="radio" name="show_wet_menu" id="show_wet_menu_custom" value="custom" %s %s /> <label for="show_wet_menu_custom">%s</label><br />',
             checked("custom", $show_wet_menu, false),
             $customHeaderMenuExists ? "" : "disabled", // if no menu, disabled
             __('Show custom menu', "cds-snc")
         );
+
+        if (!$customHeaderMenuExists) {
+            printf(
+                '<p class="description" style="margin-top: -5px; margin-bottom: 5px;">%s <a href="%s">%s</a>.</p>',
+                __("You can set a custom menu in", "cds-snc"),
+                get_admin_url() . 'nav-menus.php',
+                __("Appearance > Menus", "cds-snc")
+            );
+        }
+
         printf(
             '<input type="radio" name="show_wet_menu" id="show_wet_menu_none" value="none" %s /> <label for="show_wet_menu_none">%s</label><br />',
             checked("none", $show_wet_menu, false),

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -383,7 +383,11 @@ class SiteSettings
     {
         $show_wet_menu = get_option('show_wet_menu');
         $locations = get_nav_menu_locations();
-        $customHeaderMenuExists = array_key_exists('header', $locations) && is_int($locations['header']);
+        $customHeaderMenu = (array_key_exists('header', $locations) && is_int($locations['header'])) ? $locations['header'] : false;
+        if ($customHeaderMenu) {
+            // set it to the name of the menu
+            $customHeaderMenu = wp_get_nav_menu_object($customHeaderMenu)->name;
+        }
 
         echo('<fieldset>');
         printf('<legend class="screen-reader-text"><span>%s</span></legend>', $args['title']);
@@ -393,13 +397,14 @@ class SiteSettings
             __('Show Canada.ca menu', "cds-snc")
         );
         printf(
-            '<input type="radio" name="show_wet_menu" id="show_wet_menu_custom" value="custom" %s %s /> <label for="show_wet_menu_custom">%s</label><br />',
+            '<input type="radio" name="show_wet_menu" id="show_wet_menu_custom" value="custom" %s %s /> <label for="show_wet_menu_custom">%s%s</label><br />',
             checked("custom", $show_wet_menu, false),
-            $customHeaderMenuExists ? "" : "disabled", // if no menu, disabled
-            __('Show custom menu', "cds-snc")
+            $customHeaderMenu ? "" : "disabled", // if no menu, disabled input
+            __('Show custom menu', "cds-snc"),
+            ': “' . $customHeaderMenu . '”' // if menu, echo its name into the label
         );
 
-        if (!$customHeaderMenuExists) {
+        if (!$customHeaderMenu) {
             printf(
                 '<p class="description" style="margin-top: -5px; margin-bottom: 5px;">%s <a href="%s">%s</a>.</p>',
                 __("You can set a custom menu in", "cds-snc"),

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -165,11 +165,11 @@ class SiteSettings
             'site_settings_group', // option_group
             'show_wet_menu',
             function ($input) {
-                if (in_array($input, ['on', 'off'])) {
+                if (in_array($input, ['canada', 'custom', 'none'])) {
                     return $input;
                 }
 
-                return 'off';
+                return '';
             }
         );
 
@@ -248,14 +248,16 @@ class SiteSettings
         );
 
         // add fields MAINTENANCE
+        $maintenanceTitle = __('Activate maintenance mode', 'cds-snc');
         add_settings_field(
             'collection_mode', // id
-            __('Activate maintenance mode', 'cds-snc'), // title
+            $maintenanceTitle, // title
             array($this, 'collectionModeCallback'), // callback
             'collection-settings-admin', // page
             'collection_settings_section_maintenance', // section
             [
-                'label_for' => 'collection_mode'
+                'label_for' => 'collection_mode',
+                'title'     => $maintenanceTitle
             ]
         );
 
@@ -282,25 +284,29 @@ class SiteSettings
         );
 
         // add fields MAINTENANCE
+        $menuTitle = __('Top menu', 'cds-snc');
         add_settings_field(
             'show_wet_menu', // id
-            __('Canada.ca top menu', 'cds-snc'), // title
+            $menuTitle, // title
             array($this, 'wetMenuCallback'), // callback
             'collection-settings-admin', // page
             'collection_settings_section_config', // section
-            [
-                'label_for' => 'show_wet_menu'
-            ]
+            [ // args
+                'label_for' => 'show_wet_menu',
+                'title'     => $menuTitle
+            ],
         );
 
+        $searchTitle = __('Search bar', 'cds-snc');
         add_settings_field(
             'show_search', // id
-            __('Search bar', 'cds-snc'), // title
+            $searchTitle, // title
             array($this, 'showSearchCallback'), // callback
             'collection-settings-admin', // page
             'collection_settings_section_config', // section
             [
-                'label_for' => 'show_search'
+                'label_for' => 'show_search',
+                'title'     => $searchTitle
             ]
         );
 
@@ -310,14 +316,16 @@ class SiteSettings
          *
          * Since the settings API doesn't let me write to that field easily, I am creating a new setting.
          */
+        $breadcrumbsTitle = __('Breadcrumbs', 'cds-snc');
         add_settings_field(
             'show_breadcrumbs', // id
-            __('Breadcrumbs', 'cds-snc'), // title
+            $breadcrumbsTitle, // title
             array($this, 'breadcrumbsCallback'), // callback
             'collection-settings-admin', // page
             'collection_settings_section_config', // section
             [
-                'label_for' => 'show_breadcrumbs'
+                'label_for' => 'show_breadcrumbs',
+                'title'     => $breadcrumbsTitle
             ]
         );
 
@@ -352,10 +360,12 @@ class SiteSettings
         );
     }
 
-    public function collectionModeCallback()
+    public function collectionModeCallback($args)
     {
         $collection_mode = get_option('collection_mode');
 
+        echo('<fieldset>');
+        printf('<legend class="screen-reader-text"><span>%s</span></legend>', $args['title']);
         printf(
             '<input type="radio" name="collection_mode" id="collection_maintenance" value="maintenance" %s /> <label for="collection_maintenance">%s</label><br />',
             checked('maintenance', $collection_mode, false),
@@ -366,28 +376,43 @@ class SiteSettings
             checked('live', $collection_mode, false),
             __('Turn off', "cds-snc")
         );
+        echo('</fieldset>');
     }
 
-    public function wetMenuCallback()
+    public function wetMenuCallback($args)
     {
         $show_wet_menu = get_option('show_wet_menu');
+        $locations = get_nav_menu_locations();
+        $customHeaderMenuExists = array_key_exists('header', $locations) && is_int($locations['header']);
 
+        echo('<fieldset>');
+        printf('<legend class="screen-reader-text"><span>%s</span></legend>', $args['title']);
         printf(
-            '<input type="radio" name="show_wet_menu" id="show_wet_menu_on" value="on" %s /> <label for="show_wet_menu_on">%s</label><br />',
-            checked("on", $show_wet_menu, false),
+            '<input type="radio" name="show_wet_menu" id="show_wet_menu_canada" value="canada" %s /> <label for="show_wet_menu_canada">%s</label><br />',
+            checked("canada", $show_wet_menu, false),
             __('Show Canada.ca menu', "cds-snc")
         );
+
         printf(
-            '<input type="radio" name="show_wet_menu" id="show_wet_menu_off" value="off" %s /> <label for="show_wet_menu_off">%s</label><br />',
-            checked("off", $show_wet_menu, false),
-            __('Hide Canada.ca menu', "cds-snc")
+            '<input type="radio" name="show_wet_menu" id="show_wet_menu_custom" value="custom" %s %s /> <label for="show_wet_menu_custom">%s</label><br />',
+            checked("custom", $show_wet_menu, false),
+            $customHeaderMenuExists ? "" : "disabled", // if no menu, disabled
+            __('Show custom menu', "cds-snc")
         );
+        printf(
+            '<input type="radio" name="show_wet_menu" id="show_wet_menu_none" value="none" %s /> <label for="show_wet_menu_none">%s</label><br />',
+            checked("none", $show_wet_menu, false),
+            __('Hide top menu', "cds-snc")
+        );
+        echo('</fieldset>');
     }
 
-    public function showSearchCallback()
+    public function showSearchCallback($args)
     {
         $show_search = get_option('show_search');
 
+        echo('<fieldset>');
+        printf('<legend class="screen-reader-text"><span>%s</span></legend>', $args['title']);
         printf(
             '<input type="radio" name="show_search" id="show_search_on" value="on" %s /> <label for="show_search_on">%s</label><br />',
             checked('on', $show_search, false),
@@ -398,12 +423,15 @@ class SiteSettings
             checked('off', $show_search, false),
             __('Hide the search bar', "cds-snc")
         );
+        echo('</fieldset>');
     }
 
-    public function breadcrumbsCallback()
+    public function breadcrumbsCallback($args)
     {
         $show_breadcrumbs = get_option('show_breadcrumbs');
 
+        echo('<fieldset>');
+        printf('<legend class="screen-reader-text"><span>%s</span></legend>', $args['title']);
         printf(
             '<input type="radio" name="show_breadcrumbs" id="show_breadcrumbs_on" value="on" %s /> <label for="show_breadcrumbs_on">%s</label><br />',
             checked("on", $show_breadcrumbs, false),
@@ -414,6 +442,7 @@ class SiteSettings
             checked("off", $show_breadcrumbs, false),
             __('Hide breadcrumbs', "cds-snc")
         );
+        echo('</fieldset>');
     }
 
     public function fipHrefCallback()
@@ -493,6 +522,7 @@ class SiteSettings
 
     public function maintenanceDescriptionCallback()
     {
+        echo '<p>';
         echo __(
             'In maintenance mode, pages and articles you publish will <strong>not</strong> be publicly visible.',
             'cds-snc'
@@ -502,5 +532,6 @@ class SiteSettings
             'Logged-in users will be able to create and view content, but all other visitors will be redirected to the maintenance page.',
             'cds-snc'
         );
+        echo '</p>';
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Site/SiteSettings.php
@@ -401,7 +401,7 @@ class SiteSettings
             checked("custom", $show_wet_menu, false),
             $customHeaderMenu ? "" : "disabled", // if no menu, disabled input
             __('Show custom menu', "cds-snc"),
-            ': “' . $customHeaderMenu . '”' // if menu, echo its name into the label
+            $customHeaderMenu ? ': “' . $customHeaderMenu . '”' : '' // if menu, echo its name into the label
         );
 
         if (!$customHeaderMenu) {

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -124,8 +124,13 @@ declare(strict_types=1);
   </div>
 
   <?php
+    // option is set in "cds-base" plugin
+    $showWetMenu = get_option('show_wet_menu');
+    // show header menu if option is not set at all or if "custom"
+    $ifShowWetMenu = (empty($showWetMenu) || $showWetMenu === 'custom') ? true : false;
+
     $headerMenu = get_top_nav();
-    if ($headerMenu && !cds_is_maintenance_mode()) :
+    if ($ifShowWetMenu && $headerMenu && !cds_is_maintenance_mode()) :
         echo $headerMenu;
     else :
         ?>


### PR DESCRIPTION
# Summary | Résumé

This PR attempts to clean up the screwy 3-way boolean logic that was happening with the menus.

In the site settings, there are now 3 settings for the top menu: 

1. Show Canada.ca menu
2. Show custom menu
3. No top menu

Each one does what it says, although option 2 is disabled until a custom menu has been created and is assigned to the header position. 

Resolves: https://github.com/cds-snc/gc-articles-issues/issues/481

It's probably worth getting @willeybryan's take on this before merging.

## Notes

What was happening previously was that we had a boolean option (show/hide canada.ca menu) but we actually had 3 possible states: show canada.ca menu, show custom menu, hide both menus. I wrote some logic that would try to infer intent: either show the canada.ca menu or the custom menu based on the last thing they touched, and setting "no menu"  would dequeue the custom menu behind the scenes. You can read all about it in this PR: https://github.com/cds-snc/gc-articles/pull/638

New behaviour is that anyone who never interacts with this settings page can toggle between the default Canada.ca menu and a custom menu as before, but you can also be explicit by selecting one of the 3 options in Site Settings. Should make things clearer, and nothing gets dequeued unexpectedly now.


## Screenshots

I also added `<fieldset>`s to the lists of radios and now they have way more space. 

| before | after (no custom menu assigned) | after (custom menu assigned) |
|--------|---------------------------------|------------------------------|
|   Current settings page. Radios are closer together and there is only 2 options for top menu.     |        More space between radios. "Set custom menu" is disabled and there is a link to the menu page.         |     More space between radios. "Set custom menu" is enabled and the name of the custom menu is displayed       |
|   <img width="1463" alt="Screen Shot 2022-08-22 at 18 42 43" src="https://user-images.githubusercontent.com/2454380/186032606-8ef0f062-b03f-4588-870f-c52e8a67d946.png">    |             <img width="1463" alt="Screen Shot 2022-08-22 at 18 42 47" src="https://user-images.githubusercontent.com/2454380/186032608-f083873d-fd4a-490d-bed1-bd3212243f06.png">               |  <img width="1463" alt="Screen Shot 2022-08-22 at 18 44 27" src="https://user-images.githubusercontent.com/2454380/186032609-24a55bde-57fa-4cc0-be83-f0ad516c3a3d.png">     |

