### PR TITLE
fix: disable tool cache from PHP setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        env:
+          NO_TOOLS_CACHE: 'true'
         with:
           php-version: 8.4
 
@@ -68,8 +70,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install subversion
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        env:
+          NO_TOOLS_CACHE: 'true'
         with:
           php-version: 8.4
 
@@ -99,7 +102,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        env:
+          NO_TOOLS_CACHE: 'true'
         with:
           php-version: 8.4
           tools: phpcs, cs2pr

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -42,7 +42,9 @@ jobs:
           node-version: 24
 
       - name: PHP Setup
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        env:
+          NO_TOOLS_CACHE: 'true'
         with:
           php-version: 8.4
 


### PR DESCRIPTION
# Summary 
Disable the tool cache and pin the action to the latest release of the action.
