### PR TITLE
fix: remove leading space from class attribute

### DIFF
--- a/wordpress/wp-content/themes/cds-website-preview/filters.php
+++ b/wordpress/wp-content/themes/cds-website-preview/filters.php
@@ -27,7 +27,7 @@ function cds_remove_wp_block_paragraph_class($content)
     return preg_replace_callback(
         '/<p\b([^>]*)>/i',
         function ($matches) {
-            $attrs = preg_replace('/\bwp-block-paragraph\b\s*/', '', $matches[1]);
+            $attrs = preg_replace('/\s*\bwp-block-paragraph\b\s*/', '', $matches[1]);
             $attrs = preg_replace('/\s*class="\s*"/', '', $attrs);
             return '<p' . $attrs . '>';
         },


### PR DESCRIPTION
# Summary
Update the `wp-block-paragraph` filter so that leading spaces are also removed from the `class` attribute when the className is deleted. This fixes the cases where multiple CSS classes were on the `<p>` tag.
