### PR TITLE
Release v3.24.1

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.5.8
 staging:
   apache: 1.2.0
-  wordpress: 3.24.0
+  wordpress: 3.24.1


### PR DESCRIPTION
# Summary
Fix Articles pagination in WordPress 6.7.1 deploy to Staging.

# Related
- #1993 
- https://github.com/cds-snc/platform-core-services/issues/631