### PR TITLE
fix: button sizing inconsistency

### DIFF
--- a/wordpress/wp-content/themes/cds-default/style.css
+++ b/wordpress/wp-content/themes/cds-default/style.css
@@ -367,7 +367,9 @@ nav.nav--about li a:focus {
   --tw-border-opacity: 0.2;
   border-bottom-width: 4px;
   border-color: rgba(17, 24, 39, var(--tw-border-opacity));
+  font-size: 20px;
   font-weight: 700;
+  line-height: 28px;
   margin: 0 0.5rem 0 0;
   padding: 0.75rem 1.25rem;
 }
@@ -435,6 +437,7 @@ nav.nav--about li a:focus {
 .wp-block-button__link {
   border-radius: 0;
   display: inline-block;
+  min-width: 10.5rem;
 }
 .wp-block-button__link:hover {
   text-decoration: none !important;


### PR DESCRIPTION
# Summary | Résumé

Updated Preview button styling to match download button:
- Font size
- Line Height
- Added min width so buttons are at consistent length

<img width="1187" height="332" alt="Screenshot 2026-07-29 at 11 38 38 AM" src="https://github.com/user-attachments/assets/4ce2bfbb-08da-40f5-87ca-e92f4f4f3526" />


# Related
- https://github.com/orgs/cds-snc/projects/51/views/1?pane=issue&itemId=219830226&issue=cds-snc%7Cplatform-core-services%7C1040