### PR TITLE
chore: wordpress 6.6.0 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.5.5
+  WP_VERSION: 6.6.0
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.5.5-php8.1-fpm-alpine@sha256:4cb01d13f5ab4b473b50f3e91a4e8bb7ce7c9da3a11a7cf46b2c817e8fea1d9e
+FROM wordpress:6.6.0-php8.1-fpm-alpine@sha256:4ae0712bc3b86076921b70d14845857496e387b016373673e15d632153827b2d
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.5.5-php8.1-fpm-alpine@sha256:4cb01d13f5ab4b473b50f3e91a4e8bb7ce7c9da3a11a7cf46b2c817e8fea1d9e
+FROM wordpress:6.6.0-php8.1-fpm-alpine@sha256:4ae0712bc3b86076921b70d14845857496e387b016373673e15d632153827b2d
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the WordPress 6.6.0 release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/584