### PR TITLE
fix: set a unique WAF rule priority

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -638,7 +638,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "Custom_PHPHighRiskMethodsVariables_BODY"
-    priority = 13
+    priority = 90
     action {
       dynamic "block" {
         for_each = var.enable_waf == true ? [""] : []


### PR DESCRIPTION
# Summary
Update the new PHP rule's priority to be unique in Production.

It is currently clashing with an AWS Shield rule that is automatically managed.