### PR TITLE
fix: remove editor h1 underline

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor.css
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Blocks/src/styles/editor.css
@@ -38,7 +38,6 @@ width: 80px;
 
 .editor-styles-wrapper h1 {
   margin-top: .75em;
-  border-bottom: 1px solid #af3c43;
   margin-bottom: .2em;
   padding-bottom: .2em;
   font-size: 34px;


### PR DESCRIPTION
# Summary
Remove the double underline from headings in the editor.

# Related
- https://github.com/cds-snc/gc-articles/issues/1875