### PR TITLE
fix: add password reset false-positive suppress

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -13,6 +13,7 @@ locals {
   wordpress_errors_skip = [
     "AH01276",
     "AH01630",
+    "action=lostpassword&error=invalidkey",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
   ]
   wordpress_warnings = [


### PR DESCRIPTION
# Summary
Update the CloudWatch `error` metric filter so that it does not trigger for password reset requests.

# Related
- https://github.com/cds-snc/platform-core-services/issues/425