### PR TITLE
chore: suppress Wordpress cron errors and treat them as warnings

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -15,6 +15,7 @@ locals {
     "AH01630",
     "AH01797",
     "action=lostpassword&error",
+    "Cron unschedule event error for hook",
     "database error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
     "HTTP/1.1\\\" 301",
@@ -29,6 +30,7 @@ locals {
     "database error",
   ]
   wordpress_warnings = [
+    "Cron unschedule event error for hook",
     "Warning",
     "warning",
   ]


### PR DESCRIPTION
# Summary
Update the Wordpress CloudWatch alarm metric patterns so that failed cron scheduling errors are treated as warnings instead.