### PR TITLE
fix: add null checking and prevent direct access

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -284,7 +284,7 @@ function convert_url($url, $lang): string
     $category_path_name = "category";
     $return_url = $url;
     $parsed_url = parse_url($return_url);
-    if (str_contains($parsed_url['path'], "/$category_path_name/")) { // only modify the url if it is a category page
+    if (!is_null($parsed_url['path']) && str_contains($parsed_url['path'], "/$category_path_name/")) { // only modify the url if it is a category page
         if (str_starts_with($parsed_url['path'], "/$category_path_name/")) {
             // currently on the EN path
             return str_replace("/$category_path_name/", "/$lang/$category_path_name/", $return_url);

--- a/wordpress/wp-content/themes/cds-default/index.php
+++ b/wordpress/wp-content/themes/cds-default/index.php
@@ -15,6 +15,10 @@
 
 declare(strict_types=1);
 
+if (!defined('ABSPATH')) {
+    exit; // Prevent direct access to WP theme files
+}
+
 get_header();
 ?>
 


### PR DESCRIPTION
# Summary
Update the CDS Default theme to add `null` checking and prevent direct access to the theme's `index.php` file.

More thorough direct PHP access blocks will be added in a subsequent PR.

# Related
- https://github.com/cds-snc/platform-core-services/issues/400
- https://github.com/cds-snc/platform-core-services/issues/403
- https://github.com/cds-snc/platform-core-services/issues/404