### PR TITLE
fix: ignore WordPress password GET requests

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -13,7 +13,7 @@ locals {
   wordpress_errors_skip = [
     "AH01276",
     "AH01630",
-    "action=lostpassword&error=invalidkey",
+    "action=lostpassword&error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
   ]
   wordpress_warnings = [


### PR DESCRIPTION
# Summary
Update the CloudWatch `error` metric filter to ignore all password reset requests that include the word `error`.