### PR TITLE
fix: prevent recreate of MySQL 5.7 param group

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -32,7 +32,7 @@ module "rds_cluster" {
 resource "aws_rds_cluster_parameter_group" "enable_audit_logging" {
   name        = "wordpress-aurora-mysql57"
   family      = "aurora-mysql5.7"
-  description = "RDS cluster parameter group with audit logging enabled for MySQL 5.7"
+  description = "RDS cluster parameter group with audit logging enabled"
 
   parameter {
     name         = "binlog_format"


### PR DESCRIPTION
# Summary
Update the existing DB parameter group to remove the change that was causing it to be recreated.

This is because the parameter group cannot be recreated while it is being used by an RDS cluster.

# Related
- https://github.com/cds-snc/platform-core-services/issues/561