### PR TITLE
chore: disable ALB 5xx alarms

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_alb.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_alb.tf
@@ -22,27 +22,6 @@ resource "aws_cloudwatch_metric_alarm" "alb_target_4xx_response" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "alb_target_5xx_response" {
-  alarm_name          = "ALBTargetGroup5xxResponse"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "HTTPCode_Target_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "300"
-  statistic           = "Sum"
-  threshold           = var.alb_target_5xx_maximum
-  treat_missing_data  = "notBreaching"
-
-  alarm_description = "Sum of 5xx response from the ALB target group in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.alert_warning.arn]
-  ok_actions        = [aws_sns_topic.alert_warning.arn]
-
-  dimensions = {
-    "TargetGroup"  = var.alb_target_group_arn_suffix
-    "LoadBalancer" = var.alb_arn_suffix
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "alb_target_response_time_average" {
   alarm_name          = "ALBTargetGroupResponseTimeAverage"
   comparison_operator = "GreaterThanThreshold"

--- a/infrastructure/terragrunt/aws/alarms/inputs.tf
+++ b/infrastructure/terragrunt/aws/alarms/inputs.tf
@@ -18,11 +18,6 @@ variable "alb_target_response_time_average_maximum" {
   type        = number
 }
 
-variable "alb_target_5xx_maximum" {
-  description = "Maximum number of 5xx responses from the ALB target group in a 5 minute period"
-  type        = number
-}
-
 variable "alb_target_4xx_maximum" {
   description = "Maximum number of 4xx responses from the ALB target group in a 5 minute period"
   type        = number

--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -61,7 +61,6 @@ inputs = {
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
-  alb_target_5xx_maximum                   = 5
   alb_target_4xx_maximum                   = 100
 
   canary_healthcheck_url_eng = "https://articles.alpha.canada.ca/sign-in-se-connecter/"

--- a/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -61,7 +61,6 @@ inputs = {
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
-  alb_target_5xx_maximum                   = 5
   alb_target_4xx_maximum                   = 100
 
   canary_healthcheck_url_eng = "https://articles.cdssandbox.xyz/sign-in-se-connecter/"


### PR DESCRIPTION
# Summary
Removing this alarm as it's duplicating the `Error` and `Warn` metric filters for the WordPress ECS task.