### PR TITLE
feat: allow non-matching countries with correct secret value

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -20,6 +20,7 @@ env:
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_custom_header_name: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_NAME }}
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
+  TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_list_manager_endpoint: ${{ secrets.PRODUCTION_LIST_MANAGER_ENDPOINT }}
   TF_VAR_default_list_manager_api_key: ${{ secrets.PRODUCTION_DEFAULT_LIST_MANAGER_API_KEY }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -23,6 +23,7 @@ env:
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
+  TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_list_manager_endpoint: ${{ secrets.STAGING_LIST_MANAGER_ENDPOINT }}
   TF_VAR_default_list_manager_api_key: ${{ secrets.STAGING_DEFAULT_LIST_MANAGER_API_KEY }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -20,6 +20,7 @@ env:
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_custom_header_name: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_NAME }}
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
+  TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_list_manager_endpoint: ${{ secrets.PRODUCTION_LIST_MANAGER_ENDPOINT }}
   TF_VAR_default_list_manager_api_key: ${{ secrets.PRODUCTION_DEFAULT_LIST_MANAGER_API_KEY }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -21,6 +21,7 @@ env:
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
   TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
+  TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_list_manager_endpoint: ${{ secrets.STAGING_LIST_MANAGER_ENDPOINT }}
   TF_VAR_default_list_manager_api_key: ${{ secrets.STAGING_DEFAULT_LIST_MANAGER_API_KEY }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -10,6 +10,12 @@ variable "cloudfront_custom_header_value" {
   sensitive   = true
 }
 
+variable "cloudfront_waf_geo_match_secret" {
+  description = "Custom header value to check to determine if the geo match statement should allow a country outside of the allowed set."
+  type        = string
+  sensitive   = true
+}
+
 variable "domain_name" {
   description = "Domain name for the load balancer, certificate and CloudFront"
   type        = string

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -853,8 +853,27 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     statement {
       not_statement {
         statement {
-          geo_match_statement {
-            country_codes = ["CA", "US"]
+          or_statement {
+            statement {
+              geo_match_statement {
+                country_codes = ["CA", "US"]
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  single_header {
+                    name = "waf-secret"
+                  }
+                }
+                search_string = var.cloudfront_waf_geo_match_secret
+                text_transformation {
+                  priority = 1
+                  type     = "NONE"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
# Summary
Add a check to the CloudFront WAF ACL's geo_match_statement that will allow a request through if it has the correct secret value.  This is being done to support GitHub runners sometimes being erroneously identified as being outside of Canada and the US.