### PR TITLE
feat: add client VPN to access database

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -13,6 +13,8 @@ env:
   TERRAFORM_VERSION: 1.7.4
   TERRAGRUNT_VERSION: 0.35.6
   TF_INPUT: false
+  TF_VAR_client_vpn_access_group_id: ${{ secrets.PRODUCTION_CLIENT_VPN_ACCESS_GROUP_ID }}
+  TF_VAR_client_vpn_saml_metadata: ${{ secrets.PRODUCTION_CLIENT_VPN_SAML_METADATA }}  
   TF_VAR_database_name: ${{ secrets.PRODUCTION_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -16,6 +16,8 @@ env:
   TERRAFORM_VERSION: 1.7.4
   TERRAGRUNT_VERSION: 0.35.6
   TF_INPUT: false
+  TF_VAR_client_vpn_access_group_id: ${{ secrets.STAGING_CLIENT_VPN_ACCESS_GROUP_ID }}
+  TF_VAR_client_vpn_saml_metadata: ${{ secrets.STAGING_CLIENT_VPN_SAML_METADATA }}  
   TF_VAR_database_name: ${{ secrets.STAGING_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -13,6 +13,8 @@ env:
   TERRAFORM_VERSION: 1.7.4
   TERRAGRUNT_VERSION: 0.35.6
   TF_INPUT: false
+  TF_VAR_client_vpn_access_group_id: ${{ secrets.PRODUCTION_CLIENT_VPN_ACCESS_GROUP_ID }}
+  TF_VAR_client_vpn_saml_metadata: ${{ secrets.PRODUCTION_CLIENT_VPN_SAML_METADATA }}
   TF_VAR_database_name: ${{ secrets.PRODUCTION_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -14,6 +14,8 @@ env:
   TERRAFORM_VERSION: 1.7.4
   TERRAGRUNT_VERSION: 0.35.6
   TF_INPUT: false
+  TF_VAR_client_vpn_access_group_id: ${{ secrets.STAGING_CLIENT_VPN_ACCESS_GROUP_ID }}
+  TF_VAR_client_vpn_saml_metadata: ${{ secrets.STAGING_CLIENT_VPN_SAML_METADATA }}
   TF_VAR_database_name: ${{ secrets.STAGING_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}

--- a/infrastructure/terragrunt/aws/database/inputs.tf
+++ b/infrastructure/terragrunt/aws/database/inputs.tf
@@ -1,3 +1,7 @@
+variable "client_vpn_security_group_id" {
+  type = string
+}
+
 variable "database_instances_count" {
   type = number
 }

--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -45,3 +45,13 @@ resource "aws_rds_cluster_parameter_group" "enable_audit_logging" {
     value = "CONNECT,QUERY_DCL,QUERY_DDL,QUERY_DML"
   }
 }
+
+resource "aws_security_group_rule" "client_vpn_ingress_database" {
+  description              = "Client VPN ingress to the database"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = var.client_vpn_security_group_id
+  security_group_id        = module.rds_cluster.proxy_security_group_id
+}

--- a/infrastructure/terragrunt/aws/network/inputs.tf
+++ b/infrastructure/terragrunt/aws/network/inputs.tf
@@ -1,0 +1,11 @@
+variable "client_vpn_access_group_id" {
+  description = "IAM Identity Center group ID that will be allowed access to the VPN."
+  type        = string
+  sensitive   = true
+}
+
+variable "client_vpn_saml_metadata" {
+  description = "IAM Identity Center application SAML metadata.  Users that want to connect to the VPN must be granted access to this app."
+  type        = string
+  sensitive   = true
+}

--- a/infrastructure/terragrunt/aws/network/outputs.tf
+++ b/infrastructure/terragrunt/aws/network/outputs.tf
@@ -1,3 +1,7 @@
+output "client_vpn_security_group_id" {
+  value = module.vpn.client_vpn_security_group_id
+}
+
 output "load_balancer_security_group_id" {
   value = aws_security_group.wordpress_load_balancer.id
 }

--- a/infrastructure/terragrunt/aws/network/vpn.tf
+++ b/infrastructure/terragrunt/aws/network/vpn.tf
@@ -5,9 +5,12 @@ module "vpn" {
   access_group_id     = var.client_vpn_access_group_id
   self_service_portal = "disabled"
 
-  vpc_id                            = module.wordpress_vpc.vpc_id
-  vpc_cidr_block                    = module.wordpress_vpc.cidr_block
-  acm_certificate_arn               = aws_acm_certificate.client_vpn.arn
+  vpc_id               = module.wordpress_vpc.vpc_id
+  vpc_cidr_block       = module.wordpress_vpc.cidr_block
+  subnet_cidr_blocks   = module.wordpress_vpc.private_subnet_cidr_blocks
+  subnet_ids           = []
+  acm_certificate_arn  = aws_acm_certificate.client_vpn.arn
+
   client_vpn_saml_metadata_document = var.client_vpn_saml_metadata
 
   billing_tag_value = var.billing_tag_value

--- a/infrastructure/terragrunt/aws/network/vpn.tf
+++ b/infrastructure/terragrunt/aws/network/vpn.tf
@@ -1,0 +1,56 @@
+module "vpn" {
+  source = "github.com/cds-snc/terraform-modules//client_vpn?ref=v9.2.5"
+
+  endpoint_name       = "private_subnets"
+  access_group_id     = var.client_vpn_access_group_id
+  self_service_portal = "disabled"
+
+  vpc_id                            = module.wordpress_vpc.vpc_id
+  vpc_cidr_block                    = module.wordpress_vpc.cidr_block
+  acm_certificate_arn               = aws_acm_certificate.client_vpn.arn
+  client_vpn_saml_metadata_document = var.client_vpn_saml_metadata
+
+  billing_tag_value = var.billing_tag_value
+}
+
+#
+# Certificate used for VPN communication
+#
+resource "tls_private_key" "client_vpn" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "client_vpn" {
+  private_key_pem       = tls_private_key.client_vpn.private_key_pem
+  validity_period_hours = 43800 # 5 years
+  early_renewal_hours   = 672   # Generate new cert if Terraform is run within 4 weeks of expiry
+
+  subject {
+    common_name = "vpn.${var.env}.articles.alpha.canada.ca"
+  }
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "ipsec_end_system",
+    "ipsec_tunnel",
+    "any_extended",
+    "cert_signing",
+  ]
+}
+
+resource "aws_acm_certificate" "client_vpn" {
+  private_key      = tls_private_key.client_vpn.private_key_pem
+  certificate_body = tls_self_signed_cert.client_vpn.cert_pem
+
+  tags = {
+    Terraform             = true
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infrastructure/terragrunt/aws/network/vpn.tf
+++ b/infrastructure/terragrunt/aws/network/vpn.tf
@@ -5,11 +5,11 @@ module "vpn" {
   access_group_id     = var.client_vpn_access_group_id
   self_service_portal = "disabled"
 
-  vpc_id               = module.wordpress_vpc.vpc_id
-  vpc_cidr_block       = module.wordpress_vpc.cidr_block
-  subnet_cidr_blocks   = module.wordpress_vpc.private_subnet_cidr_blocks
-  subnet_ids           = []
-  acm_certificate_arn  = aws_acm_certificate.client_vpn.arn
+  vpc_id              = module.wordpress_vpc.vpc_id
+  vpc_cidr_block      = module.wordpress_vpc.cidr_block
+  subnet_cidr_blocks  = module.wordpress_vpc.private_subnet_cidr_blocks
+  subnet_ids          = []
+  acm_certificate_arn = aws_acm_certificate.client_vpn.arn
 
   client_vpn_saml_metadata_document = var.client_vpn_saml_metadata
 

--- a/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
@@ -12,8 +12,9 @@ dependency "network" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    private_subnet_ids = [""]
-    vpc_id             = ""
+    client_vpn_security_group_id = "sg-0123456789101212"
+    private_subnet_ids           = [""]
+    vpc_id                       = ""
   }
 }
 
@@ -21,6 +22,7 @@ inputs = {
   database_instances_count              = 3
   database_instance_class               = "db.r4.large"
   database_performance_insights_enabled = true
+  client_vpn_security_group_id          = dependency.network.outputs.client_vpn_security_group_id
   private_subnet_ids                    = dependency.network.outputs.private_subnet_ids
   vpc_id                                = dependency.network.outputs.vpc_id
 }

--- a/infrastructure/terragrunt/env/staging/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/database/terragrunt.hcl
@@ -12,8 +12,9 @@ dependency "network" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    private_subnet_ids = [""]
-    vpc_id             = ""
+    client_vpn_security_group_id = "sg-0123456789101212"
+    private_subnet_ids           = [""]
+    vpc_id                       = ""
   }
 }
 
@@ -21,6 +22,7 @@ inputs = {
   database_instances_count              = 2
   database_instance_class               = "db.t3.small"
   database_performance_insights_enabled = false
+  client_vpn_security_group_id          = dependency.network.outputs.client_vpn_security_group_id
   private_subnet_ids                    = dependency.network.outputs.private_subnet_ids
   vpc_id                                = dependency.network.outputs.vpc_id
 }


### PR DESCRIPTION
# Summary
Add a client VPN to Articles that will allow access to the database using our AWS SSO with IAM Identity Center group membership.

By default no subnets will be associated with the VPN so there will be no additional cost.  Subnets will be associated/disassociated on an as-needed basis.

# Related
- https://github.com/cds-snc/platform-core-services/issues/549