### PR TITLE
chore: upgrade to WordPress 6.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.3.0
+  WP_VERSION: 6.3.1
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.3.0-php8.1-fpm-alpine@sha256:f703f6525b214e8f69b03bffa786011b294be56b57a115ecefe1585a4db96e7c
+FROM wordpress:6.3.1-php8.1-fpm-alpine@sha256:d889814813c8722a204017565dcc6068b24da870acf41dbb42c2501a84a16e14
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.3.0-php8.1-fpm-alpine@sha256:f703f6525b214e8f69b03bffa786011b294be56b57a115ecefe1585a4db96e7c
+FROM wordpress:6.3.1-php8.1-fpm-alpine@sha256:d889814813c8722a204017565dcc6068b24da870acf41dbb42c2501a84a16e14
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade WordPress Core to the 6.3.1 maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/443