### PR TITLE
chore: update WPML Wordpress plugins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,12 @@
+FROM node:16-alpine AS node
+
 FROM wordpress:cli-php8.1@sha256:4c249d19e7d9d404e5b2897bb9eb8b7ce1d910d62026638fd878d03c7a038539
+
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/share /usr/local/share
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
 
 WORKDIR /usr/src/wordpress
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platform-mvp",
-  "version": "3.7.6",
+  "version": "3.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-mvp",
-      "version": "3.7.6",
+      "version": "3.9.1",
       "hasInstallScript": true,
       "devDependencies": {
         "@cypress/snapshot": "^2.1.7",

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -8,7 +8,7 @@
       "type": "package",
       "package": {
         "name": "wpml/sitepress-multilingual-cms",
-        "version": "4.5.14",
+        "version": "4.6.3",
         "type": "wordpress-plugin",
         "dist": {
           "type": "zip",
@@ -23,7 +23,7 @@
       "type": "package",
       "package": {
         "name": "wpml/wpml-string-translation",
-        "version": "3.2.3",
+        "version": "3.2.5",
         "type": "wordpress-plugin",
         "dist": {
           "type": "zip",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "deb21113c9dd6e052585abce6612bdeb",
+    "content-hash": "8071251547f25c32b0878bcb6939718a",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -4133,7 +4133,7 @@
         },
         {
             "name": "wpml/sitepress-multilingual-cms",
-            "version": "4.5.14",
+            "version": "4.6.3",
             "dist": {
                 "type": "zip",
                 "url": "https://wpml.org/?download=6088&user_id={%WPML_USER_ID}&subscription_key={%WPML_KEY}&version={%VERSION}"
@@ -4157,7 +4157,7 @@
         },
         {
             "name": "wpml/wpml-string-translation",
-            "version": "3.2.3",
+            "version": "3.2.5",
             "dist": {
                 "type": "zip",
                 "url": "https://wpml.org/?download=6092&user_id={%WPML_USER_ID}&subscription_key={%WPML_KEY}&version={%VERSION}"

--- a/wordpress/wp-content/plugins/cds-base/package-lock.json
+++ b/wordpress/wp-content/plugins/cds-base/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cds-base",
-  "version": "3.7.6",
+  "version": "3.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cds-base",
-      "version": "3.7.6",
+      "version": "3.9.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {


### PR DESCRIPTION
# Summary
Update the WPML plugins to their latest versions.

Pin to Node v16 in the devcontainer.

# Related
- cds-snc/platform-core-services#311