### PR TITLE
Production release: 3.17.2

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.17.0
+  wordpress: 3.17.2
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Allow `GC Admin` role to export site content.

# Related
- #1757 
- #1759
- #1763 
- Closes cds-snc/platform-core-services#572