### PR TITLE
fix: create WAF IP set in us-east-1

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -914,7 +914,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_alb" {
 # that crosses a block threshold will be added to the blocklist.
 #
 module "waf_ip_blocklist" {
-  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.2"
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.5"
 
   # IP blocklist must be in us-east-1 as the CloudFront WAF
   # requires it to work with the IP set
@@ -929,6 +929,7 @@ module "waf_ip_blocklist" {
   athena_lb_table_name        = "lb_logs"
   athena_waf_table_name       = "waf_logs"
   athena_workgroup_name       = "logs"
+  athena_region               = var.region
 
   waf_scope                        = "CLOUDFRONT"
   waf_ip_blocklist_update_schedule = "rate(1 hour)"

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -916,6 +916,12 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_alb" {
 module "waf_ip_blocklist" {
   source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.2"
 
+  # IP blocklist must be in us-east-1 as the CloudFront WAF
+  # requires it to work with the IP set
+  providers = {
+    aws = aws.us-east-1
+  }
+
   service_name                = "gc-articles"
   athena_database_name        = "access_logs"
   athena_query_results_bucket = module.athena_bucket.s3_bucket_id

--- a/infrastructure/terragrunt/env/staging/load-balancer/.terraform.lock.hcl
+++ b/infrastructure/terragrunt/env/staging/load-balancer/.terraform.lock.hcl
@@ -1,9 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:aTsKLhA0m6ZW560baooNkF1t47TZvpBvaoPEI8wQpDo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.97.0"
-  constraints = "~> 5.0"
+  constraints = ">= 4.9.0, ~> 5.0"
   hashes = [
     "h1:0cMARQKxeJIHYi+p1Yg391n3oytz92H0/E/gdTSo1vg=",
     "h1:2vyaumyNsiPVqJsMQwaSbrrssj6HcJVspxJawhu0UsU=",


### PR DESCRIPTION
# Summary
Attempting to use the WAF IP set with the CloudFront WAF ACL fails if the IP set is not in `us-east-1`.

This was tested locally and works as expected so this PR is syncing the Terraform code with the infrastructure state.

# Related
- #2167 