### PR TITLE
release v3.8.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.2.14
 staging:
   apache: 1.0.21
-  wordpress: 3.7.6
+  wordpress: 3.8.0


### PR DESCRIPTION
# Summary | Résumé

Wordpress update to 6.1.1
Workaround for language switcher on Category pages.

# Test instructions | Instructions pour tester la modification

This will trigger the new updates to be deployed on Staging. Functionality should be tested on Staging prior to deploying to Production.