### PR TITLE
Release v4.3.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.7.3
 staging:
   apache: 1.2.0
-  wordpress: 4.2.1
+  wordpress: 4.3.0


### PR DESCRIPTION
# Summary
WordPress 6.8.3 Staging release.

# Related
- https://github.com/cds-snc/gc-articles/pull/2297