### PR TITLE
fix: checkout code in vulnerability scan

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -33,6 +33,16 @@ jobs:
           DNS_PROXY_SAFELIST: "${{ vars.DNS_PROXY_SAFELIST }}"
           DNS_PROXY_WILDCARDGREEDY: "true"
 
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Add Composer auth credentials
+        run: |
+          cd wordpress
+          composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
+
       - name: Setup build args
         env:
           BUILD_ARGS_TEMPLATE: ${{ matrix.build_args }}


### PR DESCRIPTION
# Summary
Update the vulnerability workflow to checkout the code before attempting to build the Docker image.
