### PR TITLE
chore: upgrade to WordPress to 7.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
   WPML_KEY: ${{ secrets.WPML_KEY }}
   # WP_VERSION needs to match the version found in ~/wordpress/docker/Dockerfile
-  WP_VERSION: 7.0.2
+  WP_VERSION: 7.0.3
 
 permissions:
   contents: read

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:9c5ea2aceb5948ae3c925b21ee3715b5d5779d17beed1e645de901d66c694c7f
+FROM wordpress:7.0.3-php8.4-fpm-alpine@sha256:c73b5b2b8bbe81d6582c1dfd096701387530b8e722ebaa628d4af61bd77a2636
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && apk upgrade --no-cache imagemagick imagemagick-webp \

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN npm --unsafe-perm install
 # when updating the Wordpress version, update the version in the files:
 #     - ~/wordpress/docker/local.Dockerfile
 #     - ~/github/workflows/ci.yml
-FROM wordpress:7.0.3-php8.4-fpm-alpine@sha256:c73b5b2b8bbe81d6582c1dfd096701387530b8e722ebaa628d4af61bd77a2636
+FROM wordpress:7.0.3-php8.4-fpm-alpine@sha256:a41bfb69a1e04464ea203d446f73e841a58b9bd90f3e4e00198d915c8dc4f089
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && apk upgrade --no-cache imagemagick imagemagick-webp \

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:7.0.2-php8.4-fpm-alpine@sha256:9c5ea2aceb5948ae3c925b21ee3715b5d5779d17beed1e645de901d66c694c7f
+FROM wordpress:7.0.3-php8.4-fpm-alpine@sha256:c73b5b2b8bbe81d6582c1dfd096701387530b8e722ebaa628d4af61bd77a2636
 
 WORKDIR /usr/src/wordpress
 

--- a/wordpress/docker/local.Dockerfile
+++ b/wordpress/docker/local.Dockerfile
@@ -1,5 +1,5 @@
 # wordpress version needs to match the version found in ~/wordpress/docker/Dockerfile
-FROM wordpress:7.0.3-php8.4-fpm-alpine@sha256:c73b5b2b8bbe81d6582c1dfd096701387530b8e722ebaa628d4af61bd77a2636
+FROM wordpress:7.0.3-php8.4-fpm-alpine@sha256:a41bfb69a1e04464ea203d446f73e841a58b9bd90f3e4e00198d915c8dc4f089
 
 WORKDIR /usr/src/wordpress
 


### PR DESCRIPTION
# Summary | Résumé

Upgrade to WordPress 7.0.3