### PR TITLE
chore: Update WP to 6.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.0.3
+  WP_VERSION: 6.1.1
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.0.3-php8.1-fpm-alpine@sha256:b325e13d26dfed641743b3733ef0bb65be9162f4338b0d690bbb10e95ed88291
+FROM wordpress:6.1.1-php8.1-fpm-alpine@sha256:50d6cd2b892b28ac33ed3de47aae062d7d45fa1233d8ce32c41338e772e0d017
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.0.3-php8.1-fpm-alpine@sha256:b325e13d26dfed641743b3733ef0bb65be9162f4338b0d690bbb10e95ed88291
+FROM wordpress:6.1.1-php8.1-fpm-alpine@sha256:50d6cd2b892b28ac33ed3de47aae062d7d45fa1233d8ce32c41338e772e0d017
 
 WORKDIR /usr/src/wordpress
 

--- a/wordpress/wp-content/plugins/gc-lists/tests/TestCase.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/TestCase.php
@@ -20,11 +20,13 @@ class TestCase extends \WP_UnitTestCase
          * Because bootstrap.php loads the plugin in mu-plugins, activation hooks don't fire
          * and database tables don't get created, so we must manually trigger the install.
          */
+
+        parent::set_up();
         $installer = Install::getInstance();
 
         $installer->install();
         $this->factory->message = new MessageFactory( $this->factory );
-        parent::set_up();
+        
     }
 
     public function tear_down()

--- a/wordpress/wp-content/plugins/gc-lists/tests/TestCase.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/TestCase.php
@@ -23,8 +23,10 @@ class TestCase extends \WP_UnitTestCase
         $installer = Install::getInstance();
 
         $installer->install();
+        
+        $this->factory()->message = new MessageFactory( $this->factory() );
+        
         parent::set_up();
-        $this->factory->message = new MessageFactory( $this->factory );
     }
 
     public function tear_down()

--- a/wordpress/wp-content/plugins/gc-lists/tests/TestCase.php
+++ b/wordpress/wp-content/plugins/gc-lists/tests/TestCase.php
@@ -20,13 +20,11 @@ class TestCase extends \WP_UnitTestCase
          * Because bootstrap.php loads the plugin in mu-plugins, activation hooks don't fire
          * and database tables don't get created, so we must manually trigger the install.
          */
-
-        parent::set_up();
         $installer = Install::getInstance();
 
         $installer->install();
+        parent::set_up();
         $this->factory->message = new MessageFactory( $this->factory );
-        
     }
 
     public function tear_down()


### PR DESCRIPTION
# Summary | Résumé

Closes cds-snc/gc-articles-issues#533

Updates WordPress to 6.1.1.

Also fixes the `gc-lists` test cases, as the prop for `factory` was deprecated, and replaced by the `factory()` method. This wasn't a part of the 6.1.1 update, but just something that broke within our implementation.

Details about the deprecated `factory` prop can be found here: https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/abstract-testcase.php

# Test instructions | Instructions pour tester la modification

- ensure that all tests continue to pass
- this is a minor update to WordPress, so general testing in the staging environment will be needed to check that all functionality still continues as expected.