### PR TITLE
chore: ignore `error` alarms for `AH01797`

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -13,6 +13,7 @@ locals {
   wordpress_errors_skip = [
     "AH01276",
     "AH01630",
+    "AH01797",
     "action=lostpassword&error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
     "HTTP/1.1\\\" 404",


### PR DESCRIPTION
# Summary
Update the CloudWatch `error` metric alarm to ignore logs of:

```
AH01797: client denied by server configuration
```

These are fuzzing attacks being blocked by the Apache configuration.