### PR TITLE
fix: switch RDS dynamic parameter apply method

### DIFF
--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -43,13 +43,13 @@ resource "aws_rds_cluster_parameter_group" "enable_audit_logging_v8" {
   parameter {
     name         = "server_audit_logging"
     value        = "1"
-    apply_method = "pending-reboot"
+    apply_method = "immediate"
   }
 
   parameter {
     name         = "server_audit_events"
     value        = "CONNECT,QUERY_DCL,QUERY_DDL,QUERY_DML"
-    apply_method = "pending-reboot"
+    apply_method = "immediate"
   }
 }
 


### PR DESCRIPTION
# Summary
Update the apply method for the dynamic RDS parameters as these are done immediately.

This should stop the constant plan change for the parameter group.