### PR TITLE
fix: update WAF ACL rate limit and geo restriction

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/shield_advanced.tf
+++ b/infrastructure/terragrunt/aws/alarms/shield_advanced.tf
@@ -29,3 +29,13 @@ resource "aws_shield_protection_health_check_association" "cloudfront" {
   health_check_arn     = aws_route53_health_check.wordpress.arn
   shield_protection_id = aws_shield_protection.cloudfront.id
 }
+
+resource "aws_shield_application_layer_automatic_response" "alb" {
+  resource_arn = var.alb_arn
+  action       = "BLOCK"
+}
+
+resource "aws_shield_application_layer_automatic_response" "cloudfront" {
+  resource_arn = var.cloudfront_arn
+  action       = "BLOCK"
+}


### PR DESCRIPTION
# Summary
Update the WAF ACL so that it has more fine grained control over the request rate blocking rules.  Also adds a Canada and US only geolocation restriction rule.

The IPv4 rule is being removed as we will instead rely on the rate limit, AWS Shield Advanced and layer 7 DDoS rule once the AWS Terraform provider supports it.

Finally, the AWS Shield Advanced auto-mitigations to `BLOCK` are also being setup.