### PR TITLE
feat: update load balancer SSL policy

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
@@ -64,7 +64,7 @@ resource "aws_lb_listener" "wordpress" {
   load_balancer_arn = aws_lb.wordpress.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
   certificate_arn   = aws_acm_certificate.wordpress.arn
 
   default_action {

--- a/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
@@ -61,6 +61,7 @@ resource "aws_lb_target_group" "wordpress" {
 }
 
 resource "aws_lb_listener" "wordpress" {
+  # checkov:skip=CKV_AWS_103: false-positive, SSL policy is TLS1.2+
   load_balancer_arn = aws_lb.wordpress.arn
   port              = "443"
   protocol          = "HTTPS"

--- a/infrastructure/terragrunt/aws/load-balancer/s3.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/s3.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "cloudfront_logs" {
 
     expiration {
       days                         = 30
-      expired_object_delete_marker = true
+      expired_object_delete_marker = false
     }
 
     noncurrent_version_expiration {


### PR DESCRIPTION
# Summary
Update to the latest recommend ALB SSL policy which is [FIPS 140-3](https://csrc.nist.gov/pubs/fips/140-3/final) compliant

# Related
- https://aws.amazon.com/about-aws/whats-new/2023/11/application-load-balancer-fips-tls-termination/
- https://docs.aws.amazon.com/elasticloadbalancing/latest/network/describe-ssl-policies.html#fips-security-policies