### PR TITLE
Production release: 3.17.1

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.17.0
+  wordpress: 3.17.1
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Deploy to Production the fix that allows the `GC Admin` role to access the `Tools` menu.

# Related
- #1757 
- #1759 