### PR TITLE
feat: remove Zendesk functionality

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/Setup.php
@@ -119,10 +119,12 @@ class Setup
         }
 
         $messenger = new Messenger();
-        $response = $messenger->createTicket($goal, $fullname, $email, $message);
+        // TODO: Replace this with a call to Freshdesk, or remove it entirely
+        // Remove the createTicket() call to disable Zendesk tickets
+        // $response = $messenger->createTicket($goal, $fullname, $email, $message);
 
         $platform_message = __('Requester:', 'cds-snc') . " " . $email . "\n\n" . $message;
-        $messenger->sendMail('platform-mvp@cds-snc.ca', $platform_message);
+        $response = $messenger->sendMail('platform-mvp@cds-snc.ca', $platform_message);
 
         if (isset($_POST['cc']) && $_POST['cc'] !== "") {
             $messenger->sendMail($email, $message);

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/RequestSite/Setup.php
@@ -98,10 +98,12 @@ class Setup
         $email = $_POST['email'];
 
         $messenger = new Messenger();
-        $response = $messenger->createTicket($goal, $fullname, $email, $message);
+        // TODO: Replace this with a call to Freshdesk, or remove it entirely
+        // Remove the createTicket() call to disable Zendesk tickets
+        // $response = $messenger->createTicket($goal, $fullname, $email, $message);
 
         $platform_message = __('Requester:', 'cds-snc') . " " . $email . "\n\n" . $message;
-        $messenger->sendMail('platform-mvp@cds-snc.ca', $platform_message);
+        $response = $messenger->sendMail('platform-mvp@cds-snc.ca', $platform_message);
 
         $cc = $_POST['cc'] ?? '';
         if ($cc) {


### PR DESCRIPTION
# Summary | Résumé

Removing Zendesk functionality, by commenting out the calls to functions to create tickets.

References to Zendesk are currently left in the code because the plan is to replace Zendesk with Freshdesk in the future.

Closes cds-snc/gc-articles-issues#529 and cds-snc/gc-articles-issues#517

# Test instructions | Instructions pour tester la modification

Filling out the forms for "Request a Site" or "Contact Us" will function properly, without returning a Zendesk related error.