### PR TITLE
feat: add OIDC role to manage ECR image pushes

### DIFF
--- a/.github/workflows/build_push_container.yml
+++ b/.github/workflows/build_push_container.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         env:
-          ROLE_NAME: ${{ github.event_name == 'release' && 'gc-articles-ecr-tag-release' || 'gc-articles-apply' }}}
+          ROLE_NAME: ${{ github.ref == 'refs/heads/main' && 'gc-articles-apply' || 'gc-articles-ecr-tag-release' }}
         with:
           role-to-assume: arn:aws:iam::729164266357:role/${{ env.ROLE_NAME }}
           role-session-name: ECRPush

--- a/.github/workflows/build_push_container.yml
+++ b/.github/workflows/build_push_container.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+        env:
+          ROLE_NAME: ${{ github.event_name == 'release' && 'gc-articles-ecr-tag-release' || 'gc-articles-apply' }}}
         with:
-          role-to-assume: arn:aws:iam::729164266357:role/gc-articles-apply
+          role-to-assume: arn:aws:iam::729164266357:role/${{ env.ROLE_NAME }}
           role-session-name: ECRPush
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/build_push_prod_container.yml
+++ b/.github/workflows/build_push_prod_container.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
-          role-to-assume: arn:aws:iam::472286471787:role/gc-articles-apply
+          role-to-assume: arn:aws:iam::472286471787:role/gc-articles-ecr-tag-release
           role-session-name: ECRPush
           aws-region: ${{ env.AWS_REGION }}
 

--- a/infrastructure/terragrunt/aws/ecr/oidc.tf
+++ b/infrastructure/terragrunt/aws/ecr/oidc.tf
@@ -1,0 +1,25 @@
+locals {
+  ecr_push_role = "gc-articles-ecr-push"
+}
+
+module "ecr_push_role" {
+  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v7.0.2"
+  billing_tag_value = var.billing_tag_value
+  roles = [
+    {
+      name      = local.ecr_push_role
+      repo_name = "gc-articles"
+      claim     = "ref:refs/tags/v*"
+    }
+  ]
+}
+
+data "aws_iam_policy" "ecr_read_write" {
+  name = "AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_push_role" {
+  role       = local.ecr_push_role
+  policy_arn = data.aws_iam_policy.ecr_read_write.arn
+  depends_on = [module.ecr_push_role]
+}

--- a/infrastructure/terragrunt/aws/ecr/oidc.tf
+++ b/infrastructure/terragrunt/aws/ecr/oidc.tf
@@ -1,25 +1,53 @@
 locals {
-  ecr_push_role = "gc-articles-ecr-push"
+  ecr_tag_release = "gc-articles-ecr-tag-release"
 }
 
-module "ecr_push_role" {
+module "ecr_tag_release" {
   source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v7.0.2"
   billing_tag_value = var.billing_tag_value
   roles = [
     {
-      name      = local.ecr_push_role
+      name      = local.ecr_tag_release
       repo_name = "gc-articles"
       claim     = "ref:refs/tags/v*"
     }
   ]
 }
 
-data "aws_iam_policy" "ecr_read_write" {
-  name = "AmazonEC2ContainerRegistryPowerUser"
+resource "aws_iam_role_policy_attachment" "ecr_tag_release" {
+  role       = local.ecr_tag_release
+  policy_arn = aws_iam_policy.ecr_push.arn
+  depends_on = [
+    module.ecr_tag_release
+  ]
 }
 
-resource "aws_iam_role_policy_attachment" "ecr_push_role" {
-  role       = local.ecr_push_role
-  policy_arn = data.aws_iam_policy.ecr_read_write.arn
-  depends_on = [module.ecr_push_role]
+resource "aws_iam_policy" "ecr_push" {
+  name   = "wordpress-ecr-push"
+  path   = "/"
+  policy = data.aws_iam_policy_document.ecr_push.json
+}
+
+data "aws_iam_policy_document" "ecr_push" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:CompleteLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:InitiateLayerUpload",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage"
+    ]
+    resources = [
+      aws_ecr_repository.wordpress.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken"
+    ]
+    resources = ["*"]
+  }
 }


### PR DESCRIPTION
# Summary
Add OIDC role that can perform ECR image pushes on GitHub tag references.  This will be used by the workflows that push the release tag Docker images.

# Related
- https://github.com/cds-snc/platform-core-services/issues/469