### PR TITLE
feat: upgrade to WordPress 6.8.1 maintenance release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.8.0
+  WP_VERSION: 6.8.1
 
 jobs:
   php-tests:

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -75,7 +75,8 @@
     "shawnhooper/delete-orphaned-multisite-tables": "1.0",
     "league/html-to-markdown": "^5.1",
     "wpackagist-plugin/gutenberg-custom-fields":"1.5.6",
-    "wpackagist-plugin/jwt-authentication-for-wp-rest-api": "1.3.6"
+    "wpackagist-plugin/jwt-authentication-for-wp-rest-api": "1.3.6",
+    "wpackagist-plugin/wordpress-importer": "^0.8.4"
   },
   "require-dev": {
     "pestphp/pest": "^1.16",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70c001b0088062beb9ad92693b64332e",
+    "content-hash": "9b3693002fbf160c85ff497cc0801d09",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -4022,6 +4022,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/two-factor/"
+        },
+        {
+            "name": "wpackagist-plugin/wordpress-importer",
+            "version": "0.8.4",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wordpress-importer/",
+                "reference": "tags/0.8.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-importer.0.8.4.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wordpress-importer/"
         },
         {
             "name": "wpackagist-plugin/wp-rest-api-v2-menus",

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.8.0-php8.1-fpm-alpine@sha256:f1f0ee9c154d0bafeef682c39952865124682a9043fe7448d9a932edb09ed8fe
+FROM wordpress:6.8.1-php8.1-fpm-alpine@sha256:80133d7ca934fa288e4055cb4960d9edd592dad096099e2f7397f205af63a8c3
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.8.0-php8.1-fpm-alpine@sha256:f1f0ee9c154d0bafeef682c39952865124682a9043fe7448d9a932edb09ed8fe
+FROM wordpress:6.8.1-php8.1-fpm-alpine@sha256:80133d7ca934fa288e4055cb4960d9edd592dad096099e2f7397f205af63a8c3
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to the latest WordPress and add back the WordPress importer plugin to simplify testing between Staging and Prod.

# Related
- https://github.com/cds-snc/platform-core-services/issues/720
