### PR TITLE
fix: add undefined guard when building select

### DIFF
--- a/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/components/PageSelect.js
+++ b/wordpress/wp-content/plugins/cds-wpml-mods/resources/js/components/PageSelect.js
@@ -122,7 +122,7 @@ export const PageSelect = () => {
 
                 // if post has a translated_post_id, set the page to that one
                 if(post.translated_post_id) {
-                    setPage(_pages.find(p => p.value === post.translated_post_id))
+                    setPage(_pages.find(p => p.value === post.translated_post_id) || emptyPage)
                 }
             }
 


### PR DESCRIPTION
# Summary 
Add a check to make sure `undefined` is not returned to the SelectControl component.

# Related
- https://github.com/cds-snc/platform-core-services/issues/981
