### PR TITLE
Production release: 3.16.1

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.16.0
+  wordpress: 3.16.1
   infrastructure: 1.3.1
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Update production to WordPress 6.5.2.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/556