### PR TITLE
fix: add Sentinel subscription filter pattern

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/cloudwatch_logs.tf
+++ b/infrastructure/terragrunt/aws/ecs/cloudwatch_logs.tf
@@ -20,3 +20,11 @@ module "sentinel_forwarder" {
 
   cloudwatch_log_arns = [aws_cloudwatch_log_group.wordpress_ecs_logs.arn]
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "sentinel_forwarder" {
+  name            = "All ECS logs"
+  log_group_name  = aws_cloudwatch_log_group.wordpress_ecs_logs.name
+  filter_pattern  = "[w1=\"*\"]"
+  destination_arn = module.sentinel_forwarder.lambda_arn
+  distribution    = "Random"
+}


### PR DESCRIPTION
# Summary
Add the CloudWatch log group subscription filter that will cause all WordPress ECS logs to be forwarded
to Sentinel.

# Related
- https://github.com/cds-snc/platform-core-services/issues/398
