### PR TITLE
chore: suppress `icon_error.gif` GET request alarms

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -22,6 +22,7 @@ locals {
     "HTTP/1.1\\\" 400",
     "HTTP/1.1\\\" 403",
     "HTTP/1.1\\\" 404",
+    "icon_error.gif HTTP/1.1\\\" 200",
     "Undefined constant",
     "value_error.email",
     "/usr/src/wordpress/wp-content/languages",


### PR DESCRIPTION
# Summary
Update the CloudWatch error alarms to no longer trigger for the `icon_error.gif` file.