### PR TITLE
fix: update how composer is installed in Docker container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
     rsync \
     git \
     subversion \
-    composer \
     nodejs \
     npm \
     zsh \
@@ -27,6 +26,11 @@ RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
     php8-tokenizer \
     php8-dom \
     php8-xml
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+     php composer-setup.php && \
+     php -r "unlink('composer-setup.php');" && \
+     mv composer.phar /usr/local/bin/composer;    
 
 RUN pecl install pcov  \
     && docker-php-ext-enable pcov

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,9 @@ RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
     php8-dom \
     php8-xml
 
+# Install Composer with this method instead of using `apk add composer` because
+# the version of Composer in the Alpine package repository also installs a secondary version 
+# of PHP that is not compatible with the version of PHP installed in the container.
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
      php composer-setup.php && \
      php -r "unlink('composer-setup.php');" && \


### PR DESCRIPTION
# Summary | Résumé

Closes #1098 

On a fresh install, the command `articles install` was failing.

# Test instructions | Instructions pour tester la modification

- run a fresh install for local development
- use the following to re-create the container with the new changes: `docker-compose build --no-cache`
- the command `articles install` should complete successfully

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
