### PR TITLE
Release v3.20.1

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1
-  wordpress: 3.20.0
+  wordpress: 3.20.1


### PR DESCRIPTION
# Summary
Fix HtmlPageCrawler regression after WordPress 6.6.0 upgrade.

# Related
- https://github.com/cds-snc/gc-articles/pull/1832