### PR TITLE
Production release: 3.18.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.17.2
+  wordpress: 3.18.0
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
WordPress 6.5.4 maintenance release upgrade.

# Related
- https://github.com/cds-snc/gc-articles/pull/1781
- Closes https://github.com/cds-snc/platform-core-services/issues/579