### PR TITLE
chore: more error tokens to ignore

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -11,8 +11,10 @@ locals {
     "fatal",
   ]
   wordpress_errors_skip = [
-    "slug=error",
+    "AH01276",
     "AH01630",
+    "error=invalidkey",
+    "slug=error",
   ]
   wordpress_warnings = [
     "Warning",


### PR DESCRIPTION
# Summary
Update the WordPress CloudWatch `error` metric filters with more tokens that should be ignored.  These correspond to:

- People attempting to generate directory listings.
- People resetting their password.

# Related
- https://github.com/cds-snc/platform-core-services/issues/400