### PR TITLE
chore: upgrade to WordPress 6.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.5.0
+  WP_VERSION: 6.5.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.5.0-php8.1-fpm-alpine@sha256:07dfc2a769bbb5cd8e2327b254a59f5a5aae1d3537725e3c554d2881968a5fa2
+FROM wordpress:6.5.2-php8.1-fpm-alpine@sha256:eb40a00416a185793ae9feaadf6bfb94324a6bdf6e02b154edda9e2bd7d90a31
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.5.0-php8.1-fpm-alpine@sha256:07dfc2a769bbb5cd8e2327b254a59f5a5aae1d3537725e3c554d2881968a5fa2
+FROM wordpress:6.5.2-php8.1-fpm-alpine@sha256:eb40a00416a185793ae9feaadf6bfb94324a6bdf6e02b154edda9e2bd7d90a31
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to latest WordPress 6.5.2 Docker image.