### PR TITLE
chore: upgrade to WordPress 6.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 6.8.2
+  WP_VERSION: 6.8.3
 
 jobs:
   php-tests:

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:6.8.2-php8.1-fpm-alpine@sha256:207c51e53247f619d434e0c065741902d1bfc0c8cfe4545ea317d5686590e225
+FROM wordpress:6.8.3-php8.1-fpm-alpine@sha256:24260c29b8772aed84d4fed2fcbb3ccc6df24b21b9423e94be6cc1e4a4d600a2
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:6.8.2-php8.1-fpm-alpine@sha256:207c51e53247f619d434e0c065741902d1bfc0c8cfe4545ea317d5686590e225
+FROM wordpress:6.8.3-php8.1-fpm-alpine@sha256:24260c29b8772aed84d4fed2fcbb3ccc6df24b21b9423e94be6cc1e4a4d600a2
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary
Upgrade to latest security release of WordPress.
