### PR TITLE
Patch for the missing HTTP_REFERER issue

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Checklists/Setup.php
@@ -27,6 +27,22 @@ class Setup
         add_action('publishpress_checklists_modules_loaded', [$this, 'addChecklistRole']);
         // called when plugin is deactivated
         add_action('deactivate_publishpress-checklists/publishpress-checklists.php', [$this, 'removeChecklistRole']);
+
+        // Keep until issue is solved: https://github.com/publishpress/PublishPress-Checklists/issues/411
+        add_action('admin_init', [$this, 'defaultHttpReferer'], 5);
+    }
+
+    public function defaultHttpReferer()
+    {
+        $publishPressSlug = 'ppch-checklists';
+
+        if (!isset($_GET['page']) || $_GET['page'] !== $publishPressSlug) {
+            return;
+        }
+
+        if (!isset($_SERVER['HTTP_REFERER'])) {
+            $_SERVER['HTTP_REFERER'] = get_admin_url() . 'admin.php?page=' . urlencode($publishPressSlug);
+        }
     }
 
     public function addActions()


### PR DESCRIPTION
# Summary | Résumé

Adding a patch that I think will resolve this checklists bug we're seeing in staging and prod: https://github.com/cds-snc/gc-articles-issues/issues/490

The idea is that if we are on the publishpress page that we prefill the `$_SERVER['HTTP_REFERER']` key with the current page URL. It's hard to test locally but I think it will do the trick.

also opened up an issue here: https://github.com/publishpress/PublishPress-Checklists/issues/411

