### PR TITLE
fix: remove ALB automatic response

### DIFF
--- a/infrastructure/terragrunt/aws/alarms/shield_advanced.tf
+++ b/infrastructure/terragrunt/aws/alarms/shield_advanced.tf
@@ -30,11 +30,6 @@ resource "aws_shield_protection_health_check_association" "cloudfront" {
   shield_protection_id = aws_shield_protection.cloudfront.id
 }
 
-resource "aws_shield_application_layer_automatic_response" "alb" {
-  resource_arn = var.alb_arn
-  action       = "BLOCK"
-}
-
 resource "aws_shield_application_layer_automatic_response" "cloudfront" {
   resource_arn = var.cloudfront_arn
   action       = "BLOCK"


### PR DESCRIPTION
# Summary
The ALB now only accepts incoming connections from the CloudFront prefix list and no longer
has a firewall.  As a result the Shield automatic response can be removed.

Note that this was already removed when the firewall was deleted in a previous PR but now
the Terraform resource is causing apply failures as it can't be recreated without that firewall.
