### PR TITLE
fix: allow `Tools` menu for GC Admin role

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -56,6 +56,12 @@ class Menus
             "Listes GC",
         ];
 
+        if (Utils::isWPEnvGCAdmin()) {
+            // Add items to the admin array
+            $allowed[] = "Tools";
+            $allowed[] = "Outils";
+        }
+
         //  __('Settings'), __('Appearance')
         // http://localhost/wp-admin/options-reading.php
         end($menu);

--- a/wordpress/wp-content/plugins/cds-base/classes/Utils.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Utils.php
@@ -60,6 +60,19 @@ class Utils
         return false;
     }
 
+    public static function isWPEnvGCAdmin(): bool
+    {
+        $current_user = wp_get_current_user();
+
+        if ($current_user) {
+            if (in_array("administrator", $current_user->roles)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static function addHttp($url, $protocol = "https")
     {
 


### PR DESCRIPTION
# Summary
Update the allowed menus so that the GC Admin role can see the `Tools` dashboard menu.

# Related
- #1757 