### PR TITLE
chore: upgrade to Wordpress 6.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.3.1
+  WP_VERSION: 6.3.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.3.1-php8.1-fpm-alpine@sha256:8f227c350b78a556c0e1080ed4fe3505a1d6418538faf4374e478c92143147a9
+FROM wordpress:6.3.2-php8.1-fpm-alpine@sha256:2d46444c8d92c2e7ac5512d5b5b1a4d5c2ad2d567fa432a498bc5f8dd9a2d90e
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.3.1-php8.1-fpm-alpine@sha256:8f227c350b78a556c0e1080ed4fe3505a1d6418538faf4374e478c92143147a9
+FROM wordpress:6.3.2-php8.1-fpm-alpine@sha256:2d46444c8d92c2e7ac5512d5b5b1a4d5c2ad2d567fa432a498bc5f8dd9a2d90e
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Update to the [6.3.2 maintenance and security release](https://wordpress.org/documentation/wordpress-version/version-6-3-2/).

# Related
- https://github.com/cds-snc/platform-core-services/issues/484