### PR TITLE
fix: client VPN ingress to DB is on 3306

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -49,8 +49,8 @@ resource "aws_rds_cluster_parameter_group" "enable_audit_logging" {
 resource "aws_security_group_rule" "client_vpn_ingress_database" {
   description              = "Client VPN ingress to the database"
   type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
+  from_port                = 3306
+  to_port                  = 3306
   protocol                 = "tcp"
   source_security_group_id = var.client_vpn_security_group_id
   security_group_id        = module.rds_cluster.proxy_security_group_id


### PR DESCRIPTION
# Summary
Update the client VPN to DB security group ingress rule to allow port `3306`.

# Related
- https://github.com/cds-snc/platform-core-services/issues/549