### PR TITLE
fix: allows GC Admin role to manage PAT

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
+++ b/wordpress/wp-content/plugins/cds-base/classes/Modules/Cleanup/Menus.php
@@ -157,6 +157,7 @@ class Menus
         $allowed = [
             __('Notify API Settings', 'cds-snc'),
             __('Site Settings', 'cds-snc'),
+            __('CDS Default Settings', 'cds-snc'),
         ];
 
         try {


### PR DESCRIPTION
# Summary | Résumé
Fix to allow GitHub repo and Personal Access Token (PAT) for GC Admin


Related:
https://github.com/orgs/cds-snc/projects/51/views/1?pane=issue&itemId=178171194&issue=cds-snc%7Cplatform-core-services%7C984