### PR TITLE
chore: upgrade to WordPress 6.5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.5.4
+  WP_VERSION: 6.5.5
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.5.4-php8.1-fpm-alpine@sha256:e0c4ecbfa6e72ed4419f365a2b4585063ba0385dc48a202cd74d0bb8dfed045c
+FROM wordpress:6.5.5-php8.1-fpm-alpine@sha256:740784c6b585bb51faaf59cc02443705b04f65fb3dfa4e0cefb3af920f512c11
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.5.4-php8.1-fpm-alpine@sha256:e0c4ecbfa6e72ed4419f365a2b4585063ba0385dc48a202cd74d0bb8dfed045c
+FROM wordpress:6.5.5-php8.1-fpm-alpine@sha256:740784c6b585bb51faaf59cc02443705b04f65fb3dfa4e0cefb3af920f512c11
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the latest security and maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/583