### PR TITLE
chore: bump to MySQL 5.7 Aurora 2.10.3

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -7,7 +7,7 @@ module "rds_cluster" {
 
   database_name  = var.database_name
   engine         = "aurora-mysql"
-  engine_version = "5.7.mysql_aurora.2.10.0"
+  engine_version = "5.7.mysql_aurora.2.10.3"
   instances      = var.database_instances_count
   instance_class = var.database_instance_class
   username       = var.database_username


### PR DESCRIPTION
# Summary
Patch version bump to the MySQL database cluster TF version.  This is being done so that the Prod release doesn't downgrade the cluster which applied a patch version automatically.

# Related
- #1171 