### PR TITLE
feat: add Sentinel forwarder for WordPress logs

### DIFF
--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -34,6 +34,8 @@ env:
   TF_VAR_s3_uploads_secret: ${{ secrets.PRODUCTION_S3_UPLOADS_SECRET }}
   TF_VAR_c3_aws_access_key_id: ${{ secrets.PRODUCTION_C3_AWS_ACCESS_KEY_ID }}
   TF_VAR_c3_aws_secret_access_key: ${{ secrets.PRODUCTION_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_URL }}
   TF_VAR_wordpress_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_AUTH_KEY }}
   TF_VAR_wordpress_secure_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_SECURE_AUTH_KEY }}

--- a/.github/workflows/deploy-staging-container.yml
+++ b/.github/workflows/deploy-staging-container.yml
@@ -33,6 +33,8 @@ env:
   TF_VAR_s3_uploads_secret: ${{ secrets.STAGING_S3_UPLOADS_SECRET }}
   TF_VAR_c3_aws_access_key_id: ${{ secrets.STAGING_C3_AWS_ACCESS_KEY_ID }}
   TF_VAR_c3_aws_secret_access_key: ${{ secrets.STAGING_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.STAGING_SLACK_WEBHOOK_URL }}
   TF_VAR_wordpress_auth_key: ${{ secrets.STAGING_WORDPRESS_AUTH_KEY }}
   TF_VAR_wordpress_secure_auth_key: ${{ secrets.STAGING_WORDPRESS_SECURE_AUTH_KEY }}

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -29,6 +29,8 @@ env:
   TF_VAR_s3_uploads_secret: ${{ secrets.PRODUCTION_S3_UPLOADS_SECRET }}
   TF_VAR_c3_aws_access_key_id: ${{ secrets.PRODUCTION_C3_AWS_ACCESS_KEY_ID }}
   TF_VAR_c3_aws_secret_access_key: ${{ secrets.PRODUCTION_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_URL }}
   TF_VAR_wordpress_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_AUTH_KEY }}
   TF_VAR_wordpress_secure_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_SECURE_AUTH_KEY }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -32,6 +32,8 @@ env:
   TF_VAR_s3_uploads_secret: ${{ secrets.STAGING_S3_UPLOADS_SECRET }}
   TF_VAR_c3_aws_access_key_id: ${{ secrets.STAGING_C3_AWS_ACCESS_KEY_ID }}
   TF_VAR_c3_aws_secret_access_key: ${{ secrets.STAGING_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.STAGING_SLACK_WEBHOOK_URL }}
   TF_VAR_wordpress_auth_key: ${{ secrets.STAGING_WORDPRESS_AUTH_KEY }}
   TF_VAR_wordpress_secure_auth_key: ${{ secrets.STAGING_WORDPRESS_SECURE_AUTH_KEY }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -29,6 +29,8 @@ env:
   TF_VAR_s3_uploads_secret: ${{ secrets.PRODUCTION_S3_UPLOADS_SECRET }}
   TF_VAR_c3_aws_access_key_id: ${{ secrets.PRODUCTION_C3_AWS_ACCESS_KEY_ID }}
   TF_VAR_c3_aws_secret_access_key: ${{ secrets.PRODUCTION_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.PRODUCTION_SLACK_WEBHOOK_URL }}
   TF_VAR_wordpress_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_AUTH_KEY }}
   TF_VAR_wordpress_secure_auth_key: ${{ secrets.PRODUCTION_WORDPRESS_SECURE_AUTH_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -30,6 +30,8 @@ env:
   TF_VAR_s3_uploads_secret: ${{ secrets.STAGING_S3_UPLOADS_SECRET }}
   TF_VAR_c3_aws_access_key_id: ${{ secrets.STAGING_C3_AWS_ACCESS_KEY_ID }}
   TF_VAR_c3_aws_secret_access_key: ${{ secrets.STAGING_C3_AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.STAGING_SLACK_WEBHOOK_URL }}
   TF_VAR_wordpress_auth_key: ${{ secrets.STAGING_WORDPRESS_AUTH_KEY }}
   TF_VAR_wordpress_secure_auth_key: ${{ secrets.STAGING_WORDPRESS_SECURE_AUTH_KEY }}

--- a/infrastructure/terragrunt/aws/ecs/cloudwatch_logs.tf
+++ b/infrastructure/terragrunt/aws/ecs/cloudwatch_logs.tf
@@ -7,3 +7,16 @@ resource "aws_cloudwatch_log_group" "ecs_events" {
   name              = "/aws/lambda/${aws_lambda_function.ecs_events.function_name}"
   retention_in_days = 14
 }
+
+module "sentinel_forwarder" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v6.1.0//sentinel_forwarder"
+  function_name     = "sentinel-forwarder"
+  billing_tag_value = var.billing_tag_value
+
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:71"
+
+  customer_id = var.sentinel_customer_id
+  shared_key  = var.sentinel_shared_key
+
+  cloudwatch_log_arns = [aws_cloudwatch_log_group.wordpress_ecs_logs.arn]
+}

--- a/infrastructure/terragrunt/aws/ecs/inputs.tf
+++ b/infrastructure/terragrunt/aws/ecs/inputs.tf
@@ -209,3 +209,13 @@ variable "wordpress_logged_in_salt" {
 variable "wordpress_nonce_salt" {
   type = string
 }
+
+variable "sentinel_customer_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "sentinel_shared_key" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
# Summary
Add the Sentinel forwarder TF module to send WordPress ECS logs to Sentinel.

# Related
- https://github.com/cds-snc/platform-core-services/issues/398