### PR TITLE
chore: ignore invalid email address error from ListManager

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -21,6 +21,7 @@ locals {
     "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",
     "Undefined constant",
+    "value_error.email",
     "/usr/src/wordpress/wp-content/languages",
   ]
   wordpress_database_errors = [


### PR DESCRIPTION
# Summary
Update the CloudWatch error metric so that when an invalid email address error is returned from ListManager, it does not trigger an alarm.