### PR TITLE
feat: add alarm for suspicious logins

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_ecs.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_ecs.tf
@@ -130,6 +130,35 @@ resource "aws_cloudwatch_metric_alarm" "wordpress_warnings" {
   ok_actions        = [aws_sns_topic.alert_warning.arn]
 }
 
+resource "aws_cloudwatch_log_metric_filter" "wordpress_suspicious_login" {
+  name           = "WordPressSuspiciousLogin"
+  pattern        = "\"non-GC email login\""
+  log_group_name = var.wordpress_log_group_name
+
+  metric_transformation {
+    name          = "WordPressSuspiciousLogin"
+    namespace     = "WordPress"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "wordpress_suspicious_login" {
+  alarm_name          = "WordPressSuspiciousLogin"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.wordpress_suspicious_login.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.wordpress_suspicious_login.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "WordPress login from a non-Government of Canada email address"
+  alarm_actions     = [aws_sns_topic.alert_warning.arn]
+  ok_actions        = [aws_sns_topic.alert_warning.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "wordpress_ecs_warn_error_event" {
   name           = "WordPressEcsWarningEvent"
   pattern        = "?Warn ?Error"

--- a/infrastructure/terragrunt/aws/alarms/queries.tf
+++ b/infrastructure/terragrunt/aws/alarms/queries.tf
@@ -42,3 +42,18 @@ resource "aws_cloudwatch_query_definition" "wordpress_failed_logins" {
     | limit 100
   QUERY
 }
+
+resource "aws_cloudwatch_query_definition" "wordpress_suspicious_activity" {
+  name = "Wordpress - suspicious activity"
+
+  log_group_names = [
+    var.wordpress_log_group_name
+  ]
+
+  query_string = <<-QUERY
+    fields @timestamp, @message, @logStream
+    | filter @message like /SUSPICIOUS/
+    | sort @timestamp desc
+    | limit 100
+  QUERY
+}


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm when a non-Government of Canada email address logs into the WordPress admin dashboard.

# Related
- https://github.com/cds-snc/platform-core-services/issues/439