### PR TITLE
fix: increase number of PHP-FPM children

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - ./wordpress/docker/php/conf.d/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
       - ./wordpress/docker/php/conf.d/max_execution_time.ini:/usr/local/etc/php/conf.d/max_execution_time.ini
       - ./wordpress/docker/php/conf.d/expose_php.ini:/usr/local/etc/php/conf.d/expose_php.ini
+      - ./wordpress/docker/php/conf.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
     networks:
       - app-network
 

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -44,6 +44,9 @@ COPY ./wordpress/docker/php/conf.d/memory_limit.ini /usr/local/etc/php/conf.d/me
 COPY ./wordpress/docker/php/conf.d/uploads.ini /usr/local/etc/php/conf.d/uploads.ini
 COPY ./wordpress/docker/php/conf.d/expose_php.ini /usr/local/etc/php/conf.d/expose_php.ini
 
+# Copy PHP-FPM config
+COPY ./wordpress/docker/php/conf.d/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
+
 # Copy wp-content (including installed plugins) and vendor folder from composer stage
 COPY --from=composer /app/wordpress/wp-content ./wp-content
 COPY --from=composer /app/wordpress/vendor ./vendor

--- a/wordpress/docker/php/conf.d/zz-docker.conf
+++ b/wordpress/docker/php/conf.d/zz-docker.conf
@@ -1,0 +1,13 @@
+[global]
+daemonize = no
+
+[www]
+listen = 9000
+
+;Update PHP-FPM settings
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 6
+pm.max_requests = 500


### PR DESCRIPTION
# Summary
Update the PHP-FPM config to increase the max number of processes available to handle requests.  We are occasionally seeing the `max_children` available exhausted, which leads to unhealthy load balancer hosts.

Also introduces a setting to remove child processes from the pool after they have served 500 requests to help clear up any potential memory leaks.

These settings should still keep us within our 1vCPU and 3GB memory resource limits per ECS task.

# Related
- https://github.com/cds-snc/platform-core-services/issues/415