### PR TITLE
fix: set build-args directly for both images

### DIFF
--- a/.github/workflows/docker-staging-sbom.yml
+++ b/.github/workflows/docker-staging-sbom.yml
@@ -20,10 +20,8 @@ jobs:
         include:
           - image: "wordpress"
             path: "wordpress/docker/Dockerfile"
-            build_args: '--build-arg WPML_USER_ID="SECRET_WPML_USER_ID" --build-arg WPML_KEY="SECRET_WPML_KEY"'
           - image: "apache"
             path: "wordpress/docker/apache/Dockerfile"
-            build_args: '--build-arg APACHE_KEY="APACHE_KEY" --build-arg APACHE_CERT="APACHE_CERT"'
 
     steps:
     - name: Audit DNS requests
@@ -45,26 +43,15 @@ jobs:
         cd wordpress
         composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
 
-    - name: Setup build args
-      env:
-        BUILD_ARGS_TEMPLATE: ${{ matrix.build_args }}
-        WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
-        WPML_KEY: ${{ secrets.WPML_KEY }}
-      run: |
-        BUILD_ARGS="$BUILD_ARGS_TEMPLATE"
-        while IFS= read -r secret_ref; do
-          secret_name="${secret_ref#SECRET_}"
-          secret_value="${!secret_name}"
-          BUILD_ARGS="${BUILD_ARGS//"$secret_ref"/"$secret_value"}"
-        done < <(grep -oP 'SECRET_\w+' <<< "$BUILD_ARGS")
-        echo "BUILD_ARGS=$BUILD_ARGS" >> "$GITHUB_ENV"
-
     - name: Build image
       run: |
         docker build \
         --platform linux/arm64 \
         --build-arg git_sha="$GITHUB_SHA" \
-        $BUILD_ARGS \
+        --build-arg WPML_USER_ID="${{ secrets.WPML_USER_ID }}" \
+        --build-arg WPML_KEY="${{ secrets.WPML_KEY }}" \
+        --build-arg APACHE_KEY="APACHE_KEY" \
+        --build-arg APACHE_CERT="APACHE_CERT" \
         -t "${{ matrix.image }}" \
         -f "${{ matrix.path }}" .
 

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -18,10 +18,8 @@ jobs:
         include:
           - image: "wordpress"
             path: "wordpress/docker/Dockerfile"
-            build_args: '--build-arg WPML_USER_ID="SECRET_WPML_USER_ID" --build-arg WPML_KEY="SECRET_WPML_KEY"'
           - image: "apache"
             path: "wordpress/docker/apache/Dockerfile"
-            build_args: '--build-arg APACHE_KEY="APACHE_KEY" --build-arg APACHE_CERT="APACHE_CERT"'
 
     steps:
       - name: Audit DNS requests
@@ -43,26 +41,15 @@ jobs:
           cd wordpress
           composer config github-oauth.github.com ${{ secrets.COMPOSER_GITHUB_TOKEN }}
 
-      - name: Setup build args
-        env:
-          BUILD_ARGS_TEMPLATE: ${{ matrix.build_args }}
-          WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
-          WPML_KEY: ${{ secrets.WPML_KEY }}
-        run: |
-          BUILD_ARGS="$BUILD_ARGS_TEMPLATE"
-          while IFS= read -r secret_ref; do
-            secret_name="${secret_ref#SECRET_}"
-            secret_value="${!secret_name}"
-            BUILD_ARGS="${BUILD_ARGS//"$secret_ref"/"$secret_value"}"
-          done < <(grep -oP 'SECRET_\w+' <<< "$BUILD_ARGS")
-          echo "BUILD_ARGS=$BUILD_ARGS" >> "$GITHUB_ENV"
-
       - name: Build image
         run: |
           docker build \
           --platform linux/arm64 \
           --build-arg git_sha="$GITHUB_SHA" \
-          $BUILD_ARGS \
+          --build-arg WPML_USER_ID="${{ secrets.WPML_USER_ID }}" \
+          --build-arg WPML_KEY="${{ secrets.WPML_KEY }}" \
+          --build-arg APACHE_KEY="APACHE_KEY" \
+          --build-arg APACHE_CERT="APACHE_CERT" \
           -t "${{ matrix.image }}" \
           -f "${{ matrix.path }}" .
 


### PR DESCRIPTION
# Summary
Update the Docker build command so that the build-args are set directly for both images.
