### PR TITLE
feat: update error/warning metric patterns

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_ecs.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_ecs.tf
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "wordpress_failed_login" {
 
 resource "aws_cloudwatch_log_metric_filter" "wordpress_errors" {
   name           = "WordPressErrors"
-  pattern        = "[(w1=\"*Failed*\" || w1=\"*failed*\" || w1=\"*Error*\" || w1=\"*error*\" || w1=\"*Fatal*\" || w1=\"*fatal*\" ) && w1!=\"*slug=error*\"]"
+  pattern        = local.wordpress_error_metric_pattern
   log_group_name = var.wordpress_log_group_name
 
   metric_transformation {
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_metric_alarm" "wordpress_errors" {
 
 resource "aws_cloudwatch_log_metric_filter" "wordpress_warnings" {
   name           = "WordPressWarnings"
-  pattern        = "[(w1=\"*Warning*\" || w1=\"*warning*\") && w1!=\"*Undefined array key*c3-cloudfront-clear-cache*\"]"
+  pattern        = local.wordpress_warning_metric_pattern
   log_group_name = var.wordpress_log_group_name
 
   metric_transformation {

--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -1,0 +1,26 @@
+locals {
+  # WordPress ECS task metric filters.  These are used to create CloudWatch alarms based on the number of
+  # errors/warnings in the logs, as identified by the tokens.  Any log message that has a token in the `_skip` list
+  # will not be counted as an error/warning.
+  wordpress_errors = [
+    "Failed",
+    "failed",
+    "Error",
+    "error",
+    "Fatal",
+    "fatal",
+  ]
+  wordpress_errors_skip = [
+    "slug=error",
+    "AH01630",
+  ]
+  wordpress_warnings = [
+    "Warning",
+    "warning",
+  ]
+  wordpress_warnings_skip = [
+    "Undefined array key*c3-cloudfront-clear-cache",
+  ]
+  wordpress_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_errors_skip)}*\"]"
+  wordpress_warning_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_warnings)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_warnings_skip)}*\"]"
+}


### PR DESCRIPTION
# Summary
Update how the WordPress ECS task error/warning metric filter patterns are managed.  This will make it easier to manage the list of tokens and exclusions going forward.

# Related
- https://github.com/cds-snc/platform-core-services/issues/406