### PR TITLE
Release v3.27.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.5.10
 staging:
   apache: 1.2.0
-  wordpress: 3.26.1
+  wordpress: 3.27.0


### PR DESCRIPTION
# Summary
WordPress 6.8 upgrade in Staging.

# Related
- https://github.com/cds-snc/platform-core-services/issues/710