### PR TITLE
feat: updated event type

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/webhook.php
+++ b/wordpress/wp-content/themes/cds-default/inc/webhook.php
@@ -33,7 +33,6 @@ function onSavePost($post_ID, $post)
                 return;
             }
 
-            // Use the configurable event type, defaulting to 'gc-articles-update'
             $event_type = get_option('GITHUB_EVENT_TYPE');
             if (empty($event_type)) {
                 $event_type = 'gc-articles-update';

--- a/wordpress/wp-content/themes/cds-default/inc/webhook.php
+++ b/wordpress/wp-content/themes/cds-default/inc/webhook.php
@@ -2,7 +2,21 @@
 
 function onSavePost($post_ID, $post)
 {
+    if (wp_is_post_revision($post_ID) || wp_is_post_autosave($post_ID)) {
+        return;
+    }
+
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+
     if ($post->post_status === "publish") {
+        $transient_key = 'github_dispatch_' . $post_ID;
+        if (get_transient($transient_key)) {
+            return;
+        }
+        set_transient($transient_key, true, 5);
+
         try {
             // Get configurable repository URL
             $repo_url = get_option('GITHUB_REPOSITORY_URL');
@@ -19,13 +33,19 @@ function onSavePost($post_ID, $post)
                 return;
             }
 
+            // Use the configurable event type, defaulting to 'gc-articles-update'
+            $event_type = get_option('GITHUB_EVENT_TYPE');
+            if (empty($event_type)) {
+                $event_type = 'gc-articles-update';
+            }
+
             $args = [
                 'headers' => [
                     'Accept' => 'application/vnd.github+json',
                     'Authorization' => 'token ' . $token,
                     'Content-Type' => 'application/json'
                 ],
-                'body' => json_encode(['event_type' => 'strapi_update'])
+                'body' => json_encode(['event_type' => $event_type])
             ];
 
             $response = wp_remote_post($url, $args);

--- a/wordpress/wp-content/themes/cds-default/settings.php
+++ b/wordpress/wp-content/themes/cds-default/settings.php
@@ -47,7 +47,6 @@ function cds_default_settings_init()
         }
     );
 
-    // Register GitHub Event Type setting
     register_setting(
         'cds_default_github_option_group',
         'GITHUB_EVENT_TYPE',

--- a/wordpress/wp-content/themes/cds-default/settings.php
+++ b/wordpress/wp-content/themes/cds-default/settings.php
@@ -47,6 +47,15 @@ function cds_default_settings_init()
         }
     );
 
+    // Register GitHub Event Type setting
+    register_setting(
+        'cds_default_github_option_group',
+        'GITHUB_EVENT_TYPE',
+        function ($input) {
+            return sanitize_text_field($input);
+        }
+    );
+
     add_settings_section(
         'cds_default_github_section',
         __('GitHub integration', 'cds-snc'),
@@ -71,6 +80,15 @@ function cds_default_settings_init()
         'cds-default-settings-admin',
         'cds_default_github_section',
         ['label_for' => 'github_repository_url']
+    );
+
+    add_settings_field(
+        'github_event_type',
+        __('GitHub Event Type', 'cds-snc'),
+        'cds_default_event_type_callback',
+        'cds-default-settings-admin',
+        'cds_default_github_section',
+        ['label_for' => 'github_event_type']
     );
 }
 
@@ -123,6 +141,16 @@ function cds_default_repository_callback($args)
         esc_attr($current_repo)
     );
     echo '<p class="description">' . __('Format: owner/repository-name (e.g., cds-snc/my-project)', 'cds-snc') . '</p>';
+}
+
+function cds_default_event_type_callback($args)
+{
+    $current_event_type = get_option('GITHUB_EVENT_TYPE');
+    printf(
+        '<input class="regular-text" type="text" name="GITHUB_EVENT_TYPE" id="github_event_type" value="%s" placeholder="gc-articles-update">',
+        esc_attr($current_event_type)
+    );
+    echo '<p class="description">' . __('The event_type sent in the repository dispatch payload. Defaults to <code>gc-articles-update</code> if left empty.', 'cds-snc') . '</p>';
 }
 
 function cds_default_add_styles()


### PR DESCRIPTION
# Summary | Résumé

- Updated event_type so it is not hardcoded, it is now an event field under Settings -> CDS Default Settings
- Fix for multiple workflow runs

Related:

https://github.com/orgs/cds-snc/projects/51/views/1?pane=issue&itemId=178207230&issue=cds-snc%7Cplatform-core-services%7C985

