### PR TITLE
feat: add WAF IP blocklist and count rule to firewall

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -924,5 +924,8 @@ module "waf_ip_blocklist" {
   athena_waf_table_name       = "waf_logs"
   athena_workgroup_name       = "logs"
 
+  waf_scope                        = "CLOUDFRONT"
+  waf_ip_blocklist_update_schedule = "rate(1 hour)"
+
   billing_tag_value = var.billing_tag_value
 }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -801,6 +801,27 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
   }
 
+  rule {
+    name     = "BlockedIPv4"
+    priority = 120
+
+    action {
+      count {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = module.waf_ip_blocklist.ipv4_blocklist_arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockedIPv4"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "wordpress"
@@ -886,4 +907,22 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_cloudfront
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_alb" {
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.wordpress_waf_alb.arn
+}
+
+#
+# IPv4 blocklist that is automatically managed by a Lambda function.  Any IP address in the WAF logs
+# that crosses a block threshold will be added to the blocklist.
+#
+module "waf_ip_blocklist" {
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.2"
+
+  service_name                = "gc-articles"
+  athena_database_name        = "access_logs"
+  athena_query_results_bucket = module.athena_bucket.s3_bucket_id
+  athena_query_source_bucket  = var.cbs_satellite_bucket_name
+  athena_lb_table_name        = "lb_logs"
+  athena_waf_table_name       = "waf_logs"
+  athena_workgroup_name       = "logs"
+
+  billing_tag_value = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Add the WAF IP blocklist module so that we can start blocking the repeated low volume fuzzing attacks we've been seeing against the service.

The firewall rule is currently set to `COUNT` so we can evaluate how it performs for a few days before starting to block traffic.
