### PR TITLE
Production release: 3.20.1

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.1.1
-  wordpress: 3.20.0
+  wordpress: 3.20.1
   infrastructure: 1.5.2
 staging:
   apache: 1.1.1


### PR DESCRIPTION
# Summary
Deploy HtmlPageCrawler WordPress 6.6.0 regression fix to Production.

# Related
- https://github.com/cds-snc/gc-articles/pull/1832