### PR TITLE
chore: reduce CloudFront log duration to 30 days

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/s3.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/s3.tf
@@ -19,7 +19,12 @@ resource "aws_s3_bucket" "cloudfront_logs" {
     enabled = true
 
     expiration {
-      days = 90
+      days                         = 30
+      expired_object_delete_marker = true
+    }
+
+    noncurrent_version_expiration {
+      days = 30
     }
   }
 


### PR DESCRIPTION
# Summary
Update the S3 lifecycle rules for the CloudFront access logs to only keep the last 30 days of log data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/401