### PR TITLE
fix: suppress the Warnings on missing properties

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -35,6 +35,7 @@ locals {
     "warning",
   ]
   wordpress_warnings_skip = [
+    "Attempt to read property*class-wp-rest-templates-controller.php",
     "Undefined array key*c3-cloudfront-clear-cache",
     "/usr/src/wordpress/wp-content/languages",
     "chmod()",


### PR DESCRIPTION
# Summary
Update the Warning alarm suppressions to ignore the missing properties in the `class-wp-rest-templates-controller`.

These are occurring when specific posts are saved and do not have a user or data impact.

# Related
- https://github.com/cds-snc/platform-core-services/issues/558