### PR TITLE
chore: remove ALB 4xx alarm

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_alb.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_alb.tf
@@ -1,27 +1,6 @@
 #
 # ALB: target group health and response times
 # 
-resource "aws_cloudwatch_metric_alarm" "alb_target_4xx_response" {
-  alarm_name          = "ALBTargetGroup4xxResponse"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "HTTPCode_Target_4XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "300"
-  statistic           = "Sum"
-  threshold           = var.alb_target_4xx_maximum
-  treat_missing_data  = "notBreaching"
-
-  alarm_description = "Sum of 4xx response from the ALB target group in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.alert_warning.arn]
-  ok_actions        = [aws_sns_topic.alert_warning.arn]
-
-  dimensions = {
-    "TargetGroup"  = var.alb_target_group_arn_suffix
-    "LoadBalancer" = var.alb_arn_suffix
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "alb_target_response_time_average" {
   alarm_name          = "ALBTargetGroupResponseTimeAverage"
   comparison_operator = "GreaterThanThreshold"

--- a/infrastructure/terragrunt/aws/alarms/inputs.tf
+++ b/infrastructure/terragrunt/aws/alarms/inputs.tf
@@ -18,11 +18,6 @@ variable "alb_target_response_time_average_maximum" {
   type        = number
 }
 
-variable "alb_target_4xx_maximum" {
-  description = "Maximum number of 4xx responses from the ALB target group in a 5 minute period"
-  type        = number
-}
-
 variable "healthcheck_domain" {
   description = "Domain name for the Route53 healthcheck."
   type        = string

--- a/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/alarms/terragrunt.hcl
@@ -61,7 +61,6 @@ inputs = {
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
-  alb_target_4xx_maximum                   = 100
 
   healthcheck_domain = "articles.alpha.canada.ca"
   healthcheck_path   = "/sign-in-se-connecter/"

--- a/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -61,7 +61,6 @@ inputs = {
 
   alb_target_group_arn_suffix              = dependency.load-balancer.outputs.alb_target_group_arn_suffix
   alb_target_response_time_average_maximum = 2
-  alb_target_4xx_maximum                   = 100
 
   healthcheck_domain = "articles.cdssandbox.xyz"
   healthcheck_path   = "/sign-in-se-connecter/"


### PR DESCRIPTION
# Summary
Remove the load balancer's 4xx HTTP status code CloudWatch alarm.

This is being done because the alarm is being triggered by fuzzing attacks against the site and provides no actionable value.

# Related
- https://github.com/cds-snc/platform-core-services/issues/439