### PR TITLE
fix: use existing isValidDomain method

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TrackLogins/TrackLogins.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use UAParser\Parser;
 use WP_REST_Response;
 use CDS\Utils;
+use CDS\Modules\Users\EmailDomains;
 
 class TrackLogins
 {
@@ -89,8 +90,8 @@ class TrackLogins
 
     public function logUserLogin($user_login, $user): void
     {
-        // Detect email addresses that do not end with @cds-snc.ca, gc.ca or canada.ca
-        if (!preg_match('/(@cds-snc|@canada|\.gc)\.ca$/', $user->user_email)) {
+        // Detect non-Government of Canada logins
+        if (!EmailDomains::isValidDomain($user->user_email)) {
             error_log("SUSPICIOUS: non-GC email login: {$user->user_email}");
         }
         $this->insertUserLogin($user, $user_agent = $this->getUserAgent());


### PR DESCRIPTION
# Summary
Update the `logUserLogin` hook to use the existing `isValidDomain` to determine if a user's email address domain is allowed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/445