### PR TITLE
Production release: 3.20.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.19.0
+  wordpress: 3.20.0
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Release WordPress 6.6 upgrade to Production.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/584