### PR TITLE
Use default Notify configuration in CDS base

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifyClient.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifyClient.php
@@ -17,7 +17,7 @@ class NotifyClient
     private function setupClient(): ?\Alphagov\Notifications\Client
     {
         try {
-            $NOTIFY_API_KEY = get_option('NOTIFY_API_KEY') ?: getenv('DEFAULT_NOTIFY_API_KEY');
+            $NOTIFY_API_KEY = getenv('DEFAULT_NOTIFY_API_KEY');
 
             if (!$NOTIFY_API_KEY) {
                 return null;

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/NotifySettings.php
@@ -100,6 +100,7 @@ If you did not subscribe, please ignore this message.";
 
     public function notifyApiSettingsCreateAdminPage()
     {
+        /* These settings are only used by GC-Lists */
         $this->NOTIFY_API_KEY = get_option('NOTIFY_API_KEY') ?: '';
         $this->NOTIFY_GENERIC_TEMPLATE_ID = get_option('NOTIFY_GENERIC_TEMPLATE_ID') ?: '';
         $this->NOTIFY_SUBSCRIBE_TEMPLATE_ID = get_option('NOTIFY_SUBSCRIBE_TEMPLATE_ID') ?: '';

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/Setup.php
@@ -26,6 +26,6 @@ class Setup
      */
     protected function isNotifyConfigured(): bool
     {
-        return (bool)get_option('NOTIFY_API_KEY') || (bool)getenv('DEFAULT_NOTIFY_API_KEY');
+        return (bool)getenv('DEFAULT_NOTIFY_API_KEY');
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/includes/wp-mail-notify-api.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Notify/includes/wp-mail-notify-api.php
@@ -5,7 +5,7 @@ use CDS\Modules\Notify\NotifyClient;
 if (!function_exists('wp_mail')) {
     function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
     {
-        $templateId = get_option('NOTIFY_GENERIC_TEMPLATE_ID') ?: '40454604-8702-4eeb-9b38-1ed3104fb960';
+        $templateId = '40454604-8702-4eeb-9b38-1ed3104fb960';
         $notifyClient = new NotifyClient();
 
         try {


### PR DESCRIPTION
Our default Notify configuration uses our CDS Articles Notify service, with a generic template for inviting users, password resets, and form submissions.

If you set a new API key in GC lists, or if you set a new 'message template id', our user invite logic actually prefers those values, which was messing up our invites and password resets.

Essentially, if you use any different Notify API key, the template ID won't work, and if you use a different template ID, the values it's expecting are different.

So we are just hard-coding our current Notify service in for system messages and that should mean that it works out of the box and it's not affected by updates to GC Lists.
