### PR TITLE
feat: remove options from Contact Us form

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Forms/Contact/ContactForm.php
@@ -131,12 +131,6 @@ class ContactForm
                     <?php
                         Utils::radioField(
                             'goal',
-                            'Request a demo to learn more about GC Articles.',
-                            __('Request a demo to learn more about GC Articles.', 'cds-snc'),
-                            val: $all_values['goal']
-                        );
-                        Utils::radioField(
-                            'goal',
                             'Ask a question.',
                             __('Ask a question.', 'cds-snc'),
                             val: $all_values['goal']
@@ -151,12 +145,6 @@ class ContactForm
                             'goal',
                             'Give feedback.',
                             __('Give feedback.', 'cds-snc'),
-                            val: $all_values['goal']
-                        );
-                        Utils::radioField(
-                            'goal',
-                            'Other',
-                            __('Other', 'cds-snc'),
                             val: $all_values['goal']
                         );
                     ?>

--- a/wordpress/wp-content/plugins/cds-base/languages/cds-snc-fr_CA.po
+++ b/wordpress/wp-content/plugins/cds-base/languages/cds-snc-fr_CA.po
@@ -239,10 +239,6 @@ msgstr "Objectif de votre message"
 msgid "Your answer helps us make sure your message gets to the right people."
 msgstr "Votre réponse nous aide à transmettre votre message au bon endroit"
 
-#: classes/Modules/Forms/Contact/ContactForm.php:135
-msgid "Request a demo to learn more about GC Articles."
-msgstr "Demander une démonstration pour en savoir plus sur Articles GC."
-
 #: classes/Modules/Forms/Contact/ContactForm.php:141
 msgid "Ask a question."
 msgstr "Posez-nous une question."

--- a/wordpress/wp-content/plugins/cds-base/languages/cds-snc.pot
+++ b/wordpress/wp-content/plugins/cds-base/languages/cds-snc.pot
@@ -241,10 +241,6 @@ msgstr ""
 msgid "Your answer helps us make sure your message gets to the right people."
 msgstr ""
 
-#: classes/Modules/Forms/Contact/ContactForm.php:135
-msgid "Request a demo to learn more about GC Articles."
-msgstr ""
-
 #: classes/Modules/Forms/Contact/ContactForm.php:141
 msgid "Ask a question."
 msgstr ""


### PR DESCRIPTION
# Summary | Résumé

fixes cds-snc/gc-articles-issues#548

# Test instructions | Instructions pour tester la modification

- Load the Contact Us form, observe that the 2 radio options have been removed
- Submit the Contact Us form to see that it still works