### PR TITLE
fix: increase the WAF GET rate limits

### DIFF
--- a/.github/workflows/terragrunt-apply-production.yml
+++ b/.github/workflows/terragrunt-apply-production.yml
@@ -20,6 +20,7 @@ env:
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
+  TF_VAR_cloudfront_waf_rate_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_RATE_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.PRODUCTION_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.PRODUCTION_S3_UPLOADS_BUCKET }}

--- a/.github/workflows/terragrunt-apply-staging.yml
+++ b/.github/workflows/terragrunt-apply-staging.yml
@@ -24,6 +24,7 @@ env:
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
+  TF_VAR_cloudfront_waf_rate_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_RATE_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}

--- a/.github/workflows/terragrunt-plan-production.yml
+++ b/.github/workflows/terragrunt-plan-production.yml
@@ -20,6 +20,7 @@ env:
   TF_VAR_database_username: ${{ secrets.PRODUCTION_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.PRODUCTION_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
+  TF_VAR_cloudfront_waf_rate_secret: ${{ secrets.PRODUCTION_CLOUDFRONT_WAF_RATE_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.PRODUCTION_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.PRODUCTION_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.PRODUCTION_S3_UPLOADS_BUCKET }}

--- a/.github/workflows/terragrunt-plan-staging.yml
+++ b/.github/workflows/terragrunt-plan-staging.yml
@@ -22,6 +22,7 @@ env:
   TF_VAR_database_username: ${{ secrets.STAGING_DATABASE_USERNAME }}
   TF_VAR_database_password: ${{ secrets.STAGING_DATABASE_PASSWORD }}
   TF_VAR_cloudfront_waf_geo_match_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_GEO_MATCH_SECRET }}
+  TF_VAR_cloudfront_waf_rate_secret: ${{ secrets.STAGING_CLOUDFRONT_WAF_RATE_SECRET }}
   TF_VAR_default_notify_api_key: ${{ secrets.STAGING_DEFAULT_NOTIFY_API_KEY }}
   TF_VAR_encryption_key: ${{ secrets.STAGING_ENCRYPTION_KEY }}
   TF_VAR_s3_uploads_bucket: ${{ secrets.STAGING_S3_UPLOADS_BUCKET }}

--- a/infrastructure/terragrunt/aws/load-balancer/inputs.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/inputs.tf
@@ -4,6 +4,12 @@ variable "cloudfront_waf_geo_match_secret" {
   sensitive   = true
 }
 
+variable "cloudfront_waf_rate_secret" {
+  description = "Custom header value to check to determine if the rate limit statement should allow a request to bypass the rate limit."
+  type        = string
+  sensitive   = true
+}
+
 variable "domain_name" {
   description = "Domain name for the load balancer, certificate and CloudFront"
   type        = string

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -137,9 +137,32 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
 
     statement {
-      rate_based_statement {
-        limit              = local.rate_limit_all_requests
-        aggregate_key_type = "IP"
+      and_statement {
+        statement {
+          rate_based_statement {
+            limit              = local.rate_limit_all_requests
+            aggregate_key_type = "IP"
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  single_header {
+                    name = "waf-rate-bypass"
+                  }
+                }
+                search_string = var.cloudfront_waf_rate_secret
+                text_transformation {
+                  priority = 1
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
       }
     }
 
@@ -167,13 +190,36 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
 
     statement {
-      rate_based_statement {
-        limit              = local.rate_limit_all_requests
-        aggregate_key_type = "CUSTOM_KEYS"
+      and_statement {
+        statement {
+          rate_based_statement {
+            limit              = local.rate_limit_all_requests
+            aggregate_key_type = "CUSTOM_KEYS"
 
-        custom_key {
-          ja4_fingerprint {
-            fallback_behavior = "MATCH"
+            custom_key {
+              ja4_fingerprint {
+                fallback_behavior = "MATCH"
+              }
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  single_header {
+                    name = "waf-rate-bypass"
+                  }
+                }
+                search_string = var.cloudfront_waf_rate_secret
+                text_transformation {
+                  priority = 1
+                  type     = "NONE"
+                }
+              }
+            }
           }
         }
       }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -137,14 +137,11 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
 
     statement {
-      and_statement {
-        statement {
-          rate_based_statement {
-            limit              = local.rate_limit_all_requests
-            aggregate_key_type = "IP"
-          }
-        }
-        statement {
+      rate_based_statement {
+        limit              = local.rate_limit_all_requests
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
           not_statement {
             statement {
               byte_match_statement {
@@ -190,20 +187,17 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
     }
 
     statement {
-      and_statement {
-        statement {
-          rate_based_statement {
-            limit              = local.rate_limit_all_requests
-            aggregate_key_type = "CUSTOM_KEYS"
+      rate_based_statement {
+        limit              = local.rate_limit_all_requests
+        aggregate_key_type = "CUSTOM_KEYS"
 
-            custom_key {
-              ja4_fingerprint {
-                fallback_behavior = "MATCH"
-              }
-            }
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
           }
         }
-        statement {
+
+        scope_down_statement {
           not_statement {
             statement {
               byte_match_statement {

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -3,7 +3,7 @@ locals {
   bot_control_excluded_rules   = ["CategoryHttpLibrary", "SignalNonBrowserUserAgent"]
   common_excluded_rules        = ["GenericRFI_QUERYARGUMENTS", "GenericRFI_BODY", "GenericRFI_URIPATH", "CrossSiteScripting_BODY", "SizeRestrictions_BODY"]
   php_excluded_rules           = ["PHPHighRiskMethodsVariables_BODY"]
-  rate_limit_all_requests      = 1000
+  rate_limit_all_requests      = 2000
   rate_limit_mutating_requests = 200
 }
 


### PR DESCRIPTION
# Summary
Update the IP and JA4 rate limits allow 2,000 requests in a 5 minute period. We'll revert this once we get the Notify admin header secret added as a bypass.

Note this has already been updated in Prod through the console.