### PR TITLE
Production release: 4.3.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.2.0
-  wordpress: 4.2.1
+  wordpress: 4.3.0
   infrastructure: 1.7.3
 staging:
   apache: 1.2.0


### PR DESCRIPTION
# Summary
WordPress 6.8.3 Prod release.

# Related
- https://github.com/cds-snc/gc-articles/pull/2297