### PR TITLE
chore: ignore HTTP 403 errors

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -17,6 +17,7 @@ locals {
     "action=lostpassword&error",
     "database error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
+    "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",
   ]
   wordpress_database_errors = [


### PR DESCRIPTION
# Summary
Update the CloudWatch error alarm so that requests that generate an HTTP 403 response do not trigger the alarm.

This is being done because fuzzing attacks will often generate 403 responses for requests that include at least one of the error alarm's filter words.  For example, here is a request from a recent fuzzing attack that was properly blocked but still triggered the alarm:
```
3.117 - - [11/Oct/2023:21:13:32 +0000] "GET /wp-content/plugins/sitepress-multilingual-cms/dist/css/?id=JJJ0QQQ&action=JJJ1QQQ&page=JJJ2QQQ&name=JJJ3QQQ&f=JJJ4QQQ&url=JJJ5QQQ&email=JJJ6QQQ&type=JJJ7QQQ&file=JJJ8QQQ&title=JJJ9QQQ&code=JJJ10QQQ&q=JJJ11QQQ&user=JJJ12QQQ&token=JJJ13QQQ&t=JJJ14QQQ&c=JJJ15QQQ&data=JJJ16QQQ&mode=JJJ17QQQ&order=JJJ18QQQ&lang=JJJ19QQQ&p=JJJ20QQQ&key=JJJ21QQQ&status=JJJ22QQQ&start=JJJ23QQQ&charset=JJJ24QQQ&s=JJJ25QQQ&post=JJJ26QQQ&login=JJJ27QQQ&search=JJJ28QQQ&content=JJJ29QQQ&comment=JJJ30QQQ&step=JJJ31QQQ&ajax=JJJ32QQQ&debug=JJJ33QQQ&state=JJJ34QQQ&query=JJJ35QQQ&error=JJJ36QQQ&save=JJJ37QQQ&sort=JJJ38QQQ&format=JJJ39QQQ&tab=JJJ40QQQ&offset=JJJ41QQQ&edit=JJJ42QQQ&preview=JJJ43QQQ&filter=JJJ44QQQ&from=JJJ45QQQ&view=JJJ46QQQ&a=JJJ47QQQ&limit=JJJ48QQQ&do=JJJ49QQQ&plugin=JJJ50QQQ&theme=JJJ51QQQ&text=JJJ52QQQ&test=JJJ53QQQ&path=JJJ54QQQ&pass=JJJ55QQQ&dir=JJJ56QQQ&show=JJJ57QQQ&h=JJJ58QQQ&value=JJJ59QQQ&filename=JJJ60QQQ&redirect=JJJ61QQQ&year=JJJ62QQQ&group=JJJ63QQQ&template=JJJ64QQQ&subject=JJJ65QQQ&m=JJJ66QQQ&u=JJJ67QQQ&dest=JJJ68QQQ&uri=JJJ69QQQ&continue=JJJ70QQQ&window=JJJ71QQQ&next=JJJ72QQQ&reference=JJJ73QQQ&site=JJJ74QQQ&&9iQIE=JJJ75QQQ& HTTP/1.1" 403 199
```
