### PR TITLE
feat: notify website team on prod releases

### DIFF
--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -125,6 +125,12 @@ jobs:
         working-directory: infrastructure/terragrunt/env/prod/ecs
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Post to slack
+        if: success()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":lapage: New GC Articles <https://github.com/cds-snc/gc-articles/commit/${{ github.sha }}|release has been deployed>!"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_WEBSITE_INFINITE }}
+
       - name: Report deployment to Sentinel
         if: always()
         uses: cds-snc/sentinel-forward-data-action@main


### PR DESCRIPTION
# Summary
Add a new step to the production release workflow that lets the website team know that a new Articles release has been deployed.

This should help more quickly identify issues impacting the website caused by the releases.