### PR TITLE
enable 2fa, directs to profile page

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TwoFactor/TwoFactor.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TwoFactor/TwoFactor.php
@@ -15,9 +15,12 @@ class TwoFactor
         add_filter('two_factor_providers', [$this, 'configureProviders']);
         add_action('plugins_loaded', [$this, 'loadTwoFactorCore']);
         add_action('wp_dashboard_setup', [$this, 'dashboardWidget']);
-        add_action('wp_login', [$this, 'redirectIfNo2FA'], 10, 2);
-        add_action('admin_init', [$this, 'enforce2FA']);
-        add_action('admin_notices', [$this, 'twoFactorRequiredNotice']);
+
+        if (wp_get_environment_type() === 'production' || wp_get_environment_type() === 'staging') {
+            add_action('wp_login', [$this, 'redirectIfNo2FA'], 10, 2);
+            add_action('admin_init', [$this, 'enforce2FA']);
+            add_action('admin_notices', [$this, 'twoFactorRequiredNotice']);
+        }
     }
 
     public function loadTwoFactorCore(): void

--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/TwoFactor/TwoFactor.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/TwoFactor/TwoFactor.php
@@ -15,6 +15,9 @@ class TwoFactor
         add_filter('two_factor_providers', [$this, 'configureProviders']);
         add_action('plugins_loaded', [$this, 'loadTwoFactorCore']);
         add_action('wp_dashboard_setup', [$this, 'dashboardWidget']);
+        add_action('wp_login', [$this, 'redirectIfNo2FA'], 10, 2);
+        add_action('admin_init', [$this, 'enforce2FA']);
+        add_action('admin_notices', [$this, 'twoFactorRequiredNotice']);
     }
 
     public function loadTwoFactorCore(): void
@@ -58,5 +61,57 @@ class TwoFactor
         $panel .= '</div>';
 
         echo $panel;
+    }
+
+    public function redirectIfNo2FA(string $username, \WP_User $user): void
+    {
+        if (!class_exists('Two_Factor_Core_Alias')) {
+            return;
+        }
+
+        if (!Two_Factor_Core_Alias::is_user_using_two_factor($user)) {
+            wp_safe_redirect(admin_url('profile.php?2fa_required=1') . '#two-factor-options');
+            exit;
+        }
+    }
+
+    public function enforce2FA(): void
+    {
+        if (wp_doing_ajax() || wp_doing_cron()) {
+            return;
+        }
+
+        if (!class_exists('Two_Factor_Core_Alias')) {
+            return;
+        }
+
+        $user = wp_get_current_user();
+        if (!$user->exists()) {
+            return;
+        }
+
+        if (Two_Factor_Core_Alias::is_user_using_two_factor($user)) {
+            return;
+        }
+
+        // Allow profile.php, user is directed to configure 2FA.
+        $page = $GLOBALS['pagenow'] ?? '';
+        if ($page === 'profile.php') {
+            return;
+        }
+
+        wp_safe_redirect(admin_url('profile.php?2fa_required=1') . '#two-factor-options');
+        exit;
+    }
+
+    public function twoFactorRequiredNotice(): void
+    {
+        if (!isset($_GET['2fa_required'])) {
+            return;
+        }
+
+        echo '<div class="notice notice-error"><p>';
+        echo esc_html__('You must configure two-factor authentication before you can access GC Articles.', 'cds-snc');
+        echo '</p></div>';
     }
 }


### PR DESCRIPTION
# Summary | Résumé

2FA is currently not mandatory. This change allows users to log in, but those without 2FA enabled will only be locked to the profile page until they enable 2FA.

Related to:

https://github.com/orgs/cds-snc/projects/51/views/1?pane=issue&itemId=164926466&issue=cds-snc%7Cplatform-core-services%7C960