### PR TITLE
fix: return HTML instead of HtmlPageCrawler object

### DIFF
--- a/wordpress/wp-content/themes/cds-redirector/filter-core-buttons.php
+++ b/wordpress/wp-content/themes/cds-redirector/filter-core-buttons.php
@@ -23,7 +23,7 @@ function cds_filter_core_buttons($block_content, $block)
                 $links .= $link;
             }
 
-            return $links;
+            return $links->outerHtml();
         } catch (Exception $e) {
             //no-op
         }

--- a/wordpress/wp-content/themes/cds-website-preview/filter-core-image.php
+++ b/wordpress/wp-content/themes/cds-website-preview/filter-core-image.php
@@ -11,7 +11,7 @@ function cds_filter_core_image($block_content, $block)
             // add the following styles to prevent the image from being improperly sized
             $img_html->css('max-width', '100%');
             $img_html->css('height', 'auto');
-            return $img_html;
+            return $img_html->outerHtml();
         } catch (Exception $e) {
             //no-op
         }


### PR DESCRIPTION
# Summary
Update the filters that use an `HtmlPageCrawler` to return the outerHTML of the `HtmlPageCrawler`, rather than the object.

This will fix the regression seen with the WordPress 6.6 release that is causing those filters to fail with a fatal error.