### PR TITLE
chore: ignore CloudWatch errors from 404 requests

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -15,6 +15,7 @@ locals {
     "AH01630",
     "action=lostpassword&error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
+    "HTTP/1.1\" 404",
   ]
   wordpress_warnings = [
     "Warning",


### PR DESCRIPTION
# Summary
Update the CloudWatch `error` metric filter so that it doesn't count HTTP requests that have a status of 404.

This is being done to stop fuzzing attacks from triggering an error alarm.