### PR TITLE
Fix download button css

### DIFF
--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -569,3 +569,18 @@ body .is-layout-flow > * {
   margin-block-start: 0.5em;
   margin-block-end: 0.5em;
 }
+
+/* Fix for file upload button styles */
+.wp-block-file__button {
+  background-color: #284162;
+  color: #fff !important;
+  border-radius: 0.3em;
+  display: block;
+  text-align: center;
+}
+
+.wp-block-file__button:hover {
+  color: #fff !important;
+  background-color: #1c578a;
+  text-decoration: none;
+}


### PR DESCRIPTION
# Summary | Résumé

The default styles for file downloads are "broken"

<img width="298" alt="Screenshot 2023-07-21 at 10 26 22 AM" src="https://github.com/cds-snc/gc-articles/assets/62242/834134ac-ee7c-42ec-baeb-00f81ae83065">

This update fixes the hover state
<img width="433" alt="Screenshot 2023-07-21 at 10 27 07 AM" src="https://github.com/cds-snc/gc-articles/assets/62242/57585408-ee6f-4f6e-ac18-b1f4cf368805">

As a workaround before this PR the forms team is adding an html block.

https://articles.alpha.canada.ca/forms-formulaires/templates/

```css
<!-- Override the WP button styles for file upload -->

<style>
.wp-block-file__button{
background-color:#284162;
color:#fff !important;
border-radius: 0.3em;
display: block;
text-align: center;
}

.wp-block-file__button:hover{
color:#fff !important;
background-color: #1c578a;
text-decoration:none;
}

</style>
```

