### PR TITLE
feat: upgrade to WordPress 6.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.7.1
+  WP_VERSION: 6.7.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.7.1-php8.1-fpm-alpine@sha256:666ca6ad3da06953b0a3913f832d7aab4e82383fc0aca8f0a951fbacf0925789
+FROM wordpress:6.7.2-php8.1-fpm-alpine@sha256:d6cfdc7875479aacfd158658b2c1b5671cb4e3e92b9c2e799016dabc4139daa1
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.7.1-php8.1-fpm-alpine@sha256:666ca6ad3da06953b0a3913f832d7aab4e82383fc0aca8f0a951fbacf0925789
+FROM wordpress:6.7.2-php8.1-fpm-alpine@sha256:d6cfdc7875479aacfd158658b2c1b5671cb4e3e92b9c2e799016dabc4139daa1
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the 6.7.2 maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/670