### PR TITLE
test: specify WP_VERSION for CI env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       DB_DATABASE: wordpress_test
       DB_USER: root
       DB_PASSWORD: root
+      WP_VERSION: 6.0.3
     steps:
       - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
+  # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
   WP_VERSION: 6.0.3
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
+  WP_VERSION: 6.0.3
 
 jobs:
   php-tests:
@@ -35,7 +36,6 @@ jobs:
       DB_DATABASE: wordpress_test
       DB_USER: root
       DB_PASSWORD: root
-      WP_VERSION: 6.0.3
     steps:
       - uses: actions/checkout@v2.3.4
 

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -25,6 +25,9 @@ RUN npm --unsafe-perm install
 
 ## Release build
 
+# when updating the Wordpress version, update the version in the files:
+#     - ~/wordpress/docker/local.Dockerfile
+#     - ~/github/workflows/ci.yml
 FROM wordpress:6.0.3-php8.1-fpm-alpine
 
 RUN apk add --no-cache $PHPIZE_DEPS \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,3 +1,4 @@
+# wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
 FROM wordpress:6.0.3-php8.1-fpm-alpine
 
 WORKDIR /usr/src/wordpress


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

The tests, by default, download the `latest` version of Wordpress. This worked fine up until version 6.1 was released.  Adding the specific `WP_VERSION` environment variable fixed this issue.

# Test instructions | Instructions pour tester la modification

Run the CI actions for the PR.  The tests should pass.

