### PR TITLE
fix: set EFS security group ID to blank

### DIFF
--- a/infrastructure/terragrunt/aws/network/outputs.tf
+++ b/infrastructure/terragrunt/aws/network/outputs.tf
@@ -11,7 +11,7 @@ output "ecs_service_security_group_id" {
 }
 
 output "efs_security_group_id" {
-  value = var.enable_efs ? aws_security_group.wordpress_efs[0].id : null
+  value = var.enable_efs ? aws_security_group.wordpress_efs[0].id : ""
 }
 
 output "private_subnet_ids" {

--- a/infrastructure/terragrunt/aws/network/outputs.tf
+++ b/infrastructure/terragrunt/aws/network/outputs.tf
@@ -11,7 +11,7 @@ output "ecs_service_security_group_id" {
 }
 
 output "efs_security_group_id" {
-  value = var.enable_efs ? aws_security_group.wordpress_efs[0].id : ""
+  value = var.enable_efs ? aws_security_group.wordpress_efs[0].id : "empty"
 }
 
 output "private_subnet_ids" {


### PR DESCRIPTION
# Summary 
Update how the EFS security group ID is set from the `network` module.  This is because a `null` value removes the output and causes an error with the `efs` module.
