### PR TITLE
Production release: 3.24.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.2.0
-  wordpress: 3.23.0
+  wordpress: 3.24.0
   infrastructure: 1.5.8
 staging:
   apache: 1.2.0


### PR DESCRIPTION
# Summary
WordPress 6.7.1 maintenance release upgrade in Prod.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/629
- #1988 