### PR TITLE
chore: add redirect for National Manager's Community

### DIFF
--- a/wordpress/.htaccess-multisite
+++ b/wordpress/.htaccess-multisite
@@ -22,6 +22,9 @@ RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
 RewriteRule ^pspc-innovation-network(.*)$ https://gcxgce.sharepoint.com/teams/10002125/ [R=301,L]
 RewriteRule ^gc-data-conference(.*)$ https://www.csps-efpc.gc.ca/events/data-conference2024/about-eng.aspx [R=301,L]
 RewriteRule ^framework-for-leading-change(.*)$ https://change-leadership.github.io/framework-for-leading-change/ [R=301,L]
+RewriteRule ^national-managers-community/fr/(.*)$ https://www.csps-efpc.gc.ca/partnerships/nmc-fra.aspx [R=301,L]
+RewriteCond %{REQUEST_URI} !wp-admin
+RewriteRule ^national-managers-community(.*)$ https://www.csps-efpc.gc.ca/partnerships/nmc-eng.aspx [R=301,L]
 
 RewriteCond %{REQUEST_URI} wp-login.php
 RewriteRule ^ /404 [L]


### PR DESCRIPTION
# Summary
Add a redirect to send NMC requests to their new site.  This redirect includes logic to still allow access to the WordPress admin dashboard so that GC Lists can still be used in the short term.

# Related
- https://github.com/cds-snc/platform-core-services/issues/676