### PR TITLE
chore: upgrade to WordPress 6.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.6.1
+  WP_VERSION: 6.6.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.6.1-php8.1-fpm-alpine@sha256:1fe2d4a9b77e259434f7c030898cb4705d6cb93509b8a43ccb7d4f97fc3def93
+FROM wordpress:6.6.2-php8.1-fpm-alpine@sha256:3501596c2e47e46884c7cc756423aab4c4fab85dca4760ab56fb50010942aefb
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.6.1-php8.1-fpm-alpine@sha256:1fe2d4a9b77e259434f7c030898cb4705d6cb93509b8a43ccb7d4f97fc3def93
+FROM wordpress:6.6.2-php8.1-fpm-alpine@sha256:3501596c2e47e46884c7cc756423aab4c4fab85dca4760ab56fb50010942aefb
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the latest WordPress maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/593