### PR TITLE
Production release: 3.13.1

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.13.0
+  wordpress: 3.13.1
   infrastructure: 1.2.41
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Upgrade to WordPress 6.4.1.

# Related
- Closes cds-snc/platform-core-services#499