### PR TITLE
fix: add encrypted GitHub token for Composer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>cds-snc/renovate-config"
+    "github>cds-snc/renovate-config",
+    "github>cds-snc/renovate-config-private//config/gc-articles"
   ],
   "dependencyDashboardApproval": true
 }


### PR DESCRIPTION
# Summary
Update the Renovate config to include an encrypted GitHub token that will allow Renovate to clone Composer dependency GitHub repositories without any rate limiting.

Token was encrypted and scoped to only work on cds-snc/gc-articles using the Renovate bot's public key:
https://docs.renovatebot.com/configuration-options/#encrypted

# Related
* #1024 
* #1025 
* cds-snc/renovate-config-private#2
* renovatebot/renovate#16193