### PR TITLE
chore: update WordPress to use RDS cluster endpoint

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -2,7 +2,7 @@
 # RDS MySQL cluster across 3 subnets
 #
 module "rds_cluster" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.3.9"
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.3"
   name   = "wordpress"
 
   database_name  = var.database_name

--- a/infrastructure/terragrunt/aws/database/secrets.tf
+++ b/infrastructure/terragrunt/aws/database/secrets.tf
@@ -10,7 +10,7 @@ resource "aws_secretsmanager_secret" "database_host" {
 
 resource "aws_secretsmanager_secret_version" "database_host" {
   secret_id     = aws_secretsmanager_secret.database_host.id
-  secret_string = module.rds_cluster.proxy_endpoint
+  secret_string = module.rds_cluster.rds_cluster_endpoint
 }
 
 resource "aws_secretsmanager_secret" "database_name" {


### PR DESCRIPTION
# Summary
Update the database host secret to contain the cluster's endpoint rather than the proxy.

This is being done in preparation for the blue/green deployment which requires the RDS proxy to be temporarily removed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/561