### PR TITLE
chore: deploy Apache increased timeouts to Staging

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -3,5 +3,5 @@ production:
   wordpress: 3.11.8
   infrastructure: 1.2.36
 staging:
-  apache: 1.1.0
+  apache: 1.1.1
   wordpress: 3.11.8


### PR DESCRIPTION
# Summary
Update the Staging Apache container with v1.1.1 which includes increased proxy timeout values.

# Related
- https://github.com/cds-snc/gc-articles/pull/1465
- https://github.com/cds-snc/platform-core-services/issues/440