### PR TITLE
fix: WP 6.1.x global stylesheet hotfix plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       wp plugin activate jwt-authentication-for-wp-rest-api --network;
       wp plugin activate delete-orphaned-multisite-tables --network;
       wp plugin activate gc-lists --network;
+      wp plugin activate wp-hotfix-56970 --network;
       '
     volumes:
       - wordpress:/usr/src/wordpress

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -63,6 +63,19 @@
       }
     },
     {
+      "type": "package",
+      "package": {
+        "name": "ironprogrammer/wp-hotfix-56970",
+        "type": "wordpress-plugin",
+        "version": "0.2",
+        "source": {
+          "url": "https://github.com/ironprogrammer/wp-hotfix-56970",
+          "type": "git",
+          "reference": "v0.2"
+        }
+      }
+    },    
+    {
       "type": "composer",
       "url": "https://my.yoast.com/packages/"
     },
@@ -97,6 +110,7 @@
     "wpackagist-plugin/jwt-authentication-for-wp-rest-api": "^1.2",
     "yoast/duplicate-post": "^4.4",
     "shawnhooper/delete-orphaned-multisite-tables": "1.0",
+    "ironprogrammer/wp-hotfix-56970": "0.2",
     "league/html-to-markdown": "^5.1",
     "wpackagist-plugin/publishpress-checklists": "^2.7",
     "wpackagist-plugin/simple-history": "^3.2",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33115b3672958edfdb5eb287a2774a1d",
+    "content-hash": "b4471665712e4ca8a3f061a6a31ad710",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -1571,6 +1571,16 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2022-09-21T21:30:03+00:00"
+        },
+        {
+            "name": "ironprogrammer/wp-hotfix-56970",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ironprogrammer/wp-hotfix-56970",
+                "reference": "v0.2"
+            },
+            "type": "wordpress-plugin"
         },
         {
             "name": "league/html-to-markdown",


### PR DESCRIPTION
# Summary
Add the WP 6.1.x [ironprogrammer/wp-hotfix-56970](https://github.com/ironprogrammer/wp-hotfix-56970).  This moves the global stylesheet from transient to WP_Object_Cache, and resolves an inline CSS issue related to Gallery blocks when upgrading to WordPress 6.1.1.

The fix for this is planned for WP 6.2.

# Related
- cds-snc/gc-articles-issues#557
- WordPress/gutenberg#45713