### PR TITLE
chore: suppress HTTP 301 CloudWatch alarms

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -17,6 +17,7 @@ locals {
     "action=lostpassword&error",
     "database error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
+    "HTTP/1.1\\\" 301",
     "HTTP/1.1\\\" 400",
     "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",


### PR DESCRIPTION
# Summary
Update the CloudWatch error alarms so that they do no trigger for HTTP 301 request logs.

This is being done because of XSS scanners commonly using the `onerror` tag, which triggers the alarm.