### PR TITLE
fix: block all public access to upload bucket

### DIFF
--- a/infrastructure/terragrunt/aws/storage/s3.tf
+++ b/infrastructure/terragrunt/aws/storage/s3.tf
@@ -1,9 +1,7 @@
 module "wordpress_storage" {
-  source                  = "github.com/cds-snc/terraform-modules//S3?ref=v7.0.2"
-  bucket_name             = "platform-gc-articles-${var.env}-uploads"
-  billing_tag_value       = var.billing_tag_value
-  block_public_policy     = false
-  restrict_public_buckets = false
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v7.0.2"
+  bucket_name       = "platform-gc-articles-${var.env}-uploads"
+  billing_tag_value = var.billing_tag_value
 }
 
 resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {


### PR DESCRIPTION
# Summary
Update the S3 upload bucket to block all public access. Objects are now being accessed through CloudFront.

# :warning:  Note
This change was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471