### PR TITLE
fix: site creation and NYN content SHA

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Installer.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Wpml/Installer.php
@@ -17,7 +17,6 @@ use WPML\Setup\Endpoint\LicenseStep;
 use WPML\Setup\Endpoint\SetOriginalLanguage;
 use WPML\Setup\Endpoint\SetSecondaryLanguages;
 use WPML\Setup\Endpoint\SetSupport;
-use WPML\TM\ATE\Sitekey\Endpoint;
 use WPML\TranslationMode\Endpoint\SetTranslateEverything;
 
 class Installer
@@ -81,10 +80,6 @@ class Installer
             [
                 "endpoint" => FinishStep::class,
                 "data" => ["finished" => true]
-            ],
-            [
-                "endpoint" => Endpoint::class,
-                "data" => []
             ],
             [
                 "endpoint" => PrepareSetup::class,

--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -73,6 +73,7 @@ function cds_security_headers($headers)
             "'sha256-9vpql/NLyCCe3HPEb2b/lcLKPbkRi48w2Lfn0AbTxsQ='",
             "'sha256-+zAcjG07bIcQUdOJ4VdpR6NeUqSj+ijz0iNFSRtHtFU='",
             "'sha256-w/MihaBU9WFQdzQiyd/HoTEHWRaWJyFmDE63TBablMI='",
+            "'sha256-mlQdACKZOv0Ge2eMnCyUrDeDg6euHtWjTJoE256s0hM='",
             "https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js",


### PR DESCRIPTION
# Summary
1. Fix the new site creation.  The WPML installer Endpoint step now requires instantiated classes to run.
2. Fix the [NYN](https://articles.alpha.canada.ca/fyn-rjff/) Content Security Policy violation by adding the content SHA.
