### PR TITLE
Return the properly filtered result

### DIFF
--- a/wordpress/wp-content/themes/cds-website-preview/filter-core-image.php
+++ b/wordpress/wp-content/themes/cds-website-preview/filter-core-image.php
@@ -11,7 +11,7 @@ function cds_filter_core_image($block_content, $block)
             // add the following styles to prevent the image from being improperly sized
             $img_html->css('max-width', '100%');
             $img_html->css('height', 'auto');
-            return $block_html;
+            return $img_html;
         } catch (Exception $e) {
             //no-op
         }


### PR DESCRIPTION
# Summary | Résumé

Small bugfix introduced with the image filters, was returning the full HTML instead of the filtered result
