### PR TITLE
fix: RDS copy tags and audit logging

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -19,6 +19,7 @@ locals {
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
     "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",
+    "Undefined constant",
   ]
   wordpress_database_errors = [
     "database error",

--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -2,7 +2,7 @@
 # RDS MySQL cluster across 3 subnets
 #
 module "rds_cluster" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=v7.2.3"
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v7.2.4"
   name   = "wordpress"
 
   database_name  = var.database_name


### PR DESCRIPTION
# Summary
Update to the latest TF module which will do the following:

1. Copy resource tags to snapshots.
2. Export database `audit` logs to CloudWatch.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471