### PR TITLE
chore: suppress CloudWatch error false-positives

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -13,8 +13,7 @@ locals {
   wordpress_errors_skip = [
     "AH01276",
     "AH01630",
-    "error=invalidkey",
-    "slug=error",
+    "GET /notification-gc-notify/wp-json/wp/v2/pages",
   ]
   wordpress_warnings = [
     "Warning",


### PR DESCRIPTION
# Summary
Update the CloudWatch error metric filter to ignore `GET` requests to the Notify wp-json endpoint.

This is because these will often contain error tokens as part of the `GET` request parametres during fuzzing attacks.

# Related
- https://github.com/cds-snc/platform-core-services/issues/400