### PR TITLE
chore: enable WordPress debug logs

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -63,7 +63,7 @@
       },
       {
         "name": "WORDPRESS_DEBUG",
-        "value": 1
+        "value": "1"
       }
     ],
     "secrets": [

--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -64,6 +64,10 @@
       {
         "name": "WORDPRESS_DEBUG",
         "value": "1"
+      },
+      {
+        "name": "WORDPRESS_DEBUG_LOG",
+        "value": "/dev/stdout"
       }
     ],
     "secrets": [

--- a/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
+++ b/infrastructure/terragrunt/aws/ecs/container-definitions/wordpress.json.tmpl
@@ -60,6 +60,10 @@
       {
         "name": "C3_DISTRIBUTION_ID",
         "value": "${C3_DISTRIBUTION_ID}"
+      },
+      {
+        "name": "WORDPRESS_DEBUG",
+        "value": 1
       }
     ],
     "secrets": [

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -108,6 +108,7 @@ define('WP_DEFAULT_THEME', getenv_docker('WP_DEFAULT_THEME', 'cds-default'));
 
 define('WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', ''));
 define('WP_DEBUG_DISPLAY', !!getenv_docker('WORDPRESS_DEBUG_DISPLAY', 0));
+define('WP_DEBUG_LOG', !!getenv_docker('WORDPRESS_DEBUG_LOG', 'wp-content/debug.log'));
 @ini_set('display_errors', WP_DEBUG_DISPLAY);
 /* Add any custom values between this line and the "stop editing" line. */
 


### PR DESCRIPTION
# Summary
Update the ECS task to enable debug logs.  This will be used to troubleshoot the REST API Controller warnings being seen after the WordPress 6.5 upgrade.

# Related
- https://github.com/cds-snc/platform-core-services/issues/558