### PR TITLE
chore: upgrade to WordPress 6.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.4.2
+  WP_VERSION: 6.4.3
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.4.2-php8.1-fpm-alpine@sha256:73f8033d2109bc2a32a20302cdf4791dc75fde4723d6f362e360233d5305507b
+FROM wordpress:6.4.3-php8.1-fpm-alpine@sha256:2c51ee772ac0731d83c5e1d8aacd22365fc521c2a120ff029068dea0d84dbed8
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.4.2-php8.1-fpm-alpine@sha256:73f8033d2109bc2a32a20302cdf4791dc75fde4723d6f362e360233d5305507b
+FROM wordpress:6.4.3-php8.1-fpm-alpine@sha256:2c51ee772ac0731d83c5e1d8aacd22365fc521c2a120ff029068dea0d84dbed8
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary 
Upgrade to the WordPress 6.4.3 maintenance and security release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/535