### PR TITLE
chore: suppress HTTP 400 bad request errors

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -17,6 +17,7 @@ locals {
     "action=lostpassword&error",
     "database error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
+    "HTTP/1.1\\\" 400",
     "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",
     "Undefined constant",


### PR DESCRIPTION
# Summary
Do not trigger a CloudWatch error alarm for HTTP 400 response codes.

We have been seeing a few of these over the past weeks caused by people scanning for [WordPress vulnerabilities](https://wpscan.com/vulnerability/4631519b-2060-43a0-b69b-b3d7ed94c705/):
```http
GET /wp-admin/admin-ajax.php?action=heateor_sss_sharing_count&urls[%3Cimg%20src%3dx%20onerror%3dalert(document.domain)%3E] HTTP/1.1" 400 
```