### PR TITLE
fix: update CSP to allow connections to canada.ca

### DIFF
--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -21,6 +21,7 @@ function cds_security_headers($headers)
         ],
         "connect-src" => [
             "'self'",
+            "https://www.canada.ca",
             "https://www.google-analytics.com",
         ],
         "default-src" => [


### PR DESCRIPTION
# Summary
Update the CSP to allow for the download of the Canada.ca default menu content.

# Related
- https://github.com/cds-snc/platform-core-services/issues/395