### PR TITLE
fix: allow SVG media uploads in CDS Redirector theme

### DIFF
--- a/wordpress/wp-content/themes/cds-redirector/functions.php
+++ b/wordpress/wp-content/themes/cds-redirector/functions.php
@@ -210,22 +210,6 @@ add_filter('use_block_editor_for_post', '__return_true', 5);
 add_filter('user_can_richedit', '__return_true', 50);
 
 // Allow SVG
-add_filter('wp_check_filetype_and_ext', function ($data, $file, $filename, $mimes) {
-
-    global $wp_version;
-    if ($wp_version !== '4.7.1') {
-        return $data;
-    }
-
-    $filetype = wp_check_filetype($filename, $mimes);
-
-    return [
-        'ext'             => $filetype['ext'],
-        'type'            => $filetype['type'],
-        'proper_filename' => $data['proper_filename']
-    ];
-}, 10, 4);
-
 add_filter('upload_mimes', function ($mimes) {
     $mimes['json'] = 'application/json';
     $mimes['svg'] = 'image/svg+xml';

--- a/wordpress/wp-content/themes/cds-redirector/functions.php
+++ b/wordpress/wp-content/themes/cds-redirector/functions.php
@@ -209,7 +209,6 @@ add_filter('gutenberg_can_edit_post', '__return_true', 5);
 add_filter('use_block_editor_for_post', '__return_true', 5);
 add_filter('user_can_richedit', '__return_true', 50);
 
-
 // Allow SVG
 add_filter('wp_check_filetype_and_ext', function ($data, $file, $filename, $mimes) {
 
@@ -227,21 +226,17 @@ add_filter('wp_check_filetype_and_ext', function ($data, $file, $filename, $mime
     ];
 }, 10, 4);
 
-function cc_mime_types($mimes)
-{
+add_filter('upload_mimes', function ($mimes) {
     $mimes['json'] = 'application/json';
     $mimes['svg'] = 'image/svg+xml';
     return $mimes;
-}
-add_filter('upload_mimes', 'cc_mime_types');
+});
 
-function fix_svg()
-{
+add_action('admin_head', function () {
     echo '<style type="text/css">
           .attachment-266x266, .thumbnail img {
                width: 100% !important;
                height: auto !important;
           }
           </style>';
-}
-add_action('admin_head', 'fix_svg');
+});

--- a/wordpress/wp-content/themes/cds-redirector/functions.php
+++ b/wordpress/wp-content/themes/cds-redirector/functions.php
@@ -208,3 +208,40 @@ function cds_get_active_language(): ?string
 add_filter('gutenberg_can_edit_post', '__return_true', 5);
 add_filter('use_block_editor_for_post', '__return_true', 5);
 add_filter('user_can_richedit', '__return_true', 50);
+
+
+// Allow SVG
+add_filter('wp_check_filetype_and_ext', function ($data, $file, $filename, $mimes) {
+
+    global $wp_version;
+    if ($wp_version !== '4.7.1') {
+        return $data;
+    }
+
+    $filetype = wp_check_filetype($filename, $mimes);
+
+    return [
+        'ext'             => $filetype['ext'],
+        'type'            => $filetype['type'],
+        'proper_filename' => $data['proper_filename']
+    ];
+}, 10, 4);
+
+function cc_mime_types($mimes)
+{
+    $mimes['json'] = 'application/json';
+    $mimes['svg'] = 'image/svg+xml';
+    return $mimes;
+}
+add_filter('upload_mimes', 'cc_mime_types');
+
+function fix_svg()
+{
+    echo '<style type="text/css">
+          .attachment-266x266, .thumbnail img {
+               width: 100% !important;
+               height: auto !important;
+          }
+          </style>';
+}
+add_action('admin_head', 'fix_svg');


### PR DESCRIPTION
# Summary
Update the CDS Redirector theme so that users can upload SVG images.

# Related
- https://github.com/cds-snc/platform-core-services/issues/756