### PR TITLE
fix: allow API requests through IP reputation rule

### DIFF
--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -342,15 +342,30 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
         scope_down_statement {
           not_statement {
-            statement {
-              regex_match_statement {
-                field_to_match {
-                  uri_path {}
+            and_statement {
+              statement {
+                regex_match_statement {
+                  field_to_match {
+                    uri_path {}
+                  }
+                  regex_string = "^[^/]*/wp-json/wp/v2/(pages|posts)$"
+                  text_transformation {
+                    priority = 1
+                    type     = "LOWERCASE"
+                  }
                 }
-                regex_string = "^[^/]*/wp-json/wp/v2/(pages|posts)$"
-                text_transformation {
-                  priority = 1
-                  type     = "LOWERCASE"
+              }
+              statement {
+                byte_match_statement {
+                  field_to_match {
+                    method {}
+                  }
+                  search_string         = "get"
+                  positional_constraint = "EXACTLY"
+                  text_transformation {
+                    priority = 0
+                    type     = "LOWERCASE"
+                  }
                 }
               }
             }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -342,29 +342,31 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
 
         scope_down_statement {
           not_statement {
-            and_statement {
-              statement {
-                regex_match_statement {
-                  field_to_match {
-                    uri_path {}
-                  }
-                  regex_string = "^[^/]*/wp-json/wp/v2/(pages|posts)$"
-                  text_transformation {
-                    priority = 1
-                    type     = "LOWERCASE"
+            statement {
+              and_statement {
+                statement {
+                  regex_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    regex_string = "^[^/]*/wp-json/wp/v2/(pages|posts)$"
+                    text_transformation {
+                      priority = 1
+                      type     = "LOWERCASE"
+                    }
                   }
                 }
-              }
-              statement {
-                byte_match_statement {
-                  field_to_match {
-                    method {}
-                  }
-                  search_string         = "get"
-                  positional_constraint = "EXACTLY"
-                  text_transformation {
-                    priority = 0
-                    type     = "LOWERCASE"
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      method {}
+                    }
+                    search_string         = "get"
+                    positional_constraint = "EXACTLY"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
                   }
                 }
               }

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -349,7 +349,7 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
                     field_to_match {
                       uri_path {}
                     }
-                    regex_string = "^[^/]*/wp-json/wp/v2/(pages|posts)$"
+                    regex_string = "^(/[^/]+)?/wp-json/wp/v2/(pages|posts)/?$"
                     text_transformation {
                       priority = 1
                       type     = "LOWERCASE"

--- a/infrastructure/terragrunt/aws/load-balancer/waf.tf
+++ b/infrastructure/terragrunt/aws/load-balancer/waf.tf
@@ -339,6 +339,23 @@ resource "aws_wafv2_web_acl" "wordpress_waf" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesAmazonIpReputationList"
         vendor_name = "AWS"
+
+        scope_down_statement {
+          not_statement {
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                regex_string = "^[^/]*/wp-json/wp/v2/(pages|posts)$"
+                text_transformation {
+                  priority = 1
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
# Summary
Update the `AWSManagedRulesAmazonIpReputationList` so that GET requests to the pages and posts API endpoint are no longer inspected. 

This is being done because GitHub runners attempting to call the API are getting blocked as malicious.
