### PR TITLE
Production release: 3.17.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.16.5
+  wordpress: 3.17.0
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Deploy Wordpress 6.5.3 maintenance and security upgrade to prod.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/562