### PR TITLE
fix: category language switcher

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -227,7 +227,7 @@ function language_switcher_output($languages)
         foreach ($languages as $language) {
             $text = get_language_text($language['translated_name']);
             if (!$language['active']) {
-                $link = '<a lang="' . $text['abbr'] . '" hreflang="' . $text['abbr'] . '" href="' . check_translated_url($language['url'], $text['abbr']) . '">';
+                $link = '<a lang="' . $text['abbr'] . '" hreflang="' . $text['abbr'] . '" href="' . convert_url($language['url'], $text['abbr']) . '">';
                 $link .= '<span class="hidden-xs">' . $text['full'] . '</span>';
                 $link .= '<abbr title="' . $text['full'] . '" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">';
                 $link .= $text['abbr'];
@@ -244,19 +244,54 @@ function language_switcher_output($languages)
 
     return $langs;
 }
-
-function check_translated_url($url, $lang): string
+/*
+    TODO: Replace this hack function with a proper solution.
+*/
+/*
+    * This function is a total hack to fix a WPML bug.
+    * The `convert_url` function used by WPML does not work properly
+    * when the page is a `category` page. This function is a hack to
+    * fix that issue.
+    *
+    * WARNING: This function assumes only two languages: EN and FR.
+    *
+    * WARNING: `$category_path_name` is hardcoded, and will break if the category path
+    * is changed within the Wordpress dashboard for any of the sites.
+    *
+    * @param string $url - the original, incorrect, `translated_url` provided by the
+    *                      get_ls_languages() function, found within the
+    *                      `wpml_active_languages` apply_filter hook.
+    * @param string $lang - the language code for the target language
+    * @return string - the correct url for the target language
+    *                   the url will have the root path for the target language,
+    *                   and the category slug for the current category, in the
+    *                   current (non-target) language. When Wordpress detects the language
+    *                   in the category slug, it will redirect to the correct category slug
+    *                   in the target language, based on the root path.
+    *
+    *                   eg: On the EN page for a category called "test-en", the incorrect url
+    *                   for the language switcher will be:
+    *                       ~/category/test-en
+    *
+    *                   This function will convert that url to:
+    *                       ~/fr/category/test-en
+    *
+    *                   Wordpress will then redirect to the correct url for the target language:
+    *                       ~/fr/category/test-fr
+*/
+function convert_url($url, $lang): string
 {
-    $link_url = $url;
-    $parsed_url = parse_url($link_url);
-    if (str_contains($parsed_url['path'], "/category/")) {
-        if (str_starts_with($parsed_url['path'], "/category/")) {
-            $link_url = str_replace("/category/", "/$lang/category/", $link_url);
-        } else {
-            $link_url = preg_replace("/(\/[a-z]{1,2})?\/category\//", "/category/", $link_url);
+    $category_path_name = "category";
+    $return_url = $url;
+    $parsed_url = parse_url($return_url);
+    if (str_contains($parsed_url['path'], "/$category_path_name/")) { // only modify the url if it is a category page
+        if (str_starts_with($parsed_url['path'], "/$category_path_name/")) { // currently on the EN path
+            $return_url = str_replace("/$category_path_name/", "/$lang/$category_path_name/", $return_url);
+        } else { // otherwise it must be on the FR path
+            $return_url = str_replace("/fr/", "/", $return_url);
         }
     }
-    return $link_url;
+    return $return_url;
 }
 
 function manual_language_switcher(): string
@@ -299,6 +334,7 @@ function language_switcher(): string
 
     if (function_exists('icl_get_languages')) {
         $languages = apply_filters('wpml_active_languages', null, 'orderby=id&order=desc');
+
         if ($languages && 1 < count($languages)) {
             $langs = language_switcher_output($languages);
             return join(', ', $langs);

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -270,6 +270,7 @@ function manual_language_switcher(): string
     }
 
     $custom_language_switcher = get_post_meta($wp_query->post->ID, 'locale_switch_link', true);
+    error_log("language_switcher:" . $custom_language_switcher);
 
     // format: {"active":false,"translated_name":"English","url":"/"}
     if ($custom_language_switcher) {

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -334,7 +334,6 @@ function language_switcher(): string
 
     if (function_exists('icl_get_languages')) {
         $languages = apply_filters('wpml_active_languages', null, 'orderby=id&order=desc');
-
         if ($languages && 1 < count($languages)) {
             $langs = language_switcher_output($languages);
             return join(', ', $langs);

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -245,12 +245,12 @@ function language_switcher_output($languages)
     return $langs;
 }
 /*
-    TODO: Replace this hack function with a proper solution.
+    TODO: Replace this workaround function with a proper solution.
 */
 /*
-    * This function is a total hack to fix a WPML bug.
+    * This function is a workaround to fix a WPML bug.
     * The `convert_url` function used by WPML does not work properly
-    * when the page is a `category` page. This function is a hack to
+    * when the page is a `category` page. This function is a workaround to
     * fix that issue.
     *
     * WARNING: This function assumes only two languages: EN and FR.

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -297,9 +297,7 @@ function language_switcher(): string
     }
 
     if (function_exists('icl_get_languages')) {
-        $languages = apply_filters('wpml_active_languages', null);
-        error_log("LANGUAGES: ......");
-        error_log(var_export($languages, true));
+        $languages = apply_filters('wpml_active_languages', null, 'orderby=id&order=desc');
         if ($languages && 1 < count($languages)) {
             $langs = language_switcher_output($languages);
             return join(', ', $langs);

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -285,11 +285,12 @@ function convert_url($url, $lang): string
     $return_url = $url;
     $parsed_url = parse_url($return_url);
     if (str_contains($parsed_url['path'], "/$category_path_name/")) { // only modify the url if it is a category page
-        if (str_starts_with($parsed_url['path'], "/$category_path_name/")) { // currently on the EN path
-            $return_url = str_replace("/$category_path_name/", "/$lang/$category_path_name/", $return_url);
-        } else { // otherwise it must be on the FR path
-            $return_url = str_replace("/fr/", "/", $return_url);
+        if (str_starts_with($parsed_url['path'], "/$category_path_name/")) {
+            // currently on the EN path
+            return str_replace("/$category_path_name/", "/$lang/$category_path_name/", $return_url);
         }
+        // otherwise it must be on the FR path
+        return str_replace("/fr/", "/", $return_url);
     }
     return $return_url;
 }

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -227,7 +227,7 @@ function language_switcher_output($languages)
         foreach ($languages as $language) {
             $text = get_language_text($language['translated_name']);
             if (!$language['active']) {
-                $link = '<a lang="' . $text['abbr'] . '" hreflang="' . $text['abbr'] . '" href="' . $language['url'] . '">';
+                $link = '<a lang="' . $text['abbr'] . '" hreflang="' . $text['abbr'] . '" href="' . check_translated_url($language['url'], $text['abbr']) . '">';
                 $link .= '<span class="hidden-xs">' . $text['full'] . '</span>';
                 $link .= '<abbr title="' . $text['full'] . '" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">';
                 $link .= $text['abbr'];
@@ -245,6 +245,20 @@ function language_switcher_output($languages)
     return $langs;
 }
 
+function check_translated_url($url, $lang): string
+{
+    $link_url = $url;
+    $parsed_url = parse_url($link_url);
+    if (str_contains($parsed_url['path'], "/category/")) {
+        if (str_starts_with($parsed_url['path'], "/category/")) {
+            $link_url = str_replace("/category/", "/$lang/category/", $link_url);
+        } else {
+            $link_url = preg_replace("/(\/[a-z]{1,2})?\/category\//", "/category/", $link_url);
+        }
+    }
+    return $link_url;
+}
+
 function manual_language_switcher(): string
 {
     global $wp_query;
@@ -256,7 +270,6 @@ function manual_language_switcher(): string
     }
 
     $custom_language_switcher = get_post_meta($wp_query->post->ID, 'locale_switch_link', true);
-    error_log("language_switcher:" . $custom_language_switcher);
 
     // format: {"active":false,"translated_name":"English","url":"/"}
     if ($custom_language_switcher) {
@@ -284,7 +297,9 @@ function language_switcher(): string
     }
 
     if (function_exists('icl_get_languages')) {
-        $languages = apply_filters('wpml_active_languages', null, 'orderby=id&order=desc');
+        $languages = apply_filters('wpml_active_languages', null);
+        error_log("LANGUAGES: ......");
+        error_log(var_export($languages, true));
         if ($languages && 1 < count($languages)) {
             $langs = language_switcher_output($languages);
             return join(', ', $langs);

--- a/wordpress/wp-content/themes/cds-default/tests/LanguageSwitcherTest.php
+++ b/wordpress/wp-content/themes/cds-default/tests/LanguageSwitcherTest.php
@@ -136,9 +136,19 @@ class LanguageSwitcherTest extends \WP_Mock\Tools\TestCase
 
     public function test_convert_url_hack()
     {
-        expect([
-            ["http://test.com/category/test", "fr", "http://test.com/fr/category/test"],
-            ["http://test.com/fr/category/test", "en", "http://test.com/category/test"]
-            ])->each(fn ($args) => convert_url($args[0], $args[1])->toEqual($args[2]));
+        $url = "http://test.com/fr/category/french-slug";
+        $target_lang = "en";
+        $converted_url = convert_url($url, $target_lang);
+        expect($converted_url)->toEqual("http://test.com/category/french-slug");
+
+        $url = "http://test.com/category/english-slug";
+        $target_lang = "fr";
+        $converted_url = convert_url($url, $target_lang);
+        expect($converted_url)->toEqual("http://test.com/fr/category/english-slug");
+        
+        $url = "http://test.com/non-category-page";
+        $target_lang = "fr";
+        $converted_url = convert_url($url, $target_lang);
+        expect($converted_url)->toEqual("http://test.com/non-category-page");        
     }
 }

--- a/wordpress/wp-content/themes/cds-default/tests/LanguageSwitcherTest.php
+++ b/wordpress/wp-content/themes/cds-default/tests/LanguageSwitcherTest.php
@@ -133,4 +133,12 @@ class LanguageSwitcherTest extends \WP_Mock\Tools\TestCase
             $this->containsString($nav, 'English')
         )->toBeTrue();
     }
+
+    public function test_convert_url_hack()
+    {
+        expect([
+            ["http://test.com/category/test", "fr", "http://test.com/fr/category/test"],
+            ["http://test.com/fr/category/test", "en", "http://test.com/category/test"]
+            ])->each(fn ($args) => convert_url($args[0], $args[1])->toEqual($args[2]));
+    }
 }


### PR DESCRIPTION
# Summary | Résumé

Closes: cds-snc/gc-articles-issues#525

This PR is a hack, definitely. There is a bug in WPML that incorrectly returns the URL that is supposed to be for the translated page. It returns the `translated_url` for the same language, instead of the url for the translated content.

# Test instructions | Instructions pour tester la modification

- go to a "category" page (_uncategorized_, for example.
- click the language switcher link at the top-right side of the page
- it should switch languages for that category page
- the language switcher should continue to work as before on all other pages