### PR TITLE
Release v3.26.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.5.8
 staging:
   apache: 1.2.0
-  wordpress: 3.25.0
+  wordpress: 3.26.0


### PR DESCRIPTION
# Summary
WordPress 6.7.2 maintenance release in Staging.

# Related
- https://github.com/cds-snc/platform-core-services/issues/670