### PR TITLE
fix: use SRE bot slack notifications

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/sns_topic.tf
+++ b/infrastructure/terragrunt/aws/alarms/sns_topic.tf
@@ -46,16 +46,16 @@ resource "aws_sns_topic" "alert_observe_us_east" {
 #
 resource "aws_sns_topic_subscription" "alert_warning" {
   topic_arn = aws_sns_topic.alert_warning.arn
-  protocol  = "lambda"
-  endpoint  = module.notify_slack.lambda_arn
+  protocol  = "https"
+  endpoint  = var.slack_webhook_url
 }
 
 resource "aws_sns_topic_subscription" "alert_warning_us_east" {
   provider = aws.us-east-1
 
   topic_arn = aws_sns_topic.alert_warning_us_east.arn
-  protocol  = "lambda"
-  endpoint  = module.notify_slack.lambda_arn
+  protocol  = "https"
+  endpoint  = var.slack_webhook_url
 }
 
 #
@@ -110,23 +110,4 @@ data "aws_iam_policy_document" "sns_cloudwatch" {
       identifiers = ["cloudwatch.amazonaws.com"]
     }
   }
-}
-
-#
-# Lambda: post notifications to Slack
-#
-module "notify_slack" {
-  source = "github.com/cds-snc/terraform-modules//notify_slack?ref=v6.1.1"
-
-  function_name     = "notify_slack"
-  project_name      = "Articles: ${var.env}"
-  slack_webhook_url = var.slack_webhook_url
-
-  sns_topic_arns = [
-    aws_sns_topic.alert_warning.arn,
-    aws_sns_topic.alert_warning_us_east.arn
-  ]
-
-  billing_tag_key   = var.billing_tag_key
-  billing_tag_value = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Update do use the SRE bot slack notification rather than the TF module.