### PR TITLE
feat: upgrade to WordPress 6.4.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,8 +29,8 @@ RUN apk add --update --virtual mod-deps autoconf alpine-sdk \
     zsh-autosuggestions \
     zsh-syntax-highlighting \
     gettext && \
-    # Install from testing/edge repository
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    # Install from v3.16 alpine community repo
+    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.16/community/ \
         php8-xmlwriter \
         php8-simplexml \
         php8-tokenizer \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.4.0
+  WP_VERSION: 6.4.1
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.4.0-php8.1-fpm-alpine@sha256:6ccc28f4a769f2d5f46acf04580d009911fc3db7cb548e6aa9f027675789b250
+FROM wordpress:6.4.1-php8.1-fpm-alpine@sha256:3f830c1c67fbd32bf2df4e700f020ada80cb7f610a67f4422803425300b9e39a
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.4.0-php8.1-fpm-alpine@sha256:6ccc28f4a769f2d5f46acf04580d009911fc3db7cb548e6aa9f027675789b250
+FROM wordpress:6.4.1-php8.1-fpm-alpine@sha256:3f830c1c67fbd32bf2df4e700f020ada80cb7f610a67f4422803425300b9e39a
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to latest version of WordPress.

Fix issue with local devcontainer setup.

# Related
- https://github.com/cds-snc/platform-core-services/issues/499