### PR TITLE
chore: fix deprecated workflow set-output commands

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2

--- a/.github/workflows/environments-manifest.yml
+++ b/.github/workflows/environments-manifest.yml
@@ -76,11 +76,11 @@ jobs:
           STAG_APACHE=v$(yq '.staging.apache' < ./infrastructure/environments.yml)
           PROD_INFRASTRUCTURE=v$(yq '.production.infrastructure' < ./infrastructure/environments.yml)
           echo "$(cat ./infrastructure/environments.yml)"
-          echo "::set-output name=PROD_WORDPRESS::${PROD_WORDPRESS}"
-          echo "::set-output name=STAG_WORDPRESS::${STAG_WORDPRESS}"
-          echo "::set-output name=PROD_APACHE::${PROD_APACHE}"
-          echo "::set-output name=STAG_APACHE::${STAG_APACHE}"
-          echo "::set-output name=PROD_INFRASTRUCTURE::infrastructure/${PROD_INFRASTRUCTURE}"
+          echo "PROD_WORDPRESS=${PROD_WORDPRESS}" >> "$GITHUB_OUTPUT"
+          echo "STAG_WORDPRESS=${STAG_WORDPRESS}" >> "$GITHUB_OUTPUT"
+          echo "PROD_APACHE=${PROD_APACHE}" >> "$GITHUB_OUTPUT"
+          echo "STAG_APACHE=${STAG_APACHE}" >> "$GITHUB_OUTPUT"
+          echo "PROD_INFRASTRUCTURE=infrastructure/${PROD_INFRASTRUCTURE}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
@@ -103,28 +103,28 @@ jobs:
           PROD_APACHE=v$(echo "$PREV_ENVIRONMENTS_YML" | yq '.production.apache' -)
           STAG_APACHE=v$(echo "$PREV_ENVIRONMENTS_YML" | yq '.staging.apache' -)
           PROD_INFRASTRUCTURE=v$(echo "$PREV_ENVIRONMENTS_YML" | yq '.production.infrastructure' -)
-          echo "::set-output name=PROD_WORDPRESS::${PROD_WORDPRESS}"
-          echo "::set-output name=STAG_WORDPRESS::${STAG_WORDPRESS}"
-          echo "::set-output name=PROD_APACHE::${PROD_APACHE}"
-          echo "::set-output name=STAG_APACHE::${STAG_APACHE}"
-          echo "::set-output name=PROD_INFRASTRUCTURE::infrastructure/${PROD_INFRASTRUCTURE}"
+          echo "PROD_WORDPRESS=${PROD_WORDPRESS}" >> "$GITHUB_OUTPUT"
+          echo "STAG_WORDPRESS=${STAG_WORDPRESS}" >> "$GITHUB_OUTPUT"
+          echo "PROD_APACHE=${PROD_APACHE}" >> "$GITHUB_OUTPUT"
+          echo "STAG_APACHE=${STAG_APACHE}" >> "$GITHUB_OUTPUT"
+          echo "PROD_INFRASTRUCTURE=infrastructure/${PROD_INFRASTRUCTURE}" >> "$GITHUB_OUTPUT"
           
       - name: Container deploy environment
         id: environment
         run: |
           if [ ${{ steps.previous.outputs.PROD_WORDPRESS }} != ${{ steps.versions.outputs.PROD_WORDPRESS }} ]; then
             echo "CONTAINER_DEPLOYMENT=production"
-            echo "::set-output name=CONTAINER_DEPLOYMENT::production"
+            echo "CONTAINER_DEPLOYMENT=production" >> "$GITHUB_OUTPUT"
           elif [ ${{ steps.previous.outputs.STAG_WORDPRESS }} != ${{ steps.versions.outputs.STAG_WORDPRESS }} ]; then
             echo "CONTAINER_DEPLOYMENT=staging"
-            echo "::set-output name=CONTAINER_DEPLOYMENT::staging"
+            echo "CONTAINER_DEPLOYMENT=staging" >> "$GITHUB_OUTPUT"
           elif [ ${{ steps.previous.outputs.PROD_APACHE }} != ${{ steps.versions.outputs.PROD_APACHE }} ]; then
             echo "CONTAINER_DEPLOYMENT=production"
-            echo "::set-output name=CONTAINER_DEPLOYMENT::production"
+            echo "CONTAINER_DEPLOYMENT=production" >> "$GITHUB_OUTPUT"
           elif [ ${{ steps.previous.outputs.STAG_APACHE }} != ${{ steps.versions.outputs.STAG_APACHE }} ]; then
             echo "CONTAINER_DEPLOYMENT=staging"
-            echo "::set-output name=CONTAINER_DEPLOYMENT::staging"
+            echo "CONTAINER_DEPLOYMENT=staging" >> "$GITHUB_OUTPUT"
           else
             echo "CONTAINER_DEPLOYMENT=false"
-            echo "::set-output name=CONTAINER_DEPLOYMENT::false"
+            echo "CONTAINER_DEPLOYMENT=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
# Summary
Update the deprecated `set-output` GitHub workflow commands to use the [new syntax](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).
