### PR TITLE
fix: update config extends to use `local`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>cds-snc/renovate-config",
-    "github>cds-snc/renovate-config-private//config/gc-articles"
+    "local>cds-snc/renovate-config",
+    "local>cds-snc/renovate-config-private//config/gc-articles"
   ],
   "dependencyDashboardApproval": true
 }


### PR DESCRIPTION
# Summary
Update the Renovate `extends` to use `local` to include config.  This should then allow Renovate to load the configuration from internal org repos.

With the current setup, Renovate is failing to load the private config as its token does not have access:
```
DEBUG: Failed to retrieve config/gc-articles.json from repo
{
  "statusCode": 404,
  "url": "https://api.github.com/repos/cds-snc/renovate-config-private/contents/config/gc-articles.json"
}
```

# Related
* #1089 
* [Renovate private config presets](https://docs.renovatebot.com/getting-started/private-packages/#private-config-presets)