### PR TITLE
fix: block POST requests to add comments

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -648,11 +648,11 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
         statement {
           byte_match_statement {
             positional_constraint = "CONTAINS"
-            search_string = "wp-comments-post.php"
+            search_string         = "wp-comments-post.php"
             field_to_match {
               uri_path {}
             }
-            text_transformations {
+            text_transformation {
               priority = 0
               type     = "LOWERCASE"
             }
@@ -662,11 +662,11 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
         statement {
           byte_match_statement {
             positional_constraint = "EXACTLY"
-            search_string = "post"
+            search_string         = "post"
             field_to_match {
               method {}
             }
-            text_transformations {
+            text_transformation {
               priority = 0
               type     = "LOWERCASE"
             }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -626,6 +626,63 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
+    name     = "BlockComments"
+    priority = 13
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            positional_constraint = "CONTAINS"
+            search_string = "wp-comments-post.php"
+            field_to_match {
+              uri_path {}
+            }
+            text_transformations {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+
+        statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            search_string = "post"
+            field_to_match {
+              method {}
+            }
+            text_transformations {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockComments"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "WordpressRateLimit"
     priority = 101
 


### PR DESCRIPTION
# Summary
Update the WAF ACL so that POST requests to add comments are blocked.  This is being done because we are being spammed and do not want to ever allow comments to be posted.

# Related
- https://github.com/cds-snc/platform-core-services/issues/596