### PR TITLE
chore: upgrade to WordPress 6.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.5.2
+  WP_VERSION: 6.5.3
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.5.2-php8.1-fpm-alpine@sha256:26cfb14ca4071c5f55e0b79b8e93e63b7697e227366a0f6db54ff560a62de587
+FROM wordpress:6.5.3-php8.1-fpm-alpine@sha256:7c1e5c32dadc194cdd7eb0dc0306b8345114120794c6dfe9b55f57d5400ef522
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.5.2-php8.1-fpm-alpine@sha256:26cfb14ca4071c5f55e0b79b8e93e63b7697e227366a0f6db54ff560a62de587
+FROM wordpress:6.5.3-php8.1-fpm-alpine@sha256:7c1e5c32dadc194cdd7eb0dc0306b8345114120794c6dfe9b55f57d5400ef522
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the WordPress 6.5.3 maintenance and security release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/562