### PR TITLE
fix: add filter for core-image

### DIFF
--- a/wordpress/wp-content/themes/cds-website-preview/filter-core-image.php
+++ b/wordpress/wp-content/themes/cds-website-preview/filter-core-image.php
@@ -1,0 +1,23 @@
+<?php
+
+use Wa72\HtmlPageDom\HtmlPage;
+
+function cds_filter_core_image($block_content, $block)
+{
+    if ('core/image' === $block['blockName']) {
+        try {
+            $block_html = @new HtmlPage($block_content);
+            $img_html = $block_html->filter('figure img');
+            // add the following styles to prevent the image from being improperly sized
+            $img_html->css('max-width', '100%');
+            $img_html->css('height', 'auto');
+            return $block_html;
+        } catch (Exception $e) {
+            //no-op
+        }
+    }
+
+    return $block_content;
+}
+
+add_filter('render_block', 'cds_filter_core_image', 10, 3);

--- a/wordpress/wp-content/themes/cds-website-preview/functions.php
+++ b/wordpress/wp-content/themes/cds-website-preview/functions.php
@@ -12,4 +12,5 @@ function get_fonts_uri()
 
 add_theme_support('post-thumbnails');
 
+require_once __DIR__ . '/filter-core-image.php';
 require_once(__DIR__ . '/settings.php');


### PR DESCRIPTION
# Summary | Résumé

Fixes cds-snc/gc-articles-issues#552

# Test instructions | Instructions pour tester la modification

> Create an article
> Add an image using the block editor
> Set the size of the image to "Full"
> Load the page and resize the browser window
> Observe that the image maintains the correct aspect ratio