### PR TITLE
fix: pass Docker secrets to WordPress image

### DIFF
--- a/.github/workflows/docker-staging-sbom.yml
+++ b/.github/workflows/docker-staging-sbom.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - image: "wordpress"
             path: "wordpress/docker/Dockerfile"
-            build_args: '--build-arg WPML_USER_ID="WPML_USER_ID" --build-arg WPML_KEY="WPML_KEY"'
+            build_args: '--build-arg WPML_USER_ID="SECRET_WPML_USER_ID" --build-arg WPML_KEY="SECRET_WPML_KEY"'
           - image: "apache"
             path: "wordpress/docker/apache/Dockerfile"
             build_args: '--build-arg APACHE_KEY="APACHE_KEY" --build-arg APACHE_CERT="APACHE_CERT"'
@@ -45,12 +45,26 @@ jobs:
         cd wordpress
         composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
 
+    - name: Setup build args
+      env:
+        BUILD_ARGS_TEMPLATE: ${{ matrix.build_args }}
+        WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
+        WPML_KEY: ${{ secrets.WPML_KEY }}
+      run: |
+        BUILD_ARGS="$BUILD_ARGS_TEMPLATE"
+        while IFS= read -r secret_ref; do
+          secret_name="${secret_ref#SECRET_}"
+          secret_value="${!secret_name}"
+          BUILD_ARGS="${BUILD_ARGS//"$secret_ref"/"$secret_value"}"
+        done < <(grep -oP 'SECRET_\w+' <<< "$BUILD_ARGS")
+        echo "BUILD_ARGS=$BUILD_ARGS" >> "$GITHUB_ENV"
+
     - name: Build image
       run: |
         docker build \
         --platform linux/arm64 \
         --build-arg git_sha="$GITHUB_SHA" \
-        ${{ matrix.build_args }} \
+        $BUILD_ARGS \
         -t "${{ matrix.image }}" \
         -f "${{ matrix.path }}" .
 

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - image: "wordpress"
             path: "wordpress/docker/Dockerfile"
-            build_args: '--build-arg WPML_USER_ID="WPML_USER_ID" --build-arg WPML_KEY="WPML_KEY"'
+            build_args: '--build-arg WPML_USER_ID="SECRET_WPML_USER_ID" --build-arg WPML_KEY="SECRET_WPML_KEY"'
           - image: "apache"
             path: "wordpress/docker/apache/Dockerfile"
             build_args: '--build-arg APACHE_KEY="APACHE_KEY" --build-arg APACHE_CERT="APACHE_CERT"'
@@ -33,12 +33,26 @@ jobs:
           DNS_PROXY_SAFELIST: "${{ vars.DNS_PROXY_SAFELIST }}"
           DNS_PROXY_WILDCARDGREEDY: "true"
 
+      - name: Setup build args
+        env:
+          BUILD_ARGS_TEMPLATE: ${{ matrix.build_args }}
+          WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
+          WPML_KEY: ${{ secrets.WPML_KEY }}
+        run: |
+          BUILD_ARGS="$BUILD_ARGS_TEMPLATE"
+          while IFS= read -r secret_ref; do
+            secret_name="${secret_ref#SECRET_}"
+            secret_value="${!secret_name}"
+            BUILD_ARGS="${BUILD_ARGS//"$secret_ref"/"$secret_value"}"
+          done < <(grep -oP 'SECRET_\w+' <<< "$BUILD_ARGS")
+          echo "BUILD_ARGS=$BUILD_ARGS" >> "$GITHUB_ENV"
+
       - name: Build image
         run: |
           docker build \
           --platform linux/arm64 \
           --build-arg git_sha="$GITHUB_SHA" \
-          ${{ matrix.build_args }} \
+          $BUILD_ARGS \
           -t "${{ matrix.image }}" \
           -f "${{ matrix.path }}" .
 


### PR DESCRIPTION
# Summary
Update the SBOM and vulnerability scan so that the WPML secrets are passed in to allow the dependency download.
