### PR TITLE
feat: log non-Government of Canada logins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # WP Config
 ADMIN_USER=admin
 ADMIN_PASSWORD=secret
-ADMIN_EMAIL=admin@example.com
+ADMIN_EMAIL=admin@canada.ca
 
 ENCRYPTION_KEY="base64:rest_of_the_key"
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -89,6 +89,10 @@ class TrackLogins
 
     public function logUserLogin($user_login, $user): void
     {
+        // Detect email addresses that do not end with @cds-snc.ca, gc.ca or canada.ca
+        if (!preg_match('/(@cds-snc|@canada|\.gc)\.ca$/', $user->user_email)) {
+            error_log("SUSPICIOUS: non-GC email login: {$user->user_email}");
+        }
         $this->insertUserLogin($user, $user_agent = $this->getUserAgent());
     }
 

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/tests/TrackLoginsTest.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/tests/TrackLoginsTest.php
@@ -38,6 +38,7 @@ test('TrackLogins logUserLogins', function () {
     $user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36';
     $this->user = (object)[
         'ID' => 1,
+        'user_email' => 'admin@canada.ca',
     ];
     $current_time = '2021-09-16 20:46:06';
     $data = [


### PR DESCRIPTION
# Summary
Update the `cds-base` plugin so that when a user with a non-GC email address successfully authenticates, a log is written.

This will allow us to alarm on unexpected email address logins.

# Related
- https://github.com/cds-snc/platform-core-services/issues/439