### PR TITLE
fix: upgrade to latest Python Lambda runtime

### DIFF
--- a/infrastructure/terragrunt/aws/ecs/cloudwatch_events.tf
+++ b/infrastructure/terragrunt/aws/ecs/cloudwatch_events.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "ecs_events" {
 
   filename    = data.archive_file.ecs_events.output_path
   handler     = "ecs_events.lambda_handler"
-  runtime     = "python3.8"
+  runtime     = "python3.12"
   timeout     = 30
   memory_size = 512
 


### PR DESCRIPTION
# Summary
Upgrade deprecated Lambda runtime to latest.

# Related
- https://github.com/cds-snc/platform-core-services/issues/560