### PR TITLE
fix: allow OIDC ECR role to pull images

### DIFF
--- a/infrastructure/terragrunt/aws/ecr/oidc.tf
+++ b/infrastructure/terragrunt/aws/ecr/oidc.tf
@@ -32,11 +32,17 @@ data "aws_iam_policy_document" "ecr_push" {
   statement {
     effect = "Allow"
     actions = [
-      "ecr:CompleteLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:InitiateLayerUpload",
       "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage"
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart"
     ]
     resources = [
       aws_ecr_repository.wordpress.arn


### PR DESCRIPTION
# Summary
Update the OIDC ECR role's permission policy to
allow it to pull images as well.

This is needed for the Docker SBOM workflow step.

# Related
- https://github.com/cds-snc/platform-core-services/issues/469