### PR TITLE
fix: check returned array has items

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Releases/Releases.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Releases/Releases.php
@@ -51,7 +51,7 @@ class Releases
         $response = wp_remote_get("https://articles.alpha.canada.ca/wp-json/wp/v2/pages/?slug=updates");
         $responseBody = wp_remote_retrieve_body($response);
         $result = json_decode($responseBody);
-        if (is_array($result) && ! is_wp_error($result)) {
+        if (is_array($result) && $result && ! is_wp_error($result)) {
             $content = $result[0]->content->rendered;
             $content = apply_filters('the_content', $content);
             return $content;


### PR DESCRIPTION
# Summary
Update the `getEmbedPage` function to check that the returned array has items.