### PR TITLE
chore: WordPress database error CloudWatch alarm

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/cloudwatch_ecs.tf
+++ b/infrastructure/terragrunt/aws/alarms/cloudwatch_ecs.tf
@@ -101,6 +101,35 @@ resource "aws_cloudwatch_metric_alarm" "wordpress_errors" {
   ok_actions        = [aws_sns_topic.alert_warning.arn]
 }
 
+resource "aws_cloudwatch_log_metric_filter" "wordpress_database_errors" {
+  name           = "WordPressDatabaseErrors"
+  pattern        = local.wordpress_database_error_metric_pattern
+  log_group_name = var.wordpress_log_group_name
+
+  metric_transformation {
+    name          = "WordPressDatabaseErrors"
+    namespace     = "WordPress"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "wordpress_database_errors" {
+  alarm_name          = "WordPressDatabaseErrors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.wordpress_database_errors.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.wordpress_database_errors.metric_transformation[0].namespace
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "5"
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "WordPress database errors detected in a 5 minute period"
+  alarm_actions     = [aws_sns_topic.alert_warning.arn]
+  ok_actions        = [aws_sns_topic.alert_warning.arn]
+}
+
 resource "aws_cloudwatch_log_metric_filter" "wordpress_warnings" {
   name           = "WordPressWarnings"
   pattern        = local.wordpress_warning_metric_pattern

--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -29,7 +29,7 @@ locals {
   wordpress_warnings_skip = [
     "Undefined array key*c3-cloudfront-clear-cache",
   ]
-  wordpress_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_errors_skip)}*\"]"
-  wordpress_database_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_database_errors)}*\")]"
-  wordpress_warning_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_warnings)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_warnings_skip)}*\"]"
+  wordpress_error_metric_pattern          = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_errors_skip)}*\"]"
+  wordpress_database_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_database_errors)}*\")]"
+  wordpress_warning_metric_pattern        = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_warnings)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_warnings_skip)}*\"]"
 }

--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -15,8 +15,12 @@ locals {
     "AH01630",
     "AH01797",
     "action=lostpassword&error",
+    "database error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
     "HTTP/1.1\\\" 404",
+  ]
+  wordpress_database_errors = [
+    "database error",
   ]
   wordpress_warnings = [
     "Warning",
@@ -26,5 +30,6 @@ locals {
     "Undefined array key*c3-cloudfront-clear-cache",
   ]
   wordpress_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_errors_skip)}*\"]"
+  wordpress_database_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_database_errors)}*\")]"
   wordpress_warning_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_warnings)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_warnings_skip)}*\"]"
 }


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm for WordPress database alarms and ignore the term `database error` in the default WordPress error alarm.

This is being done because there are some unpatched plugins in use that generate database errors with no user facing impact.  This new alarm will ignore these but still catch cases where there is a serious database issue.

# Related
- https://github.com/cds-snc/platform-core-services/issues/465