### PR TITLE
fix: update dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,12 +20,14 @@ RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
     zsh \
     zsh-autosuggestions \
     zsh-syntax-highlighting \
-    gettext \
-    php8-xmlwriter \
-    php8-simplexml \
-    php8-tokenizer \
-    php8-dom \
-    php8-xml
+    gettext && \
+    # Install from testing/edge repository
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+        php8-xmlwriter \
+        php8-simplexml \
+        php8-tokenizer \
+        php8-dom \
+        php8-xml
 
 # Install Composer with this method instead of using `apk add composer` because
 # the version of Composer in the Alpine package repository also installs a secondary version 

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /usr/src/wordpress
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 
-RUN apk add --no-cache $PHPIZE_DEPS \
+RUN apk add --update linux-headers \
+    && apk add --no-cache $PHPIZE_DEPS \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug
 


### PR DESCRIPTION
# Summary | Résumé

With updates to the base images (`wordpress:6.1.1-php8.1-fpm-alpine` and `wordpress:cli-php8.1`), some packages were removed or moved.

When building the project, the following errors came up, which are fixed by this PR:

> #0 12.74 configure: error: rtnetlink.h is required, install the linux-headers package: apk add --update linux-headers

and

> #0 9.930 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
> #0 10.38 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
> #0 11.08 ERROR: unable to select packages:
> #0 11.12   php8-dom (no such package):
> #0 11.12     required by: world[php8-dom]
> #0 11.12   php8-simplexml (no such package):
> #0 11.12     required by: world[php8-simplexml]
> #0 11.12   php8-tokenizer (no such package):
> #0 11.12     required by: world[php8-tokenizer]
> #0 11.12   php8-xml (no such package):
> #0 11.12     required by: world[php8-xml]
> #0 11.12   php8-xmlwriter (no such package):
> #0 11.12     required by: world[php8-xmlwriter]
> ------
> failed to solve: executor failed running [/bin/sh -c apk add --update --virtual mod-deps autoconf alpine-sdk     libmcrypt-dev &&     apk add sudo --no-cache     nano     openssh     rsync     git     subversion     nodejs     npm     zsh     zsh-autosuggestions     zsh-syntax-highlighting     gettext     php8-xmlwriter     php8-simplexml     php8-tokenizer     php8-dom     php8-xml]: exit code: 5

 

# Test instructions | Instructions pour tester la modification

Build the `gc-articles` dockercontainers from scratch; there should be no errors.