### PR TITLE
fix: gc-lists plugin dev dependencies

### DIFF
--- a/wordpress/wp-content/plugins/gc-lists/resources/js/package-lock.json
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/package-lock.json
@@ -40,6 +40,7 @@
             },
             "devDependencies": {
                 "@automattic/i18n-loader-webpack-plugin": "^2.0.12",
+                "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
                 "@types/react-table": "^7.7.11",
                 "@types/styled-components": "^5.1.25",
                 "@types/uuid": "^9.0.2",
@@ -903,9 +904,16 @@
             }
         },
         "node_modules/@babel/plugin-proposal-private-property-in-object": {
-            "version": "7.21.0-placeholder-for-preset-env.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-            "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+            "version": "7.21.11",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+            "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.18.6",
+                "@babel/helper-create-class-features-plugin": "^7.21.0",
+                "@babel/helper-plugin-utils": "^7.20.2",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+            },
             "engines": {
                 "node": ">=6.9.0"
             },
@@ -2141,6 +2149,17 @@
                 "core-js-compat": "^3.31.0",
                 "semver": "^6.3.1"
             },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+            "version": "7.21.0-placeholder-for-preset-env.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+            "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
             "engines": {
                 "node": ">=6.9.0"
             },

--- a/wordpress/wp-content/plugins/gc-lists/resources/js/package.json
+++ b/wordpress/wp-content/plugins/gc-lists/resources/js/package.json
@@ -70,6 +70,7 @@
     },
     "devDependencies": {
         "@automattic/i18n-loader-webpack-plugin": "^2.0.12",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@types/react-table": "^7.7.11",
         "@types/styled-components": "^5.1.25",
         "@types/uuid": "^9.0.2",


### PR DESCRIPTION
# Summary
Add the `@babel/plugin-proposal-private-property-in-object` dependency which was being implicitly provided by another dependency.