### PR TITLE
fix: update RDS module to use standalone SG rules

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -2,7 +2,7 @@
 # RDS MySQL cluster across 3 subnets
 #
 module "rds_cluster" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.3"
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.4"
   name   = "wordpress"
 
   database_name  = var.database_name


### PR DESCRIPTION
# Summary
Update to the latest RDS module which includes a change to standalone security groups.

This will stop the custom VPN security group rule from being recreated on each apply.

# Related
- https://github.com/cds-snc/terraform-modules/pull/481