### PR TITLE
fix: removing renovate private config reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>cds-snc/renovate-config",
-    "local>cds-snc/renovate-config-private//config/gc-articles"
+    "local>cds-snc/renovate-config"
   ],
   "dependencyDashboardApproval": true
 }


### PR DESCRIPTION
Deleted the reference made from gc-articles to our private renovate config file.