### PR TITLE
chore: add tag for security-tools

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate ${{ matrix.component }} SBOM
         if: steps.changes.outputs.lock == 'true'
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@419d1118dae6b81a265d9f442b18c940b54712bc
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@4c6b386722985552f3f008d04279a3f01402cc35 # tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: ${{ matrix.component }}


### PR DESCRIPTION
# Summary | Résumé

This PR is to pin the `cds-snc/security-tools` package to the tag `v1`. This will prevent Renovate from trying to update it every time there is any kind of update to the `security-tools` repo.
