### PR TITLE
fix: remove the wp-block-paragraph tags

### DIFF
--- a/wordpress/wp-content/themes/cds-website-preview/filters.php
+++ b/wordpress/wp-content/themes/cds-website-preview/filters.php
@@ -21,3 +21,18 @@ function cds_filter_core_image($block_content, $block)
 }
 
 add_filter('render_block', 'cds_filter_core_image', 10, 3);
+
+function cds_remove_wp_block_paragraph_class($content)
+{
+    return preg_replace_callback(
+        '/<p\b([^>]*)>/i',
+        function ($matches) {
+            $attrs = preg_replace('/\bwp-block-paragraph\b\s*/', '', $matches[1]);
+            $attrs = preg_replace('/\s*class="\s*"/', '', $attrs);
+            return '<p' . $attrs . '>';
+        },
+        $content
+    );
+}
+
+add_filter('the_content', 'cds_remove_wp_block_paragraph_class', 11);

--- a/wordpress/wp-content/themes/cds-website-preview/functions.php
+++ b/wordpress/wp-content/themes/cds-website-preview/functions.php
@@ -12,5 +12,5 @@ function get_fonts_uri()
 
 add_theme_support('post-thumbnails');
 
-require_once __DIR__ . '/filter-core-image.php';
+require_once __DIR__ . '/filters.php';
 require_once(__DIR__ . '/settings.php');


### PR DESCRIPTION
# Summary
The WordPress 7 upgrade has started adding `wp-block-paragraph` tags to all our `<p>` tags.  We don't want them in the website's rendered content so this filter removes them from that site's content.
