### PR TITLE
chore: upgrade to WordPress 6.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.7.0
+  WP_VERSION: 6.7.1
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.7.0-php8.1-fpm-alpine@sha256:7e310fe1da19c61fafb3fadf00ffdae5916165115b84f439b776907c37982664
+FROM wordpress:6.7.1-php8.1-fpm-alpine@sha256:8853052e0c5f690b03ba5a148d272e82ac8977e2c3d359715c44252abaf40e13
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.7.0-php8.1-fpm-alpine@sha256:7e310fe1da19c61fafb3fadf00ffdae5916165115b84f439b776907c37982664
+FROM wordpress:6.7.1-php8.1-fpm-alpine@sha256:8853052e0c5f690b03ba5a148d272e82ac8977e2c3d359715c44252abaf40e13
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to latest WordPress maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/629