### PR TITLE
Release v5.1.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -4,4 +4,4 @@ production:
   infrastructure: 1.8.5
 staging:
   apache: 1.4.0
-  wordpress: 5.0.3
+  wordpress: 5.1.0


### PR DESCRIPTION
# Summary
WordPress 7.0.1 maintenance release to Staging.

# Related
- https://github.com/cds-snc/gc-articles/pull/2712