### PR TITLE
fix: remove ECR registry from tag lookup command

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get latest Docker image tag
         run: |
-          IMAGE_TAG="$(aws ecr describe-images --output json --repository-name ${{ env.ECR_REGISTRY }}/${{ matrix.image }} --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' | jq . --raw-output)"
+          IMAGE_TAG="$(aws ecr describe-images --output json --repository-name ${{ matrix.image }} --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' | jq . --raw-output)"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Docker vulnerability scan Wordpress


### PR DESCRIPTION
# Summary
Remove the ECR registry from the AWS CLI command used to look up the latest Docker image tag.

This will fix the Docker vulnerability scan workflow.

# Related
- #1154 
- cds-snc/platform-core-services#204