### PR TITLE
chore: upgrade to WordPress 6.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.8.1
+  WP_VERSION: 6.8.2
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.8.1-php8.1-fpm-alpine@sha256:0af4223bba84f5b661e4a4b9b760b62261134fd5951521910560b89e1a5d4948
+FROM wordpress:6.8.2-php8.1-fpm-alpine@sha256:2021a18ca3f7ff312e676b5c44e5393218a064fb6ae8261a8fa09e5ef06c67ec
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.8.1-php8.1-fpm-alpine@sha256:0af4223bba84f5b661e4a4b9b760b62261134fd5951521910560b89e1a5d4948
+FROM wordpress:6.8.2-php8.1-fpm-alpine@sha256:2021a18ca3f7ff312e676b5c44e5393218a064fb6ae8261a8fa09e5ef06c67ec
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade WordPress to latest security and maintenance release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/799