### PR TITLE
refactor: use logical operator

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Users/src/UserForm.tsx
@@ -148,7 +148,7 @@ export const UserForm = ({ isSuperAdmin = false }) => {
                             <td>
                                 {/* The "id" needs to match the field ID attribute */}
                                 <FieldError errors={errors} id={"email"}>
-                                    <input type="text" id="email" aria-describedby={findErrorId(errors, "email") ? `validation-error--email` : null} {...bindEmail} />
+                                    <input type="text" id="email" aria-describedby={findErrorId(errors, "email") && `validation-error--email`} {...bindEmail} />
                                 </FieldError>
                             </td>
                         </tr>
@@ -164,7 +164,7 @@ export const UserForm = ({ isSuperAdmin = false }) => {
                                     <select
                                         disabled={isLoading ? true : false}
                                         name="role" id="role"
-                                        aria-describedby={findErrorId(errors, "role") ? `validation-error--role` : null}
+                                        aria-describedby={findErrorId(errors, "role") && `validation-error--role`}
                                         onChange={(event) => {
                                             const val = event.target.value;
 

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListViewTable.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/ListViewTable.tsx
@@ -143,7 +143,7 @@ export const ListViewTable = () => {
                         <StyledDivider>|</StyledDivider>
                         {user?.isSuperAdmin && <><DeleteLink listId={`${row?.original?.id}`} /> <StyledDivider>|</StyledDivider> </>}
                         {getListType(row?.original?.language) === ListType.EMAIL && <UploadListLink listId={`${row?.original?.id}`} type={ListType.EMAIL} />}
-                        {getListType(row?.original?.language) === ListType.PHONE && user?.hasPhone ? <UploadListLink listId={`${row?.original?.id}`} type={ListType.PHONE} /> : null}
+                        {getListType(row?.original?.language) === ListType.PHONE && user?.hasPhone && <UploadListLink listId={`${row?.original?.id}`} type={ListType.PHONE} />}
                     </>
                 },
             },

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/lists/components/UpdateList.tsx
@@ -74,7 +74,7 @@ export const UpdateList = () => {
             __("This list has no subscribers.", "gc-lists");
     }
 
-    return list ? (
+    return list && (
         <>
             <StyledLink to={`/lists`}>
                 <Back /> <span>{__("Mailing lists", "gc-lists")}</span>
@@ -83,7 +83,6 @@ export const UpdateList = () => {
             {subscriberMessage && <p>{subscriberMessage}</p>}
             <ListForm formData={list} handler={onSubmit} serverErrors={errors} />
         </>)
-         : null
 }
 
 export default UpdateList;

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/EditMessage.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/EditMessage.tsx
@@ -177,7 +177,7 @@ export const EditMessage = () => {
                                 }
                                 <div className={errors.hasTemplate ? "error-wrapper" : ""}>
                                     {errors.hasTemplate && <span className="validation-error">{errors.hasTemplate?.message || __("Message is required", "gc-lists")}</span>}
-                                    {template.parsedContent ?
+                                    {template.parsedContent &&
                                         <>
                                             <Editor template={template.parsedContent}
                                                 handleValidate={(value: any) => {
@@ -190,7 +190,7 @@ export const EditMessage = () => {
                                                 </StyledCharacterCounter>
                                             }
                                         </>
-                                        : null}
+                                        }
                                 </div>
                             </StyledCell>
                         </tr>

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/SendMessage.tsx
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/src/messages/views/SendMessage.tsx
@@ -103,7 +103,7 @@ export const SendMessage = () => {
             <h1>{__("Send message to a list", "gc-lists")}</h1>
 
             <ListSelect onChange={handleListUpdate} messageType={messageType} />
-            {listId ?
+            {listId &&
                 <>
                     <SendToList sending={true} name={listName} count={subscriberCount} />
                     <FieldError errors={errors} id={'send'}>
@@ -134,7 +134,6 @@ export const SendMessage = () => {
                         }}>{__("Cancel")}</button>
                     </FieldError>
                 </>
-                : null
             }
             <CreateNewList />
             {content &&


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

Refactoring some of the code to use a logical conditional instead of ternary conditional. The main benefit to this is that is removes the unnecessary explicit `null` when the conditional does not match.

# Test instructions | Instructions pour tester la modification

Run the application and visit the parts of the site affected by this PR. All functionality should continue as before.
