### PR TITLE
fix: move outerHtml function to the HtmlPageCrawler object

### DIFF
--- a/wordpress/wp-content/themes/cds-redirector/filter-core-buttons.php
+++ b/wordpress/wp-content/themes/cds-redirector/filter-core-buttons.php
@@ -20,10 +20,10 @@ function cds_filter_core_buttons($block_content, $block)
                 $crawler = @new HtmlPage($html);
                 $link = $crawler->filter('a');
                 $link->addClass($className);
-                $links .= $link;
+                $links .= $link->outerHtml();
             }
 
-            return $links->outerHtml();
+            return $links;
         } catch (Exception $e) {
             //no-op
         }


### PR DESCRIPTION
# Summary
Update the CDS Redirector theme `render_block` filter to have the function call on the object rather than the string.