### PR TITLE
chore: upgrade to WordPress 6.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.3.2
+  WP_VERSION: 6.4.0
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.3.2-php8.1-fpm-alpine@sha256:4572ab237d77deb02d5363bf112f93aff34d35d3a29001b1fc1a719cbe445481
+FROM wordpress:6.4.0-php8.1-fpm-alpine@sha256:6ccc28f4a769f2d5f46acf04580d009911fc3db7cb548e6aa9f027675789b250
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.3.2-php8.1-fpm-alpine@sha256:4572ab237d77deb02d5363bf112f93aff34d35d3a29001b1fc1a719cbe445481
+FROM wordpress:6.4.0-php8.1-fpm-alpine@sha256:6ccc28f4a769f2d5f46acf04580d009911fc3db7cb548e6aa9f027675789b250
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to latest WordPress release:
https://wordpress.org/download/releases/6-4/

# Related
- https://github.com/cds-snc/platform-core-services/issues/498