### PR TITLE
fix: WAF IP blocklist permissions

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -914,7 +914,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_alb" {
 # that crosses a block threshold will be added to the blocklist.
 #
 module "waf_ip_blocklist" {
-  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.5"
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.6"
 
   # IP blocklist must be in us-east-1 as the CloudFront WAF
   # requires it to work with the IP set


### PR DESCRIPTION
# Summary
Upgrade to the latest version of the TF module which includes a fix to properly set the boto client's region.