### PR TITLE
chore: switch to cheaper DB instance class size

### DIFF
--- a/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/prod/database/terragrunt.hcl
@@ -20,7 +20,7 @@ dependency "network" {
 
 inputs = {
   database_instances_count              = 1
-  database_instance_class               = "db.r5.large"
+  database_instance_class               = "db.t4g.medium"
   database_performance_insights_enabled = true
   client_vpn_security_group_id          = dependency.network.outputs.client_vpn_security_group_id
   private_subnet_ids                    = dependency.network.outputs.private_subnet_ids

--- a/infrastructure/terragrunt/env/staging/database/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/staging/database/terragrunt.hcl
@@ -20,7 +20,7 @@ dependency "network" {
 
 inputs = {
   database_instances_count              = 1
-  database_instance_class               = "db.t3.medium"
+  database_instance_class               = "db.t4g.medium"
   database_performance_insights_enabled = false
   client_vpn_security_group_id          = dependency.network.outputs.client_vpn_security_group_id
   private_subnet_ids                    = dependency.network.outputs.private_subnet_ids


### PR DESCRIPTION
# Summary
Update Staging and Prod to use the db.t4g.medium Graviton database instance class size.  This will be cheaper than what is currently in use while still providing sufficient resources to handle the load.

## ⚠️ Note
Before being released to Prod, a new `db.t4g.medium` instance will be added to the cluster and failed over to.

# Related
- https://github.com/cds-snc/platform-core-services/issues/637