### PR TITLE
fix: Docker SBOM generate step

### DIFF
--- a/.github/workflows/build_push_apache_container.yml
+++ b/.github/workflows/build_push_apache_container.yml
@@ -91,10 +91,6 @@ jobs:
         run: |
           docker push ${{ env.PRODUCTION_ECR_REGISTRY }}/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
 
-      - name: Logout of ECR
-        if: always()
-        run: docker logout ${{ steps.login-ecr.outputs.registry }}
-
       - name: Docker generate SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
         with:
@@ -102,3 +98,7 @@ jobs:
           dockerfile_path: "wordpress/docker/apache/Dockerfile"
           sbom_name: "apache"
           token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Logout of ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build_push_container.yml
+++ b/.github/workflows/build_push_container.yml
@@ -63,10 +63,6 @@ jobs:
         run: |
           docker push ${{ env.STAGING_ECR_REGISTRY }}/${{ env.REPO_NAME }}:${{ env.IMAGE_TAG }}
 
-      - name: Logout of ECR
-        if: always()
-        run: docker logout ${{ steps.login-ecr.outputs.registry }}
-
       - name: Docker generate SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
         with:
@@ -74,3 +70,7 @@ jobs:
           dockerfile_path: "wordpress/docker/Dockerfile"
           sbom_name: "wordpress"
           token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Logout of ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
# Summary
Update the Docker SBOM step to run before the ECR
logout, as an active ECR session is now required.