### PR TITLE
Production release: 3.15.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.14.1
+  wordpress: 3.15.0
   infrastructure: 1.2.45
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Production release of WordPress 6.4.3.

# Related
- https://github.com/cds-snc/gc-articles/pull/1602
- Closes https://github.com/cds-snc/platform-core-services/issues/535