### PR TITLE
fix: update DB parameter group to enable audit log

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -2,7 +2,7 @@
 # RDS MySQL cluster across 3 subnets
 #
 module "rds_cluster" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=v7.2.4"
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v7.2.5"
   name   = "wordpress"
 
   database_name  = var.database_name
@@ -12,6 +12,10 @@ module "rds_cluster" {
   instance_class = var.database_instance_class
   username       = var.database_username
   password       = var.database_password
+
+  # Enable audit logging
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.enable_audit_logging.name
+  enabled_cloudwatch_logs_exports = ["audit"]
 
   backtrack_window             = 0 # Backtracking cannot be enabled on existing clusters :(
   backup_retention_period      = 14
@@ -23,4 +27,21 @@ module "rds_cluster" {
 
   billing_tag_key   = var.billing_tag_key
   billing_tag_value = var.billing_tag_value
+}
+
+resource "aws_rds_cluster_parameter_group" "enable_audit_logging" {
+  name        = "wordpress-aurora-mysql57"
+  family      = "aurora-mysql5.7"
+  description = "RDS cluster parameter group with audit logging enabled"
+
+  parameter {
+    name  = "server_audit_logging"
+    value = "1"
+  }
+
+  # Available events: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html#AuroraMySQL.Auditing.Enable.server_audit_events
+  parameter {
+    name  = "server_audit_events"
+    value = "CONNECT,QUERY_DCL,QUERY_DDL,QUERY_DML"
+  }
 }


### PR DESCRIPTION
# Summary
Create a custom cluster database parameter group that enables audit logging and have those logs exported
to CloudWatch.

# Related
- https://github.com/cds-snc/terraform-modules/pull/313
- https://github.com/cds-snc/platform-core-services/issues/471
- **[Configure Aurora MySQL audit logging](https://aws.amazon.com/blogs/database/configuring-an-audit-log-to-capture-database-activities-for-amazon-rds-for-mysql-and-amazon-aurora-with-mysql-compatibility/)**