### PR TITLE
chore: upgrade to WordPress 6.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.4.1
+  WP_VERSION: 6.4.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.4.1-php8.1-fpm-alpine@sha256:4a53e7e7fe2b55b9768d6a47ed2fec83f8905a9724fb5d777e93e455d80c43c5
+FROM wordpress:6.4.2-php8.1-fpm-alpine@sha256:62c9ed159ad7d20dae09dee447887879dad1b1e728b0a966ac24a4e9716d7d75
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.4.1-php8.1-fpm-alpine@sha256:4a53e7e7fe2b55b9768d6a47ed2fec83f8905a9724fb5d777e93e455d80c43c5
+FROM wordpress:6.4.2-php8.1-fpm-alpine@sha256:62c9ed159ad7d20dae09dee447887879dad1b1e728b0a966ac24a4e9716d7d75
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the latest Core security and maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/516