### PR TITLE
fix: WordPress debug logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ dist
 .terragrunt-cache
 .terraform
 *.tfstate
+*.tfvars
 
 # Python
 __pycache__/

--- a/infrastructure/terragrunt/aws/ecs/ecs.tf
+++ b/infrastructure/terragrunt/aws/ecs/ecs.tf
@@ -134,6 +134,7 @@ resource "aws_ecs_service" "wordpress_service" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
+  enable_execute_command             = true
 
   deployment_controller {
     type = "ECS"

--- a/infrastructure/terragrunt/aws/ecs/iam.tf
+++ b/infrastructure/terragrunt/aws/ecs/iam.tf
@@ -17,6 +17,12 @@ resource "aws_iam_policy" "wordpress_ecs_task_get_ecr_image" {
   policy = data.aws_iam_policy_document.wordpress_ecs_task_get_ecr_image.json
 }
 
+resource "aws_iam_policy" "wordpress_ecs_task_create_tunnel" {
+  name   = "WordpressEcsTaskCreateTunnel"
+  path   = "/"
+  policy = data.aws_iam_policy_document.wordpress_ecs_task_create_tunnel.json
+}
+
 resource "aws_iam_policy" "wordpress_ecs_task_efs" {
   count = var.enable_efs ? 1 : 0
 
@@ -43,6 +49,11 @@ resource "aws_iam_role_policy_attachment" "wordpress_ecs_task_get_secret_value_p
 resource "aws_iam_role_policy_attachment" "wordpress_ecs_task_get_ecr_image_policy_attach" {
   role       = aws_iam_role.wordpress_ecs_task.name
   policy_arn = aws_iam_policy.wordpress_ecs_task_get_ecr_image.arn
+}
+
+resource "aws_iam_role_policy_attachment" "wordpress_ecs_task_get_create_tunnel_policy_attach" {
+  role       = aws_iam_role.wordpress_ecs_task.name
+  policy_arn = aws_iam_policy.wordpress_ecs_task_create_tunnel.arn
 }
 
 resource "aws_iam_role_policy_attachment" "wordpress_ecs_task_efs_policy_attach" {
@@ -112,6 +123,20 @@ data "aws_iam_policy_document" "wordpress_ecs_task_get_ecr_image" {
       var.wordpress_repository_arn,
       var.apache_repository_arn
     ]
+  }
+}
+
+data "aws_iam_policy_document" "wordpress_ecs_task_create_tunnel" {
+  statement {
+    sid    = "CreateSSMTunnel"
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
   }
 }
 

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -74,6 +74,11 @@ COPY --from=buildjs /app/wordpress/wp-content/plugins/gc-post-meta/resources/js/
 COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-web-blocks/resources/js/build ./wp-content/plugins/cds-web-blocks/resources/js/build
 COPY --from=buildjs /app/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/build ./wp-content/plugins/cds-wpml-mods/resources/js/build
 
+# Create a writable debug.log
+RUN touch ./wp-content/debug.log \
+    && chmod 660 ./wp-content/debug.log \
+    && chown www-data:www-data ./wp-content/debug.log
+
 VOLUME /usr/src/wordpress
 
 USER www-data

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -108,7 +108,7 @@ define('WP_DEFAULT_THEME', getenv_docker('WP_DEFAULT_THEME', 'cds-default'));
 
 define('WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', ''));
 define('WP_DEBUG_DISPLAY', !!getenv_docker('WORDPRESS_DEBUG_DISPLAY', 0));
-define('WP_DEBUG_LOG', !!getenv_docker('WORDPRESS_DEBUG_LOG', 'wp-content/debug.log'));
+define('WP_DEBUG_LOG', getenv_docker('WORDPRESS_DEBUG_LOG', 'wp-content/debug.log'));
 @ini_set('display_errors', WP_DEBUG_DISPLAY);
 /* Add any custom values between this line and the "stop editing" line. */
 


### PR DESCRIPTION
# Summary
Create a `debug.log` file that the `www-data` user can write to when WordPress debug logging is enabled.

Enable ECS task remote connection to troubleshoot
file system issues.

Fix how the `WORDPRESS_DEBUG_LOG` environment variable is parsed by the `wp-config.php` file.

# Related
- https://github.com/cds-snc/platform-core-services/issues/558