### PR TITLE
feat: additional SHA for forms marketing page

### DIFF
--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -72,6 +72,7 @@ function cds_security_headers($headers)
             "'sha256-Ll9Pj6gzPpETya7YXsYglTFBzjPg0sc23VG6sms7FKE='",
             "'sha256-9vpql/NLyCCe3HPEb2b/lcLKPbkRi48w2Lfn0AbTxsQ='",
             "'sha256-+zAcjG07bIcQUdOJ4VdpR6NeUqSj+ijz0iNFSRtHtFU='",
+            "'sha256-w/MihaBU9WFQdzQiyd/HoTEHWRaWJyFmDE63TBablMI='",
             "https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js",


### PR DESCRIPTION
This PR adds the SCP SHA for the inline JS on the forms marketing page.

Error is seen here: https://articles.alpha.canada.ca/forms-formulaires/