### PR TITLE
chore: upgrade WordPress 7.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 7.0.1
+  WP_VERSION: 7.0.2
 
 permissions:
   contents: read

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:7.0.1-php8.4-fpm-alpine@sha256:29fdb128683527006459d3ccbf3f49e1b47314067562f3366c93299626a3f2db
+FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:636f52a7bdadc9389f6365e233860819149471c2497141aa93b9b6a32cd28c47
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && apk upgrade --no-cache imagemagick imagemagick-webp \

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:636f52a7bdadc9389f6365e233860819149471c2497141aa93b9b6a32cd28c47
+FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:1d64606dae40c09ed3c39c23f9a8eec94cfac0040e94ba7b7bd07703ba5fa7a9
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && apk upgrade --no-cache imagemagick imagemagick-webp \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:636f52a7bdadc9389f6365e233860819149471c2497141aa93b9b6a32cd28c47
+FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:1d64606dae40c09ed3c39c23f9a8eec94cfac0040e94ba7b7bd07703ba5fa7a9
 
 WORKDIR /usr/src/wordpress
 

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:7.0.1-php8.4-fpm-alpine@sha256:29fdb128683527006459d3ccbf3f49e1b47314067562f3366c93299626a3f2db
+FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:636f52a7bdadc9389f6365e233860819149471c2497141aa93b9b6a32cd28c47
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary | Résumé

Upgrade to WordPress 7.0.2 security release:
https://wordpress.org/news/2026/07/wordpress-7-0-2-release/