### PR TITLE
Release v3.18.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1
-  wordpress: 3.17.3
+  wordpress: 3.18.0


### PR DESCRIPTION
# Summary
Staging release of the WordPress 6.5.4 maintenance release upgrade.

# Related
- https://github.com/cds-snc/gc-articles/pull/1781
- https://github.com/cds-snc/platform-core-services/issues/579