### PR TITLE
chore: upgrade WordPress 6.5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.5.3
+  WP_VERSION: 6.5.4
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.5.3-php8.1-fpm-alpine@sha256:34eccfa8eff76767311eb6db5816b6b79e4f1906f8a869973272faa1620b3fa4
+FROM wordpress:6.5.4-php8.1-fpm-alpine@sha256:54193c0cc45e6ea93f57ff33dca0ecd39e876771bd340b5de4cef278ca1f9b9e
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.5.3-php8.1-fpm-alpine@sha256:34eccfa8eff76767311eb6db5816b6b79e4f1906f8a869973272faa1620b3fa4
+FROM wordpress:6.5.4-php8.1-fpm-alpine@sha256:54193c0cc45e6ea93f57ff33dca0ecd39e876771bd340b5de4cef278ca1f9b9e
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to WordPress 6.5.4 maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/579