### PR TITLE
Production release: 5.1.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.4.0
-  wordpress: 5.0.3
+  wordpress: 5.1.0
   infrastructure: 1.8.5
 staging:
   apache: 1.4.0


### PR DESCRIPTION
# Summary
Deploy WordPress 7.0.1 upgrade to production.

# Related
- #2712 