### PR TITLE
Production release: 5.2.0

### DIFF
--- a/infrastructure/environments.yml
+++ b/infrastructure/environments.yml
@@ -1,6 +1,6 @@
 production:
   apache: 1.4.0
-  wordpress: 5.1.2
+  wordpress: 5.2.0
   infrastructure: 1.8.5
 staging:
   apache: 1.4.0


### PR DESCRIPTION
# Summary
Deploy WordPress 7.1.0 upgrade to production.

# Related
- https://github.com/cds-snc/gc-articles/pull/2752