### PR TITLE
feat: enable RDS cluster backtracking

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -2,7 +2,7 @@
 # RDS MySQL cluster across 3 subnets
 #
 module "rds_cluster" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.2"
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v7.2.3"
   name   = "wordpress"
 
   database_name  = var.database_name


### PR DESCRIPTION
# Summary
Update to the latest Terraform `rds` module version which includes a default 72 hour backtrack window.

This will make it easier to recover from failed updates by allowing a data rewind within the window.

# Related
- https://github.com/cds-snc/terraform-modules/pull/311
- https://github.com/cds-snc/platform-core-services/issues/471