### PR TITLE
Production release: 3.23.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.2.0
-  wordpress: 3.22.0
+  wordpress: 3.23.0
   infrastructure: 1.5.8
 staging:
   apache: 1.2.0


### PR DESCRIPTION
# Summary
Upgrade to Wordpress 6.7.0 in prod.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/618
- #1971 