### PR TITLE
Production release: 3.14.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.13.2
+  wordpress: 3.14.0
   infrastructure: 1.2.42
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Production release of WordPress 6.4.2 upgrade.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/516