### PR TITLE
fix: protect against null `$post` object

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/latestPosts/LatestPosts.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/latestPosts/LatestPosts.php
@@ -40,6 +40,10 @@ class LatestPosts
     {
         global $post;
 
+        // Protect against a null $post object
+        if (is_null($post)) {
+            return $more;
+        }
         return sprintf(
             '… <a class="read-more" href="%s">%s<span class="wb-sl"> of %s</span></a>',
             get_permalink($post->ID),


### PR DESCRIPTION
# Summary
Update the excerpt function to check if the `$post` object is null before attempting to create a "read more" link.

# Related
- https://github.com/cds-snc/platform-core-services/issues/433