### PR TITLE
fix: suppress intermittent proxy getaddrinfo errors

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/locals.tf
+++ b/infrastructure/terragrunt/aws/alarms/locals.tf
@@ -18,6 +18,7 @@ locals {
     "Cron unschedule event error for hook",
     "database error",
     "GET /notification-gc-notify/wp-json/wp/v2/pages",
+    "getaddrinfo for*proxy*failed",
     "HTTP/1.1\\\" 301",
     "HTTP/1.1\\\" 400",
     "HTTP/1.1\\\" 403",
@@ -29,6 +30,7 @@ locals {
   ]
   wordpress_database_errors = [
     "database error",
+    "getaddrinfo for*proxy*failed",
   ]
   wordpress_warnings = [
     "Cron unschedule event error for hook",

--- a/infrastructure/terragrunt/aws/database/rds.tf
+++ b/infrastructure/terragrunt/aws/database/rds.tf
@@ -43,13 +43,13 @@ resource "aws_rds_cluster_parameter_group" "enable_audit_logging_v8" {
   parameter {
     name         = "server_audit_logging"
     value        = "1"
-    apply_method = "immediate"
+    apply_method = var.env == "staging" ? "pending-reboot" : "immediate"
   }
 
   parameter {
     name         = "server_audit_events"
     value        = "CONNECT,QUERY_DCL,QUERY_DDL,QUERY_DML"
-    apply_method = "immediate"
+    apply_method = var.env == "staging" ? "pending-reboot" : "immediate"
   }
 }
 


### PR DESCRIPTION
# Summary
Update the CloudWatch error alarms so that occasional failures to get the RDS proxy address info do not trigger a Slack post. These will now only be alerted if there are more than 5 in a short period of time.

Also fix a TF flip-flop with the custom RDS parameter group.