### PR TITLE
fix: suppression of translation alarms

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -20,7 +20,7 @@ locals {
     "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",
     "Undefined constant",
-    "fr_FR.po",
+    "/usr/src/wordpress/wp-content/languages",
   ]
   wordpress_database_errors = [
     "database error",
@@ -31,7 +31,7 @@ locals {
   ]
   wordpress_warnings_skip = [
     "Undefined array key*c3-cloudfront-clear-cache",
-    "fr_FR.po",
+    "/usr/src/wordpress/wp-content/languages",
     "chmod()",
   ]
   wordpress_error_metric_pattern          = "[(w1=\"*${join("*\" || w1=\"*", local.wordpress_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.wordpress_errors_skip)}*\"]"


### PR DESCRIPTION
# Summary
Update how translation file warnings are suppressed by CloudWatch.  The previous pattern was not
generic enough.

# Related
- #1529 