### PR TITLE
chore: upgrade to Wordpress 6.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.6.2
+  WP_VERSION: 6.7.0
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.6.2-php8.1-fpm-alpine@sha256:081fceb75dcb6c2a869fdb45928644ec25f79ccf3ca01df8e246170ba1a8b2be
+FROM wordpress:6.7.0-php8.1-fpm-alpine@sha256:7e310fe1da19c61fafb3fadf00ffdae5916165115b84f439b776907c37982664
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.6.2-php8.1-fpm-alpine@sha256:081fceb75dcb6c2a869fdb45928644ec25f79ccf3ca01df8e246170ba1a8b2be
+FROM wordpress:6.7.0-php8.1-fpm-alpine@sha256:7e310fe1da19c61fafb3fadf00ffdae5916165115b84f439b776907c37982664
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the latest patch release of Wordpress.

# Related
- https://github.com/cds-snc/platform-core-services/issues/618