### PR TITLE
chore: upgrade to Wordpress 6.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.2.1
+  WP_VERSION: 6.2.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.2.1-php8.1-fpm-alpine@sha256:90aad210a3ffcc29a13dd44509427ac1b4f12a21efff7542e60208e5235e31d4
+FROM wordpress:6.2.2-php8.1-fpm-alpine@sha256:2103213d427293516a3e4998bdce766416be2d5b1410daaee30f7856ffa98e54
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.2.1-php8.1-fpm-alpine@sha256:90aad210a3ffcc29a13dd44509427ac1b4f12a21efff7542e60208e5235e31d4
+FROM wordpress:6.2.2-php8.1-fpm-alpine@sha256:2103213d427293516a3e4998bdce766416be2d5b1410daaee30f7856ffa98e54
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to Wordpress 6.2.2 release:
https://wordpress.org/news/2023/05/wordpress-6-2-2-security-release/

# Related