### PR TITLE
fix: default language code if null

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           cd wordpress/wp-content/plugins/gc-lists
           ./vendor/bin/pest --coverage
+
   cds-wpml-mods-php-tests:
     runs-on: ubuntu-latest
     name: CDS Wpml Mods Plugin PHPUnit Tests

--- a/wordpress/wp-content/plugins/cds-wpml-mods/src/Post.php
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/src/Post.php
@@ -48,7 +48,8 @@ class Post
     public function getLanguageCodeOfPostObject(WP_Post $post): string
     {
         global $sitepress;
-        return $sitepress->get_language_for_element($post->ID, 'post_' . $post->post_type);
+        $language_code = $sitepress->get_language_for_element($post->ID, 'post_' . $post->post_type);
+        return is_null($language_code) ? 'en' : $language_code;
     }
 
     public function getTranslatedPostID(WP_Post $post, ?string $altLanguage = null): int|null

--- a/wordpress/wp-content/plugins/cds-wpml-mods/tests/Integration/TestPost.php
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/tests/Integration/TestPost.php
@@ -80,7 +80,22 @@ test('buildResponseObject assert response object with no language provided', fun
 test('getLanguageCodeOfPostObject', function() {
 	global $sitepress;
 	$sitepress = mock('\SitePress');
-	$sitepress->shouldReceive("get_language_for_element")->andReturn('en');
+	$sitepress->shouldReceive("get_language_for_element")->andReturn('fr');
+
+	$post_id = $this->factory()->post->create();
+	$post = get_post($post_id);
+
+	$postClass = new Post();
+
+	$language = $postClass->getLanguageCodeOfPostObject($post);
+
+	expect($language)->toEqual('fr');
+});
+
+test('getLanguageCodeOfPostObjectDefault', function() {
+	global $sitepress;
+	$sitepress = mock('\SitePress');
+	$sitepress->shouldReceive("get_language_for_element")->andReturn(null);
 
 	$post_id = $this->factory()->post->create();
 	$post = get_post($post_id);


### PR DESCRIPTION
# Summary
Update the `cds-wpml-mods` plugin to return a default language code if the post's language cannot be determined.