### PR TITLE
fix: bump CDS base role version

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Roles.php
@@ -8,7 +8,7 @@ class Roles
 {
     public function __construct()
     {
-        Utils::checkOptionCallback('cds_base_activated', '1.1.8', function () {
+        Utils::checkOptionCallback('cds_base_activated', '1.2.0', function () {
             if (is_blog_installed()) {
                 $wp_roles = wp_roles();
                 $allRoles = array_keys($wp_roles->roles); // array_keys returns only the slug


### PR DESCRIPTION
# Summary
Update the CDS base role version so that the GC Admin role capability change can be applied.

This will involve network deactivating/activating the plugin so that the role capabilities can be updated.

# Related
- #1757 
- #1759
- cds-snc/platform-core-services#572