### PR TITLE
fix: Google Tag Manager inline CSP hash

### DIFF
--- a/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
+++ b/wordpress/wp-content/plugins/cds-security-headers/cds-security-headers.php
@@ -93,7 +93,7 @@ function cds_security_headers($headers)
             "'sha256-xaR/y3UVa5H2DSzsDCewTCwStKccNcghTcH3caE7/ok='",
             "'sha256-zR0p2KmH+27/29a/Au4gPdgseccjj6bQ1s//IxzxJW4='",
             "'sha256-2SmtX8FleooXSbJX4JL6SeaaNY70u0nxCQvR/Gg2EHA='",
-            "'sha256-s4EE5d1+f+RnH0ld3ft0gIBFP9SYvXd0vW4sntyjQhQ='",
+            "'sha256-oZcz0w2RWHkYSMQ8YVYNBR9cguVgzGE9AQFBA8cl0Ic='",
             "https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/wet-boew.min.js",
             "https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js",


### PR DESCRIPTION
# Summary
Fix the hash used by the Content Security Policy to allow the Google Tag Manager inline script to run.

# Related
- https://github.com/cds-snc/platform-core-services/issues/477