### PR TITLE
Release v3.16.2

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.3.1
 staging:
   apache: 1.1.1
-  wordpress: 3.16.1
+  wordpress: 3.16.2


### PR DESCRIPTION
# Summary
Enable WordPress debug logging in Staging.

# Related
- https://github.com/cds-snc/platform-core-services/issues/558