### PR TITLE
refactor: use user returned from wp_set_current_user

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/ListManager/TestProxy.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/ListManager/TestProxy.php
@@ -33,8 +33,7 @@ test('ListManager Proxy API endpoint is registered', function () {
 test('ListManager proxy applies Authorization header and proxies request', function() {
     // Prepare a user to make the request
     $user_id = $this->factory->user->create();
-    wp_set_current_user( $user_id );
-    $user = wp_get_current_user();
+    $user = wp_set_current_user( $user_id );
 
     // Make sure the user has permissions
     $user->add_cap('list_manager_bulk_send');
@@ -97,8 +96,7 @@ test('ListManager proxy authenticates user permission (pass)', function() {
     }, 10, 3 );
 
     $user_id = $this->factory->user->create();
-    wp_set_current_user( $user_id );
-    $user = wp_get_current_user();
+    $user = wp_set_current_user( $user_id );
 
     $user->add_cap('list_manager_bulk_send');
 

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/TestPermissions.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/TestPermissions.php
@@ -43,9 +43,8 @@ test('CleanupCustomCapsForRoles', function() {
 // the test is failing because the correct capabilities are not being added to the user
 test('addDefaultUserCapsForRole sets up administrator defaults', function() {
     $user_id = $this->factory->user->create();
-    wp_set_current_user( $user_id );
+    $user = wp_set_current_user( $user_id );
 
-    $user = wp_get_current_user();
     $user->add_role('administrator');
 
     $this->assertTrue($user->has_cap('manage_notify'));
@@ -58,9 +57,8 @@ test('addDefaultUserCapsForRole sets up administrator defaults', function() {
 // the test is failing because the correct capabilities are not being added to the user
 test('addDefaultUserCapsForRole sets up gceditor defaults', function() {
     $user_id = $this->factory->user->create();
-    wp_set_current_user( $user_id );
+    $user = wp_set_current_user( $user_id );
 
-    $user = wp_get_current_user();
     $user->add_role('gceditor');
 
     $this->assertFalse($user->has_cap('manage_notify'));

--- a/wordpress/wp-content/plugins/gc-lists/tests/Integration/TestUtils.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/Integration/TestUtils.php
@@ -33,8 +33,7 @@ test('getServices', function() {
 
 test('getUserPermissions', function() {
     $user_id = $this->factory->user->create();
-    wp_set_current_user( $user_id );
-    $current_user = wp_get_current_user();
+    $current_user = wp_set_current_user( $user_id );
 
     $permissions = Utils::getUserPermissions();
 


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

A small refactor, using the `user` object returned from `wp_set_current_user`, rather than setting the user, and then retrieving it via `wp_get_current_user`.

https://developer.wordpress.org/reference/functions/wp_set_current_user/

# Test instructions | Instructions pour tester la modification

Since all the code changed in this PR is found in tests, then to test this PR, just run all the tests found in `~/wordpress/wp-content/plugins/gc-lists`