### PR TITLE
chore: switch ECS tasks to connect to RDS directly

### DIFF
--- a/infrastructure/terragrunt/aws/database/secrets.tf
+++ b/infrastructure/terragrunt/aws/database/secrets.tf
@@ -10,7 +10,7 @@ resource "aws_secretsmanager_secret" "database_host" {
 
 resource "aws_secretsmanager_secret_version" "database_host" {
   secret_id     = aws_secretsmanager_secret.database_host.id
-  secret_string = module.rds_cluster.proxy_endpoint
+  secret_string = module.rds_cluster.rds_cluster_endpoint
 }
 
 resource "aws_secretsmanager_secret" "database_name" {


### PR DESCRIPTION
# Summary
Update the `database_host` secret value to use the RDS read/write endpoint instead of the RDS proxy.

This is being done in preparation for temporarily removing the RDS proxy so that we can use an Blue/Green deployment to reduce the database instance size in production.

# Related
- https://github.com/cds-snc/platform-core-services/issues/637