### PR TITLE
fix: WAF improvements based on review

### DIFF
--- a/.github/workflows/deploy-production-container.yml
+++ b/.github/workflows/deploy-production-container.yml
@@ -18,8 +18,6 @@ env:
   TF_VAR_database_name: ${{ secrets.PRODUCTION_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
-  TF_VAR_cloudfront_custom_header_name: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_NAME }}
-  TF_VAR_cloudfront_custom_header_value: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.PRODUCTION_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.PRODUCTION_S3_UPLOADS_BUCKET }}

--- a/.github/workflows/deploy-staging-container.yml
+++ b/.github/workflows/deploy-staging-container.yml
@@ -18,8 +18,6 @@ env:
   TF_VAR_database_name: ${{ secrets.STAGING_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
-  TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
-  TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}

--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -19,8 +19,6 @@ env:
   TF_VAR_database_name: ${{ secrets.PRODUCTION_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
-  TF_VAR_cloudfront_custom_header_name: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_NAME }}
-  TF_VAR_cloudfront_custom_header_value: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.PRODUCTION_ENCRYPTION_KEY }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -23,8 +23,6 @@ env:
   TF_VAR_database_name: ${{ secrets.STAGING_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
-  TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
-  TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -19,8 +19,6 @@ env:
   TF_VAR_database_name: ${{ secrets.PRODUCTION_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
-  TF_VAR_cloudfront_custom_header_name: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_NAME }}
-  TF_VAR_cloudfront_custom_header_value: ${{ secrets.PRODUCTION_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.PRODUCTION_ENCRYPTION_KEY }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -21,8 +21,6 @@ env:
   TF_VAR_database_name: ${{ secrets.STAGING_DATABASE_NAME }}
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
-  TF_VAR_cloudfront_custom_header_name: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_NAME }}
-  TF_VAR_cloudfront_custom_header_value: ${{ secrets.STAGING_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -17,8 +17,6 @@ Host the GC Articles WordPress site in an Amazon Elastic Container Service (ECS)
 ## Environment variables
 
 The following Terraform variables are required:
-* `cloudfront_custom_header_name`: Header name added by CloudFront. Prevents direct requests to ALB.
-* `cloudfront_custom_header_value`: Header value added by CloudFront.  Prevents direct requests to ALB.
 * `database_name`: Name of the database to create in the RDS cluster
 * `database_username`: Root database user
 * `database_password`: Root database user's password

--- a/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/cloudfront.tf
@@ -7,11 +7,6 @@ resource "aws_cloudfront_distribution" "wordpress" {
     domain_name = aws_lb.wordpress.dns_name
     origin_id   = aws_lb.wordpress.name
 
-    custom_header {
-      name  = var.cloudfront_custom_header_name
-      value = var.cloudfront_custom_header_value
-    }
-
     custom_origin_config {
       http_port              = 80
       https_port             = 443

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -1,9 +1,3 @@
-variable "cloudfront_custom_header_name" {
-  description = "Custom header name added by CloudFront.  Used to block direct user requests to the ALB."
-  type        = string
-  sensitive   = true
-}
-
 variable "cloudfront_waf_geo_match_secret" {
   description = "Custom header value to check to determine if the geo match statement should allow a country outside of the allowed set."
   type        = string

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -4,12 +4,6 @@ variable "cloudfront_custom_header_name" {
   sensitive   = true
 }
 
-variable "cloudfront_custom_header_value" {
-  description = "Custom header value added by CloudFront.  Used to block direct user requests to the ALB."
-  type        = string
-  sensitive   = true
-}
-
 variable "cloudfront_waf_geo_match_secret" {
   description = "Custom header value to check to determine if the geo match statement should allow a country outside of the allowed set."
   type        = string

--- a/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
@@ -1,3 +1,4 @@
+# checkov:skip=CKV2_AWS_28: ALB only allows ingress from CloudFront which has a WAF
 resource "aws_lb" "wordpress" {
   name               = "wordpress"
   internal           = false

--- a/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/load-balancer.tf
@@ -1,5 +1,5 @@
-# checkov:skip=CKV2_AWS_28: ALB only allows ingress from CloudFront which has a WAF
 resource "aws_lb" "wordpress" {
+  # checkov:skip=CKV2_AWS_28: ALB only allows ingress from CloudFront which has a WAF
   name               = "wordpress"
   internal           = false
   load_balancer_type = "application"

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -1,9 +1,10 @@
 locals {
   # Rules that must be excluded from the AWSManagedRulesCommonRuleSet for WordPress to work
+  bot_control_excluded_rules   = ["CategoryHttpLibrary", "SignalNonBrowserUserAgent"]
   common_excluded_rules        = ["GenericRFI_QUERYARGUMENTS", "GenericRFI_BODY", "GenericRFI_URIPATH", "CrossSiteScripting_BODY", "SizeRestrictions_BODY"]
   php_excluded_rules           = ["PHPHighRiskMethodsVariables_BODY"]
   rate_limit_all_requests      = 1000
-  rate_limit_mutating_requests = 100
+  rate_limit_mutating_requests = 200
 }
 
 #
@@ -21,8 +22,55 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "GeoRestriction"
+    name     = "InvalidHost"
     priority = 1
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {}
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {}
+      }
+    }
+
+    statement {
+      not_statement {
+        statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = "host"
+              }
+            }
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+            positional_constraint = "EXACTLY"
+            search_string         = var.domain_name
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "InvalidHost"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "GeoRestriction"
+    priority = 10
 
     action {
       dynamic "block" {
@@ -73,8 +121,197 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
+    name     = "RateLimitAllRequestsIp"
+    priority = 20
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {}
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {}
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = local.rate_limit_all_requests
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitAllRequestsIp"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimitAllRequestsJA4"
+    priority = 30
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {}
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {}
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = local.rate_limit_all_requests
+        aggregate_key_type = "CUSTOM_KEYS"
+
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitAllRequestsJA4"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimitMutatingRequestsIp"
+    priority = 40
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {}
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {}
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = local.rate_limit_mutating_requests
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          regex_match_statement {
+            field_to_match {
+              method {}
+            }
+            regex_string = "^(delete|patch|post|put)$"
+            text_transformation {
+              priority = 1
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitMutatingRequestsIp"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimitMutatingRequestsJA4"
+    priority = 50
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {}
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {}
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = local.rate_limit_mutating_requests
+        aggregate_key_type = "CUSTOM_KEYS"
+
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
+
+        scope_down_statement {
+          regex_match_statement {
+            field_to_match {
+              method {}
+            }
+            regex_string = "^(delete|patch|post|put)$"
+            text_transformation {
+              priority = 1
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitMutatingRequestsJA4"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 60
+
+    override_action {
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "AWSManagedRulesCommonRuleSet"
-    priority = 5
+    priority = 70
 
     override_action {
       dynamic "none" {
@@ -116,7 +353,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 10
+    priority = 80
 
     override_action {
       dynamic "none" {
@@ -148,7 +385,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesLinuxRuleSet"
-    priority = 15
+    priority = 90
 
     override_action {
       dynamic "none" {
@@ -186,7 +423,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "Custom_LFI_QueryString"
-    priority = 20
+    priority = 100
 
     action {
       dynamic "block" {
@@ -239,7 +476,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesSQLiRuleSet"
-    priority = 25
+    priority = 110
 
     override_action {
       dynamic "none" {
@@ -283,7 +520,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "Custom_SQLi_BODY"
-    priority = 30
+    priority = 120
 
     action {
       dynamic "block" {
@@ -379,7 +616,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "Custom_SQLiExtendedPatterns_BODY"
-    priority = 35
+    priority = 130
 
     action {
       dynamic "block" {
@@ -432,7 +669,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesPHPRuleSet"
-    priority = 40
+    priority = 140
 
     override_action {
       dynamic "none" {
@@ -474,7 +711,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "AWSManagedRulesWordPressRuleSet"
-    priority = 45
+    priority = 150
 
     override_action {
       dynamic "none" {
@@ -505,40 +742,8 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "AWSManagedRulesAmazonIpReputationList"
-    priority = 50
-
-    override_action {
-      dynamic "none" {
-        for_each = var.enable_waf == true ? [""] : []
-        content {
-        }
-      }
-
-      dynamic "count" {
-        for_each = var.enable_waf == false ? [""] : []
-        content {
-        }
-      }
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesAmazonIpReputationList"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "AWSManagedRulesAmazonIpReputationList"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
     name     = "Custom_SizeRestrictions_BODY"
-    priority = 55
+    priority = 160
     action {
       dynamic "block" {
         for_each = var.enable_waf == true ? [""] : []
@@ -616,7 +821,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "Custom_CrossSiteScripting_BODY"
-    priority = 60
+    priority = 170
     action {
       dynamic "block" {
         for_each = var.enable_waf == true ? [""] : []
@@ -692,7 +897,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
   rule {
     name     = "Custom_PHPHighRiskMethodsVariables_BODY"
-    priority = 90
+    priority = 180
     action {
       dynamic "block" {
         for_each = var.enable_waf == true ? [""] : []
@@ -760,8 +965,48 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
+    name     = "AWSManagedRulesAntiDDoSRuleSet"
+    priority = 190
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAntiDDoSRuleSet"
+        vendor_name = "AWS"
+
+        managed_rule_group_configs {
+          aws_managed_rules_anti_ddos_rule_set {
+            client_side_action_config {
+              challenge {
+                sensitivity     = "HIGH"
+                usage_of_action = "ENABLED"
+                exempt_uri_regular_expression {
+                  regex_string = ".(acc|avi|css|gif|jpe?g|js|pdf|png|tiff?|ttf|webm|webp|woff2?)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAntiDDoSRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "wordpress"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
     name     = "BlockComments"
-    priority = 100
+    priority = 200
 
     action {
       dynamic "block" {
@@ -817,168 +1062,11 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
   }
 
   rule {
-    name     = "RateLimitAllRequestsIp"
-    priority = 110
-
-    action {
-      dynamic "block" {
-        for_each = var.enable_waf == true ? [""] : []
-        content {}
-      }
-
-      dynamic "count" {
-        for_each = var.enable_waf == false ? [""] : []
-        content {}
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = local.rate_limit_all_requests
-        aggregate_key_type = "IP"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "RateLimitAllRequestsIp"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "RateLimitAllRequestsJA4"
-    priority = 115
-
-    action {
-      dynamic "block" {
-        for_each = var.enable_waf == true ? [""] : []
-        content {}
-      }
-
-      dynamic "count" {
-        for_each = var.enable_waf == false ? [""] : []
-        content {}
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = local.rate_limit_all_requests
-        aggregate_key_type = "CUSTOM_KEYS"
-
-        custom_key {
-          ja4_fingerprint {
-            fallback_behavior = "MATCH"
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "RateLimitAllRequestsJA4"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "RateLimitMutatingRequestsIp"
-    priority = 120
-
-    action {
-      dynamic "block" {
-        for_each = var.enable_waf == true ? [""] : []
-        content {}
-      }
-
-      dynamic "count" {
-        for_each = var.enable_waf == false ? [""] : []
-        content {}
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = local.rate_limit_mutating_requests
-        aggregate_key_type = "IP"
-        scope_down_statement {
-          regex_match_statement {
-            field_to_match {
-              method {}
-            }
-            regex_string = "^(delete|patch|post|put)$"
-            text_transformation {
-              priority = 1
-              type     = "LOWERCASE"
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "RateLimitMutatingRequestsIp"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "RateLimitMutatingRequestsJA4"
-    priority = 125
-
-    action {
-      dynamic "block" {
-        for_each = var.enable_waf == true ? [""] : []
-        content {}
-      }
-
-      dynamic "count" {
-        for_each = var.enable_waf == false ? [""] : []
-        content {}
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = local.rate_limit_mutating_requests
-        aggregate_key_type = "CUSTOM_KEYS"
-
-        custom_key {
-          ja4_fingerprint {
-            fallback_behavior = "MATCH"
-          }
-        }
-
-        scope_down_statement {
-          regex_match_statement {
-            field_to_match {
-              method {}
-            }
-            regex_string = "^(delete|patch|post|put)$"
-            text_transformation {
-              priority = 1
-              type     = "LOWERCASE"
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "RateLimitMutatingRequestsJA4"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
     name     = "BotControl"
-    priority = 130
+    priority = 210
 
     override_action {
-      dynamic "count" {
+      dynamic "none" {
         for_each = var.enable_waf == true ? [""] : []
         content {
         }
@@ -1005,6 +1093,16 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
             text_transformation {
               priority = 1
               type     = "LOWERCASE"
+            }
+          }
+        }
+
+        dynamic "rule_action_override" {
+          for_each = local.bot_control_excluded_rules
+          content {
+            name = rule_action_override.value
+            action_to_use {
+              count {}
             }
           }
         }
@@ -1036,67 +1134,6 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 }
 
 #
-# ALB access control: block if custom header not specified
-#
-resource "aws_wafv2_web_acl" "wordpress_waf_alb" {
-  name  = "wordpress_waf_alb"
-  scope = "REGIONAL"
-
-  default_action {
-    block {}
-  }
-
-  rule {
-    name     = "CloudFrontCustomHeader"
-    priority = 201
-
-    action {
-      allow {}
-    }
-
-    statement {
-      byte_match_statement {
-        positional_constraint = "EXACTLY"
-        field_to_match {
-          single_header {
-            name = var.cloudfront_custom_header_name
-          }
-        }
-        search_string = var.cloudfront_custom_header_value
-        text_transformation {
-          priority = 1
-          type     = "NONE"
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "CloudFrontCustomHeader"
-      sampled_requests_enabled   = false
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "CloudFrontCustomHeader"
-    sampled_requests_enabled   = false
-  }
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-  }
-}
-
-#
-# WAF association
-#
-resource "aws_wafv2_web_acl_association" "wordpress_waf_alb" {
-  resource_arn = aws_lb.wordpress.arn
-  web_acl_arn  = aws_wafv2_web_acl.wordpress_waf_alb.arn
-}
-
-#
 # WAF logging
 #
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_cloudfront" {
@@ -1104,9 +1141,4 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_cloudfront
 
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs_us_east.arn]
   resource_arn            = aws_wafv2_web_acl.wordpress_waf.arn
-}
-
-resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_alb" {
-  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
-  resource_arn            = aws_wafv2_web_acl.wordpress_waf_alb.arn
 }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -998,12 +998,6 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
   }
 
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "wordpress"
-    sampled_requests_enabled   = true
-  }
-
   rule {
     name     = "BlockComments"
     priority = 200

--- a/infrastructure/terragrunt/aws/network/security-groups.tf
+++ b/infrastructure/terragrunt/aws/network/security-groups.tf
@@ -42,6 +42,10 @@ resource "aws_security_group_rule" "wordpress_ecs_egress_efs" {
   source_security_group_id = aws_security_group.wordpress_efs[0].id
 }
 
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
 data "aws_subnet" "wordpress_private_subnet" {
   count = 3
   id    = tolist(module.wordpress_vpc.private_subnet_ids)[count.index]
@@ -54,11 +58,11 @@ resource "aws_security_group" "wordpress_load_balancer" {
   vpc_id      = module.wordpress_vpc.vpc_id
 
   ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Requests from users"
+    protocol        = "tcp"
+    from_port       = 443
+    to_port         = 443
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
+    description     = "Requests from users via CloudFront"
   }
 
   dynamic "egress" {


### PR DESCRIPTION
# Summary
Adjust the WAF rules based on a review with AWS. This includes the following:

1. Optimize rule order. Cheaper rules should come first.
2. Add InvalidHost and Anti-DDoS rules.
3. Set BotControl to block with rule overrides to allow headless CMS use.
4. Remove the ALB WAF and use security groups to only allow ingress to the ALB from CloudFront.

# Related
- https://github.com/cds-snc/platform-core-services/issues/955